### PR TITLE
allow timezone abbreviated symbol as timezone argument

### DIFF
--- a/mods/service/httpd/util.go
+++ b/mods/service/httpd/util.go
@@ -4,6 +4,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/machbase/neo-server/mods/util"
 )
 
 func strBool(str string, def bool) bool {
@@ -43,7 +45,11 @@ func strTimeLocation(str string, def *time.Location) *time.Location {
 		return time.UTC
 	} else {
 		if loc, err := time.LoadLocation(str); err != nil {
-			return def
+			loc, err := util.GetTimeLocation(str)
+			if err != nil {
+				return def
+			}
+			return loc
 		} else {
 			return loc
 		}

--- a/mods/service/httpd/util.go
+++ b/mods/service/httpd/util.go
@@ -44,8 +44,8 @@ func strTimeLocation(str string, def *time.Location) *time.Location {
 	} else if tz == "utc" {
 		return time.UTC
 	} else {
-		if loc, err := time.LoadLocation(str); err != nil {
-			loc, err := util.GetTimeLocation(str)
+		if loc, err := util.GetTimeLocation(str); err != nil {
+			loc, err := time.LoadLocation(str)
 			if err != nil {
 				return def
 			}


### PR DESCRIPTION
**timezone="" ( UTC 05시 )**
![image](https://github.com/machbase/neo-server/assets/113958541/2a518369-1155-4d7e-9aa7-8c7a1c9705d7)

**timezone="KST" ( Asia/Seoul 14시 )** 
![image](https://github.com/machbase/neo-server/assets/113958541/002a3b44-bb62-415c-aefa-c35b7a7a4afa)

**timezone="local" ( Asia/Seoul 14시 )**
![image](https://github.com/machbase/neo-server/assets/113958541/5ed58fa7-fbe3-4290-9274-7ba3de4974fd)

**timzone="Asia/Seoul" ( Asia/Seoul 14시 )** 
![image](https://github.com/machbase/neo-server/assets/113958541/9df085bc-71ad-41ae-87f5-4f873a385c34)


**neo-server/mods/service/httpd/util.go** 
```bash
if loc, err := time.LoadLocation(str); err != nil {
=== 
    loc, err := util.GetTimeLocation(str)
    if err != nil {
	return def
     }
===
    return loc
```

**time.LoadLocation()** 
 : "Asia/Seoul" 사용 가능
 : "KST" 사용 불가,  util.GetTimeLocation 함수를 통해 "Asia/Seoul"로 변환

