### PR TITLE
log options command line flags

### DIFF
--- a/mods/server/svrconf.hcl
+++ b/mods/server/svrconf.hcl
@@ -47,6 +47,13 @@ module "machbase.com/neo-logging" {
     config {
         Console                     = false
         Filename                    = flag("--log-filename", "-")
+        Append                      = flag("--log-append", true)
+        RotateSchedule              = flag("--log-rotate-schedule", "@midnight")
+        MaxSize                     = flag("--log-max-size", 10)
+        MaxBackups                  = flag("--log-max-backups", 1)
+        MaxAge                      = flag("--log-max-age", 7)
+        Compress                    = flag("--log-compress", false)
+        UTC                         = flag("--log-time-utc", false)
         DefaultPrefixWidth          = 16
         DefaultEnableSourceLocation = flag("--log-source-location", false)
         DefaultLevel                = flag("--log-level", "INFO")


### PR DESCRIPTION
more log related flags

| flag (long)  | flag (short) | desc                                                                             |
|:-------------|:-------------|:-------------------------------------------------------------------------------- |
| `--log-filename`        |       | log file path (default `-` stdout)<br/> ex) `--log-filename /data/logs/machbase-neo.log` |
| `--log-level`           |       | log level. TRACE, DEBUG, INFO, WARN, ERROR (default `INFO`)<br/> ex) `--log-level INFO`  |
| `--log-append`          |       | append existing log file. (default true)               {{< neo_since ver="8.0.13" />}}   |
| `--log-rotate-schedule` |       | time scheduled log file rotation (defualt `@midnight`) {{< neo_since ver="8.0.13" />}}   |
| `--log-max-size`        |       | file max size in MB (default 10)                       {{< neo_since ver="8.0.13" />}}   |
| `--log-max-backups`     |       | maximum log file backups (default 1)                   {{< neo_since ver="8.0.13" />}}   |
| `--log-max-age`         |       | maximum days in backup files (default 7)               {{< neo_since ver="8.0.13" />}}   | 
| `--log-compress`        |       | gzip compress the backup files (dfeault false)         {{< neo_since ver="8.0.13" />}}   |
| `--log-time-utc`        |       | use UTC time for logging (default false)               {{< neo_since ver="8.0.13" />}}   |
