### PR TITLE
script halting

### DIFF
--- a/mods/tql/fm_script.go
+++ b/mods/tql/fm_script.go
@@ -611,6 +611,7 @@ func (node *Node) fmScriptOtto(initCode string, mainCode string) (any, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer closeOttoContext(ctx)
 		node.SetValue(js_ctx_key, ctx)
 	}
 	if inflight := node.Inflight(); inflight != nil {
@@ -645,6 +646,10 @@ func (ctx *OttoContext) Run() (any, error) {
 	return v.Export()
 }
 
+func closeOttoContext(ctx *OttoContext) {
+	close(ctx.vm.Interrupt)
+}
+
 func newOttoContext(node *Node, initCode string, mainCode string) (*OttoContext, error) {
 	ctx := &OttoContext{
 		node: node,
@@ -676,7 +681,6 @@ func newOttoContext(node *Node, initCode string, mainCode string) (*OttoContext,
 					return ctx.vm.Call("finalize", nil)
 				})
 			}
-			defer close(ctx.vm.Interrupt)
 		})
 	})
 	con, _ := ctx.vm.Get("console")

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -1551,7 +1551,9 @@ func TestScriptInterrupt(t *testing.T) {
 			`,
 			CtxTimeout: 100 * time.Millisecond,
 			ExpectFunc: func(t *testing.T, result string) {
-				fmt.Println(result)
+				// SCRIPT should be interrupted by context timeout,
+				// so no result should be returned
+				require.Empty(t, result)
 			},
 		},
 	}


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of script execution interruptions and adds new test cases to ensure the robustness of these changes. The most important changes include adding a mechanism to handle script panics, introducing a cleanup channel for the watchdog, and updating the test suite to cover new scenarios.

Improvements to script execution handling:

* [`mods/tql/fm_script.go`](diffhunk://#diff-a564fd397232ceefcacacfbb4707c89425fc7f9425bd095cb4dafbcff9c8e780R604-R623): Added a deferred function to handle panics during script execution by logging appropriate messages. This ensures that any interruptions or panics are properly logged.
* [`mods/tql/fm_script.go`](diffhunk://#diff-a564fd397232ceefcacacfbb4707c89425fc7f9425bd095cb4dafbcff9c8e780R650-R668): Introduced a `watchdogCleanup` channel in the `OttoContext` struct and added logic to close this channel and the `vm.Interrupt` channel to clean up resources properly. [[1]](diffhunk://#diff-a564fd397232ceefcacacfbb4707c89425fc7f9425bd095cb4dafbcff9c8e780R650-R668) [[2]](diffhunk://#diff-a564fd397232ceefcacacfbb4707c89425fc7f9425bd095cb4dafbcff9c8e780R688-R699)
* [`mods/tql/fm_script.go`](diffhunk://#diff-a564fd397232ceefcacacfbb4707c89425fc7f9425bd095cb4dafbcff9c8e780R753-R771): Implemented a goroutine to monitor the script execution and interrupt it if the task should stop, using the new `watchdogCleanup` channel.

Updates to the test suite:

* [`mods/tql/tql_test.go`](diffhunk://#diff-a506b05e7ab53f45329a482649de0f6366bcb0aa88017ba2ff72496da349a6b0R95): Added a `CtxTimeout` field to the `TqlTestCase` struct to allow setting custom context timeouts for tests.
* [`mods/tql/tql_test.go`](diffhunk://#diff-a506b05e7ab53f45329a482649de0f6366bcb0aa88017ba2ff72496da349a6b0R1540-R1608): Introduced new test cases to verify the behavior of script interruptions, including scenarios for timeout during initialization and finalization stages.