### PR TITLE
additional http response headers

### DIFF
--- a/mods/codec/builder.go
+++ b/mods/codec/builder.go
@@ -38,6 +38,7 @@ type RowsEncoder interface {
 	AddRow(values []any) error
 	Flush(heading bool)
 	ContentType() string
+	HttpHeaders() map[string][]string
 }
 
 var (
@@ -165,4 +166,8 @@ func (ds *DiscardSink) Flush(heading bool) {
 
 func (ds *DiscardSink) ContentType() string {
 	return "text/plain"
+}
+
+func (ds *DiscardSink) HttpHeaders() map[string][]string {
+	return nil
 }

--- a/mods/codec/internal/base.go
+++ b/mods/codec/internal/base.go
@@ -1,0 +1,23 @@
+package internal
+
+type RowsEncoderBase struct {
+	httpHeaders map[string][]string
+}
+
+func (reb *RowsEncoderBase) HttpHeaders() map[string][]string {
+	return reb.httpHeaders
+}
+
+func (reb *RowsEncoderBase) SetHttpHeader(key string, value string) {
+	if reb.httpHeaders == nil {
+		reb.httpHeaders = make(map[string][]string)
+	}
+	reb.httpHeaders[key] = append(reb.httpHeaders[key], value)
+}
+
+func (reb *RowsEncoderBase) DelHttpHeader(key string) {
+	if reb.httpHeaders != nil {
+		return
+	}
+	delete(reb.httpHeaders, key)
+}

--- a/mods/codec/internal/box/box_encode.go
+++ b/mods/codec/internal/box/box_encode.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/stream/spec"
 	"github.com/machbase/neo-server/mods/util"
 )
 
 type Exporter struct {
+	internal.RowsEncoderBase
 	writer table.Writer
 	rownum int64
 

--- a/mods/codec/internal/chart/chart.go
+++ b/mods/codec/internal/chart/chart.go
@@ -11,11 +11,13 @@ import (
 	"time"
 
 	"github.com/machbase/neo-server/mods/codec/facility"
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/stream/spec"
 	"github.com/machbase/neo-server/mods/util/snowflake"
 )
 
 type Chart struct {
+	internal.RowsEncoderBase
 	output       spec.OutputStream
 	toJsonOutput bool
 	option       string

--- a/mods/codec/internal/csv/csv_encode.go
+++ b/mods/codec/internal/csv/csv_encode.go
@@ -11,6 +11,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/expression"
 	"github.com/machbase/neo-server/mods/nums"
 	"github.com/machbase/neo-server/mods/stream/spec"
@@ -18,6 +19,7 @@ import (
 )
 
 type Exporter struct {
+	internal.RowsEncoderBase
 	rownum int64
 
 	writer *csv.Writer

--- a/mods/codec/internal/geomap/geomap.go
+++ b/mods/codec/internal/geomap/geomap.go
@@ -10,12 +10,14 @@ import (
 	"time"
 
 	"github.com/machbase/neo-server/mods/codec/facility"
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/nums"
 	"github.com/machbase/neo-server/mods/stream/spec"
 	"github.com/machbase/neo-server/mods/util/snowflake"
 )
 
 type GeoMap struct {
+	internal.RowsEncoderBase
 	output spec.OutputStream
 
 	MapID  string

--- a/mods/codec/internal/html/html.go
+++ b/mods/codec/internal/html/html.go
@@ -4,10 +4,12 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/stream/spec"
 )
 
 type Exporter struct {
+	internal.RowsEncoderBase
 	imageType string
 	output    spec.OutputStream
 }

--- a/mods/codec/internal/json/json_encode.go
+++ b/mods/codec/internal/json/json_encode.go
@@ -9,11 +9,13 @@ import (
 	"time"
 
 	"github.com/machbase/neo-server/api"
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/stream/spec"
 	"github.com/machbase/neo-server/mods/util"
 )
 
 type Exporter struct {
+	internal.RowsEncoderBase
 	tick time.Time
 	nrow int
 

--- a/mods/codec/internal/markdown/md_encode.go
+++ b/mods/codec/internal/markdown/md_encode.go
@@ -11,12 +11,14 @@ import (
 	"time"
 
 	"github.com/machbase/neo-server/mods/codec/facility"
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/stream/spec"
 	"github.com/machbase/neo-server/mods/util"
 	"github.com/machbase/neo-server/mods/util/mdconv"
 )
 
 type Exporter struct {
+	internal.RowsEncoderBase
 	logger     facility.Logger
 	htmlRender bool
 	brief      int64

--- a/mods/codec/internal/ndjson/encode.go
+++ b/mods/codec/internal/ndjson/encode.go
@@ -9,11 +9,13 @@ import (
 	"time"
 
 	"github.com/machbase/neo-server/api"
+	"github.com/machbase/neo-server/mods/codec/internal"
 	"github.com/machbase/neo-server/mods/stream/spec"
 	"github.com/machbase/neo-server/mods/util"
 )
 
 type Exporter struct {
+	internal.RowsEncoderBase
 	tick time.Time
 	nrow int
 

--- a/mods/codec/opts/generate.go
+++ b/mods/codec/opts/generate.go
@@ -348,7 +348,9 @@ func generatesFx(sets map[string]*SetX, imports map[string]*ImportX) {
 		orderedNames = append(orderedNames, def.Name)
 	}
 	sort.Slice(orderedNames, func(i, j int) bool { return orderedNames[i] < orderedNames[j] })
-	lines := []string{}
+	lines := []string{
+		`{Name: "httpHeader", Func: opts.HttpHeader},`,
+	}
 	for _, name := range orderedNames {
 		x := sets[name]
 		fname := strings.TrimPrefix(x.Name, "Set")

--- a/mods/codec/opts/opts.go
+++ b/mods/codec/opts/opts.go
@@ -1,3 +1,15 @@
 package opts
 
 type Option func(enc any)
+
+type CanSetHttpHeader interface {
+	SetHttpHeader(key, value string)
+}
+
+func HttpHeader(k string, v string) Option {
+	return func(enc any) {
+		if e, ok := enc.(CanSetHttpHeader); ok {
+			e.SetHttpHeader(k, v)
+		}
+	}
+}

--- a/mods/service/httpd/h_tql.go
+++ b/mods/service/httpd/h_tql.go
@@ -112,6 +112,13 @@ func (svr *httpd) handlePostTagQL(ctx *gin.Context) {
 	if chart := task.OutputChartType(); len(chart) > 0 {
 		ctx.Writer.Header().Set(TqlHeaderChartType, chart)
 	}
+	if headers := task.OutputHttpHeaders(); len(headers) > 0 {
+		for k, vs := range headers {
+			for _, v := range vs {
+				ctx.Writer.Header().Set(k, v)
+			}
+		}
+	}
 	result := task.Execute()
 	if result == nil {
 		svr.log.Error("tql execute return nil")
@@ -197,6 +204,13 @@ func (svr *httpd) handleTagQL(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Content-Encoding", task.OutputContentEncoding())
 	if chart := task.OutputChartType(); len(chart) > 0 {
 		ctx.Writer.Header().Set(TqlHeaderChartType, chart)
+	}
+	if headers := task.OutputHttpHeaders(); len(headers) > 0 {
+		for k, vs := range headers {
+			for _, v := range vs {
+				ctx.Writer.Header().Set(k, v)
+			}
+		}
 	}
 	result := task.Execute()
 	if result == nil {

--- a/mods/tql/fx_codec_opts.gen.go
+++ b/mods/tql/fx_codec_opts.gen.go
@@ -9,6 +9,7 @@ import (
 )
 
 var CodecOptsDefinitions = []Definition{
+	{Name: "httpHeader", Func: opts.HttpHeader},
 	{Name: "autoRotate", Func: opts.AutoRotate},
 	{Name: "boxDrawBorder", Func: opts.BoxDrawBorder},
 	{Name: "boxSeparateColumns", Func: opts.BoxSeparateColumns},

--- a/mods/tql/fx_generate.gen.go
+++ b/mods/tql/fx_generate.gen.go
@@ -259,6 +259,7 @@ func NewNode(task *Task) *Node {
 		"tz":        x.gen_tz,
 		"sep":       x.gen_sep,
 		// codec.opts
+		"httpHeader":          x.gen_httpHeader,
 		"autoRotate":          x.gen_autoRotate,
 		"boxDrawBorder":       x.gen_boxDrawBorder,
 		"boxSeparateColumns":  x.gen_boxSeparateColumns,
@@ -3975,6 +3976,25 @@ func (x *Node) gen_sep(args ...any) (any, error) {
 	return ret, nil
 }
 
+// gen_httpHeader
+//
+// syntax: httpHeader(string, string)
+func (x *Node) gen_httpHeader(args ...any) (any, error) {
+	if len(args) != 2 {
+		return nil, ErrInvalidNumOfArgs("httpHeader", 2, len(args))
+	}
+	p0, err := convString(args, 0, "httpHeader", "string")
+	if err != nil {
+		return nil, err
+	}
+	p1, err := convString(args, 1, "httpHeader", "string")
+	if err != nil {
+		return nil, err
+	}
+	ret := opts.HttpHeader(p0, p1)
+	return ret, nil
+}
+
 // gen_autoRotate
 //
 // syntax: autoRotate(float64)
@@ -4188,11 +4208,11 @@ func (x *Node) gen_chartOption(args ...any) (any, error) {
 
 // gen_columnTypes
 //
-// syntax: columnTypes(...types.DataType)
+// syntax: columnTypes(...api.DataType)
 func (x *Node) gen_columnTypes(args ...any) (any, error) {
 	p0 := []api.DataType{}
 	for n := 0; n < len(args); n++ {
-		argv, err := convDataType(args, n, "columnTypes", "...types.DataType")
+		argv, err := convDataType(args, n, "columnTypes", "...api.DataType")
 		if err != nil {
 			return nil, err
 		}

--- a/mods/tql/task.go
+++ b/mods/tql/task.go
@@ -495,6 +495,14 @@ func (x *Task) OutputContentEncoding() string {
 	return "identity"
 }
 
+func (x *Task) OutputHttpHeaders() map[string][]string {
+	if x.output != nil {
+
+		return x.output.HttpHeaders()
+	}
+	return nil
+}
+
 func (x *Task) OutputChartType() string {
 	if x.output != nil {
 		if x.output.IsChart() {

--- a/mods/tql/task_output.go
+++ b/mods/tql/task_output.go
@@ -228,6 +228,15 @@ func (out *output) ContentType() string {
 	return "application/octet-stream"
 }
 
+func (out *output) HttpHeaders() map[string][]string {
+	if out.encoder != nil {
+		return out.encoder.HttpHeaders()
+	} else if out.dbSink != nil {
+		return nil
+	}
+	return nil
+}
+
 func (out *output) IsChart() bool {
 	return out.isChart
 }


### PR DESCRIPTION
TQL `CSV()`  sink supports custom http response headers.

```js
SQL('select * from example limit 10')
CSV(
    httpHeader("Content-Disposition", "attachment"),
    httpHeader("X-Custom-Header", "any additional header")
)
```

**respons**

```sh
< HTTP/1.1 200 OK
< Content-Disposition: attachment
< Content-Encoding: identity
< Content-Type: text/csv; charset=utf-8
< X-Custom-Header: any additional header
< Date: Fri, 01 Nov 2024 03:11:26 GMT
< Content-Length: 503
<
timer-hello,1718788606127216000,0.9247820193075444
timer-hello,1718788647002225000,0.4162746069764663
timer-hello,1718788657002057000,0.9405939947129641
```