### PR TITLE
Fix machcli testsuite

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -10,11 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         platform:
+          - macos-15
           - macos-14
           - macos-13
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-22.04-arm
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - windows-2019
     runs-on: ${{ matrix.platform }}
     steps:
@@ -36,7 +38,7 @@ jobs:
           check-latest: true
           cache: false
       - name: Setup zig
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         uses: goto-bus-stop/setup-zig@v2
         with:
           version: 0.11.0
@@ -48,12 +50,12 @@ jobs:
       - name: Test
         run: go run mage.go test
       - name: Codecov
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Build
         run: go run mage.go machbase-neo package
       - name: Build arm32
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         run: go run mage.go buildx machbase-neo linux arm packagex linux arm

--- a/api/machcli/machcli.go
+++ b/api/machcli/machcli.go
@@ -70,13 +70,16 @@ type Config struct {
 	//	< 0 : unlimited
 	//	0 : default, maxOpenConns = CPU count * maxOpenConnsFactor
 	//	> 0 : specified max open connections
-	MaxOpenConns int
+	MaxOpenConn int
 
 	// MaxOpenConnsFactor
 	//
 	//	used to calculate the number of max open connections when maxOpenConns is 0
 	//	default is 1.5
-	MaxOpenConnsFactor float64
+	MaxOpenConnFactor float64
+
+	MaxOpenQuery       int
+	MaxOpenQueryFactor float64
 
 	TrustUsers map[string]string
 }
@@ -110,17 +113,17 @@ func NewDatabase(conf *Config) (*Database, error) {
 		ret.trustUsers[u] = p
 	}
 
-	if conf.MaxOpenConnsFactor <= 0 {
-		conf.MaxOpenConnsFactor = 1.5
+	if conf.MaxOpenConnFactor <= 0 {
+		conf.MaxOpenConnFactor = 1.5
 	}
 
-	if conf.MaxOpenConns < 0 {
-		conf.MaxOpenConns = -1
-	} else if conf.MaxOpenConns == 0 {
-		conf.MaxOpenConns = int(float64(runtime.NumCPU()) * conf.MaxOpenConnsFactor)
+	if conf.MaxOpenConn < 0 {
+		conf.MaxOpenConn = -1
+	} else if conf.MaxOpenConn == 0 {
+		conf.MaxOpenConn = int(float64(runtime.NumCPU()) * conf.MaxOpenConnFactor)
 	}
 
-	ret.SetMaxOpenConns(conf.MaxOpenConns)
+	ret.SetMaxOpenConns(conf.MaxOpenConn)
 	return ret, nil
 }
 

--- a/api/testsuite/testsuite.go
+++ b/api/testsuite/testsuite.go
@@ -274,9 +274,11 @@ func (s *Server) StartServer(m *testing.M) {
 
 	// machcli database
 	if db, err := machcli.NewDatabase(&machcli.Config{
-		Host:       "127.0.0.1",
-		Port:       s.machsvrPort,
-		TrustUsers: map[string]string{"sys": "manager"},
+		Host:         "127.0.0.1",
+		Port:         s.machsvrPort,
+		TrustUsers:   map[string]string{"sys": "manager"},
+		MaxOpenConn:  -1,
+		MaxOpenQuery: -1,
 	}); err != nil {
 		panic(err)
 	} else {

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -398,8 +398,10 @@ func (s *Server) startMachbaseCli() error {
 	db, err := machcli.NewDatabase(&machcli.Config{
 		Host:               host,
 		Port:               port,
-		MaxOpenConns:       s.Config.MaxOpenConn,
-		MaxOpenConnsFactor: s.Config.MaxOpenConnFactor,
+		MaxOpenConn:        s.Config.MaxOpenConn,
+		MaxOpenConnFactor:  s.Config.MaxOpenConnFactor,
+		MaxOpenQuery:       s.Config.MaxOpenQuery,
+		MaxOpenQueryFactor: s.Config.MaxOpenQueryFactor,
 		TrustUsers:         map[string]string{"sys": "manager"},
 	})
 	if err != nil {


### PR DESCRIPTION
This pull request includes updates to the CI configuration and changes to the database connection configuration in the `machcli` package. The most important changes include updating the CI matrix to add new platforms, modifying the setup conditions for specific tools, and refactoring the database configuration structure to include new parameters.

CI Configuration Updates:

* [`.github/workflows/ci-pr.yml`](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9R13-R19): Added new platforms `macos-15`, `ubuntu-22.04-arm`, and `ubuntu-24.04-arm` to the CI matrix, and removed `ubuntu-20.04` from the matrix.
* [`.github/workflows/ci-pr.yml`](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9L39-R41): Updated conditions for setting up Zig, running tests, and building for arm32 to use `ubuntu-22.04` instead of `ubuntu-20.04`. [[1]](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9L39-R41) [[2]](diffhunk://#diff-d7f7c1fd6d4e4da806b57e0d5a1bee46c0f8654468beedd7d571b91761474ff9L51-R60)

Database Configuration Refactoring:

* [`api/machcli/machcli.go`](diffhunk://#diff-939ca71e6bc389b23380b982a6f7e9529ea99803cf5650899fa599f317d0318eL73-R82): Renamed `MaxOpenConns` to `MaxOpenConn` and `MaxOpenConnsFactor` to `MaxOpenConnFactor`. Added new parameters `MaxOpenQuery` and `MaxOpenQueryFactor` to the `Config` struct.
* [`api/machcli/machcli.go`](diffhunk://#diff-939ca71e6bc389b23380b982a6f7e9529ea99803cf5650899fa599f317d0318eL113-R126): Updated the `NewDatabase` function to use the new `MaxOpenConn` and `MaxOpenConnFactor` parameters, and added logic to set `MaxOpenQuery` and `MaxOpenQueryFactor`.
* [`api/testsuite/testsuite.go`](diffhunk://#diff-4a99a7dc80eb245c2996180f71682adf497921e0aa880b275f15cd33989f5040R280-R281): Added `MaxOpenConn` and `MaxOpenQuery` parameters to the `StartServer` function.
* [`mods/server/server.go`](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL401-R404): Updated the `startMachbaseCli` function to use the new `MaxOpenConn`, `MaxOpenConnFactor`, `MaxOpenQuery`, and `MaxOpenQueryFactor` parameters.