### PR TITLE
Refactor error handling to use std

### DIFF
--- a/api/do_tables.go
+++ b/api/do_tables.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 func ifThenElse(cond bool, a, b string) string {
@@ -142,7 +140,7 @@ func ExistsTableTruncate(ctx context.Context, conn Conn, fullTableName string, t
 	}
 	tableType, err0 := QueryTableType(ctx, conn, fullTableName)
 	if err0 != nil {
-		err = errors.Wrap(err0, fmt.Sprintf("table '%s' doesn't exist", fullTableName))
+		err = fmt.Errorf("table '%s' doesn't exist, %s", fullTableName, err0.Error())
 		return
 	}
 	if tableType == TableTypeLog {

--- a/api/machrpc/machrpc.go
+++ b/api/machrpc/machrpc.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +16,6 @@ import (
 	"time"
 
 	"github.com/machbase/neo-server/v8/api"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -88,7 +88,7 @@ func NewClient(cfg *Config) (*Client, error) {
 		return nil, errors.New("server address is not specified")
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "NewClient")
+		return nil, fmt.Errorf("NewClient, %s", err.Error())
 	}
 	client.grpcConn = conn
 	client.cli = NewMachbaseClient(conn)
@@ -573,7 +573,7 @@ func (conn *Conn) Appender(ctx context.Context, tableName string, opts ...api.Ap
 		TableName: tableName,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "Appender")
+		return nil, fmt.Errorf("Appender, %s", err.Error())
 	}
 
 	if !openRsp.Success {
@@ -593,7 +593,7 @@ func (conn *Conn) Appender(ctx context.Context, tableName string, opts ...api.Ap
 
 	appendClient, err := conn.client.cli.Append(context.Background())
 	if err != nil {
-		return nil, errors.Wrap(err, "AppendClient")
+		return nil, fmt.Errorf("AppendClient, %s", err.Error())
 	}
 
 	ap.client = conn.client

--- a/api/machrpc/pbconv.go
+++ b/api/machrpc/pbconv.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -88,7 +87,7 @@ func ConvertAnyToPb(params []any) ([]*anypb.Any, error) {
 			return nil, fmt.Errorf("unsupported params[%d] type %T", i, p)
 		}
 		if err != nil {
-			return nil, errors.Wrapf(err, "convert params[%d]", i)
+			return nil, fmt.Errorf("convert params[%d], %s", i, err.Error())
 		}
 	}
 	return pbParams, nil

--- a/booter/boot.go
+++ b/booter/boot.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"strings"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 type Booter interface {
@@ -66,12 +64,12 @@ func (bt *boot) Startup() error {
 		// evaluate config values
 		err := EvalObject(objName, config, def.Config)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("config %s", objName))
+			return fmt.Errorf("config %s, %s", objName, err.Error())
 		}
 		// create instance
 		mod, err := fact.NewInstance(config)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("instance %s", def.Id))
+			return fmt.Errorf("instance %s, %s", def.Id, err.Error())
 		}
 		wrap := wrapper{
 			id:         def.Id,
@@ -105,7 +103,7 @@ func (bt *boot) Startup() error {
 		bootlog.Println("start", wrap.id, wrap.definition.Name)
 		err := wrap.real.Start()
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("mod start %s", wrap.id))
+			return fmt.Errorf("mod start %s, %s", wrap.id, err.Error())
 		}
 		wrap.state = Run
 	}

--- a/booter/boot_test.go
+++ b/booter/boot_test.go
@@ -1,6 +1,7 @@
 package booter_test
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"time"
 
 	"github.com/machbase/neo-server/v8/booter"
-	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 

--- a/booter/builder.go
+++ b/booter/builder.go
@@ -1,6 +1,7 @@
 package booter
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 	"github.com/zclconf/go-cty/cty/gocty"
@@ -77,7 +77,7 @@ func (bld *builder) BuildWithFiles(files []string) (Booter, error) {
 func (bld *builder) BuildWithDir(configDir string) (Booter, error) {
 	entries, err := os.ReadDir(configDir)
 	if err != nil {
-		return nil, errors.Wrap(err, "invalid config directory")
+		return nil, fmt.Errorf("invalid config directory, %s", err.Error())
 	}
 
 	files := make([]string, 0)

--- a/booter/definitions.go
+++ b/booter/definitions.go
@@ -1,6 +1,7 @@
 package booter
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
 	"github.com/zclconf/go-cty/cty/function"
 )
@@ -268,7 +268,7 @@ func EvalReflectValue(refName string, ref reflect.Value, value cty.Value) error 
 			// string config를 url.URL struct로 변환
 			v, err := url.Parse(value.AsString())
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("%s should be url", refName))
+				return fmt.Errorf("%s should be url, %s", refName, err.Error())
 			}
 			ref.Set(reflect.ValueOf(*v))
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/orcaman/concurrent-map v1.0.0
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/paulmach/orb v0.11.1
-	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.6
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/robertkrimen/otto v0.5.1
@@ -58,7 +57,6 @@ require (
 	go.abhg.dev/goldmark/mermaid v0.5.0
 	golang.org/x/crypto v0.32.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
-	golang.org/x/net v0.34.0
 	golang.org/x/sys v0.30.0
 	golang.org/x/term v0.28.0
 	golang.org/x/text v0.22.0
@@ -136,6 +134,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rs/xid v1.5.0 // indirect
@@ -154,6 +153,7 @@ require (
 	golang.org/x/arch v0.14.0 // indirect
 	golang.org/x/image v0.18.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/tools v0.23.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/mods/codec/internal/geomap/geomap.go
+++ b/mods/codec/internal/geomap/geomap.go
@@ -229,7 +229,7 @@ func (gm *GeoMap) Close() {
 	gm.appendJSCode(`var map;`)
 	gm.appendJSCode(`if (opt && opt.map) {`)
 	gm.appendJSCode(`  map = opt.map;`)
-	// remove all layers excpet the tile layer.
+	// remove all layers except the tile layer.
 	gm.appendJSCode(`  opt.map.eachLayer(function (layer) {`)
 	gm.appendJSCode(`    if (!(layer instanceof L.TileLayer)) {`)
 	gm.appendJSCode(`      opt.map.removeLayer(layer);`)
@@ -329,7 +329,7 @@ func (gm *GeoMap) Close() {
 	}
 }
 
-func crsMarshalJS(c *nums.CRS, varname string) string {
+func crsMarshalJS(c *nums.CRS, varName string) string {
 	res := []string{}
 	for _, r := range c.Options["resolutions"].([]float64) {
 		res = append(res, fmt.Sprintf("%v", r))
@@ -347,7 +347,7 @@ func crsMarshalJS(c *nums.CRS, varname string) string {
 			origin: %s,
 			bounds: L.bounds(%s)
 		});`,
-		varname,
+		varName,
 		c.Code, c.Proj, strings.Join(res, ","), org, bound)
 }
 

--- a/mods/codec/internal/json/json_decode.go
+++ b/mods/codec/internal/json/json_decode.go
@@ -2,12 +2,12 @@ package json
 
 import (
 	gojson "encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/machbase/neo-server/v8/api"
-	"github.com/pkg/errors"
 )
 
 type Decoder struct {

--- a/mods/model/model.go
+++ b/mods/model/model.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/pkg/errors"
 )
 
 type ServicePort struct {
@@ -68,15 +68,15 @@ func WithExperimentModeProvider(provider func() bool) Option {
 func (s *svr) Start() error {
 	s.bridgeDir = filepath.Join(s.configDir, "bridges")
 	if err := s.mkDirIfNotExists(s.bridgeDir, 0755); err != nil {
-		return errors.Wrap(err, "bridge defs")
+		return fmt.Errorf("bridge defs, %s", err.Error())
 	}
 	s.schedDir = filepath.Join(s.configDir, "schedules")
 	if err := s.mkDirIfNotExists(s.schedDir, 0755); err != nil {
-		return errors.Wrap(err, "schedule defs")
+		return fmt.Errorf("schedule defs, %s", err.Error())
 	}
 	s.shellDir = filepath.Join(s.configDir, "shell")
 	if err := s.mkDirIfNotExists(s.shellDir, 0700); err != nil {
-		return errors.Wrap(err, "shell defs")
+		return fmt.Errorf("shell defs, %s", err.Error())
 	}
 	return nil
 }
@@ -301,7 +301,7 @@ func (s *svr) SaveShell(def *ShellDefinition) error {
 	}
 	binpath := args[0]
 	if fi, err := os.Stat(binpath); err != nil {
-		return errors.Wrapf(err, "'%s' is not accessible", binpath)
+		return fmt.Errorf("'%s' is not accessible, %s", binpath, err.Error())
 	} else {
 		if fi.IsDir() {
 			return fmt.Errorf("'%s' is not executable", binpath)

--- a/mods/server/http_test.go
+++ b/mods/server/http_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -28,7 +29,6 @@ import (
 	"github.com/machbase/neo-server/v8/api"
 	"github.com/machbase/neo-server/v8/mods/eventbus"
 	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )

--- a/mods/server/machbase_conf.go
+++ b/mods/server/machbase_conf.go
@@ -2,10 +2,9 @@ package server
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
 	"text/template"
-
-	"github.com/pkg/errors"
 )
 
 type MachbaseConfig struct {
@@ -246,16 +245,16 @@ var conf_template string
 func applyMachbaseConfig(confpath string, conf *MachbaseConfig) error {
 	tmpl, err := template.New("machbase_conf").Parse(conf_template)
 	if err != nil {
-		return errors.Wrap(err, "config template")
+		return fmt.Errorf("config template, %s", err.Error())
 	}
 	f, err := os.OpenFile(confpath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
-		return errors.Wrap(err, "config file open")
+		return fmt.Errorf("config file open, %s", err.Error())
 	}
 	defer f.Close()
 	err = tmpl.Execute(f, conf)
 	if err != nil {
-		return errors.Wrap(err, "config file write")
+		return fmt.Errorf("config file write, %s", err.Error())
 	}
 	return nil
 }

--- a/mods/server/mqtt.go
+++ b/mods/server/mqtt.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -27,7 +28,6 @@ import (
 	"github.com/mochi-mqtt/server/v2/listeners"
 	"github.com/mochi-mqtt/server/v2/packets"
 	cmap "github.com/orcaman/concurrent-map"
-	"github.com/pkg/errors"
 )
 
 type MqttOption func(s *mqttd) error
@@ -76,10 +76,10 @@ func LoadTlsConfig(certFile string, keyFile string, loadSystemCA bool, loadPriva
 		// append root ca
 		ca, err := os.ReadFile(certFile)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("fail to load ca key: %s\n", certFile))
+			return nil, fmt.Errorf("fail to load ca key: %s, %s", certFile, err.Error())
 		}
 		if ok := rootCAs.AppendCertsFromPEM(ca); !ok {
-			return nil, errors.Wrap(err, fmt.Sprintf("fail to add ca key: %s\n", certFile))
+			return nil, fmt.Errorf("fail to add ca key: %s", certFile)
 		}
 	}
 	ret := &tls.Config{

--- a/mods/server/ssh.go
+++ b/mods/server/ssh.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,7 +17,6 @@ import (
 	"github.com/gliderlabs/ssh"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/model"
-	"github.com/pkg/errors"
 	"github.com/pkg/sftp"
 	gossh "golang.org/x/crypto/ssh"
 )
@@ -162,7 +162,7 @@ func (svr *sshd) Start() error {
 
 		ln, err := net.Listen("tcp", listenAddress)
 		if err != nil {
-			return errors.Wrap(err, "machshell")
+			return fmt.Errorf("machshell, %s", err.Error())
 		}
 		svr.listeners = append(svr.listeners, ln)
 
@@ -506,7 +506,7 @@ func signerFromPath(keypath, password string) (ssh.Signer, error) {
 	if len(keypath) > 0 {
 		pemBytes, err := os.ReadFile(keypath)
 		if err != nil {
-			return signer, errors.Wrap(err, "server key")
+			return signer, fmt.Errorf("server key, %s", err.Error())
 		}
 		var keypass []byte
 		if len(password) > 0 {
@@ -514,7 +514,7 @@ func signerFromPath(keypath, password string) (ssh.Signer, error) {
 		}
 		signer, err = signerFromPem(pemBytes, keypass)
 		if err != nil {
-			return signer, errors.Wrap(err, "server signer")
+			return signer, fmt.Errorf("server signer, %s", err.Error())
 		}
 	}
 	return signer, nil
@@ -522,7 +522,7 @@ func signerFromPath(keypath, password string) (ssh.Signer, error) {
 
 func signerFromPem(pemBytes []byte, password []byte) (ssh.Signer, error) {
 	// read pem block
-	err := errors.New("Pem decode failed, no key found")
+	err := errors.New("pem decode failed, no key found")
 	pemBlock, _ := pem.Decode(pemBytes)
 	if pemBlock == nil {
 		return nil, err

--- a/mods/server/svrauth.go
+++ b/mods/server/svrauth.go
@@ -2,12 +2,12 @@ package server
 
 import (
 	"crypto/x509"
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/mods/server/svrconf.go
+++ b/mods/server/svrconf.go
@@ -15,7 +15,6 @@ import (
 	"github.com/machbase/neo-server/v8/api/machsvr"
 	"github.com/machbase/neo-server/v8/booter"
 	"github.com/machbase/neo-server/v8/mods/logging"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -170,7 +169,7 @@ func (s *Server) checkRewriteMachbaseConf(confpath string) (bool, error) {
 	shouldRewrite := false
 	content, err := os.ReadFile(confpath)
 	if err != nil {
-		return false, errors.Wrap(err, "MACH machbase.conf not available")
+		return false, fmt.Errorf("MACH machbase.conf not available, %s", err.Error())
 	}
 	reader := bufio.NewReader(bytes.NewBuffer(content))
 	parts := []string{}
@@ -180,7 +179,7 @@ func (s *Server) checkRewriteMachbaseConf(confpath string) (bool, error) {
 			if err == io.EOF {
 				break
 			} else {
-				return false, errors.Wrap(err, "MACH machbase.conf malformed")
+				return false, fmt.Errorf("MACH machbase.conf malformed, %s", err.Error())
 			}
 		}
 		parts = append(parts, string(str))
@@ -212,7 +211,7 @@ func (s *Server) checkRewriteMachbaseConf(confpath string) (bool, error) {
 func (s *Server) rewriteMachbaseConf(confpath string) error {
 	content, err := os.ReadFile(confpath)
 	if err != nil {
-		return errors.Wrap(err, "MACH machbase.conf not available")
+		return fmt.Errorf("MACH machbase.conf not available, %s", err.Error())
 	}
 	reader := bufio.NewReader(bytes.NewBuffer(content))
 	newConfLines := []string{}
@@ -223,7 +222,7 @@ func (s *Server) rewriteMachbaseConf(confpath string) error {
 			if err == io.EOF {
 				break
 			} else {
-				return errors.Wrap(err, "MACH machbase.conf malformed")
+				return fmt.Errorf("MACH machbase.conf malformed, %s", err.Error())
 			}
 		}
 		parts = append(parts, string(str))
@@ -252,13 +251,13 @@ func (s *Server) rewriteMachbaseConf(confpath string) error {
 	}
 	fd, err := os.OpenFile(confpath, os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		return errors.Wrap(err, "MACH machbase.conf unable to write")
+		return fmt.Errorf("MACH machbase.conf unable to write, %s", err.Error())
 	}
 	if _, err = fd.Write([]byte(strings.Join(newConfLines, "\n"))); err != nil {
-		return errors.Wrap(err, "MACH machbase.conf write error")
+		return fmt.Errorf("MACH machbase.conf write error, %s", err.Error())
 	}
 	if err = fd.Close(); err != nil {
-		return errors.Wrap(err, "MACH machbase.conf close error")
+		return fmt.Errorf("MACH machbase.conf close error, %s", err.Error())
 	}
 	return nil
 }

--- a/mods/server/svrgrpc.go
+++ b/mods/server/svrgrpc.go
@@ -5,6 +5,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"os"
 	"reflect"
 	"runtime"
@@ -19,7 +21,6 @@ import (
 	"github.com/machbase/neo-server/v8/api/schedule"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/stats"
@@ -191,7 +192,7 @@ func (svr *grpcd) Start() error {
 		}
 		lsnr, err := util.MakeListener(listen)
 		if err != nil {
-			return errors.Wrap(err, "cannot start with failed listener")
+			return fmt.Errorf("cannot start with failed listener, %s", err.Error())
 		}
 		svr.log.Infof("gRPC Listen %s", listen)
 
@@ -254,7 +255,7 @@ func (svr *grpcd) loadTlsCreds() (credentials.TransportCredentials, error) {
 	block, _ := pem.Decode(caContent)
 	caCert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "fail to load server CA cert")
+		return nil, fmt.Errorf("fail to load server CA cert, %s", err.Error())
 	}
 	caPool := x509.NewCertPool()
 	caPool.AddCert(caCert)

--- a/mods/server/svrkey.go
+++ b/mods/server/svrkey.go
@@ -12,13 +12,13 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"io"
 	"math/big"
 	"reflect"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/sha3"
 )
 

--- a/mods/server/svrmgmt.go
+++ b/mods/server/svrmgmt.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -28,7 +29,6 @@ import (
 	"github.com/machbase/neo-server/v8/booter"
 	"github.com/machbase/neo-server/v8/mods"
 	"github.com/machbase/neo-server/v8/mods/model"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/peer"
 )
 
@@ -228,7 +228,7 @@ func generateClientKey(req *GenCertReq) ([]byte, []byte, string, error) {
 
 	certBytes, err := GenerateClientCertificate(req.Name, req.NotBefore, req.NotAfter, req.Issuer, req.IssuerKey, clientPub)
 	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "client certificate")
+		return nil, nil, "", fmt.Errorf("client certificate, %s", err.Error())
 	}
 
 	return certBytes, clientKeyPEM, token, nil

--- a/mods/server/svrnavel.go
+++ b/mods/server/svrnavel.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/machbase/neo-server/v8/booter"
 	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/pkg/errors"
 )
 
 func (s *Server) StartNavelCord() {

--- a/mods/shell/internal/action/context.go
+++ b/mods/shell/internal/action/context.go
@@ -1,11 +1,11 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/machbase/neo-server/v8/api"
-	"golang.org/x/net/context"
 	"golang.org/x/text/language"
 )
 

--- a/mods/tql/fm_context.go
+++ b/mods/tql/fm_context.go
@@ -1,13 +1,13 @@
 package tql
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
 
 	"github.com/machbase/neo-server/v8/api"
 	"github.com/machbase/neo-server/v8/mods/codec/opts"
-	"github.com/pkg/errors"
 )
 
 type NodeContext struct {

--- a/mods/tql/fm_csv.go
+++ b/mods/tql/fm_csv.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/machbase/neo-server/v8/api"
 	codecOpts "github.com/machbase/neo-server/v8/mods/codec/opts"
 	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/pkg/errors"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
@@ -84,7 +84,7 @@ func (src *csvSource) gen(node *Node) {
 		}
 		if stat.IsDir() {
 			node.task.LogErrorf("Fail to read %q, it is a directory", src.srcFile)
-			ErrorRecord(errors.New("Failed to read directory as CSV")).Tell(node.next)
+			ErrorRecord(errors.New("failed to read directory as CSV")).Tell(node.next)
 			return
 		}
 		content, err := os.Open(src.srcFile)

--- a/mods/tql/fm_dbsink.go
+++ b/mods/tql/fm_dbsink.go
@@ -2,12 +2,12 @@ package tql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/machbase/neo-server/v8/api"
 	"github.com/machbase/neo-server/v8/mods/bridge"
-	"github.com/pkg/errors"
 )
 
 type Table struct {
@@ -121,18 +121,18 @@ func (ins *insert) _addRowBridge(values []any) error {
 	defer conn.Close()
 	result, err := conn.ExecContext(ins.node.task.ctx, sqlText, values...)
 	if err != nil {
-		return errors.Wrap(err, sqlText)
+		return fmt.Errorf("%s, %s", err, sqlText)
 	}
 	if br.SupportLastInsertId() {
 		lastInsertId, err := result.LastInsertId()
 		if err != nil {
-			return errors.Wrap(err, sqlText)
+			return fmt.Errorf("%s, %s", err, sqlText)
 		}
 		ins.lastInsertId = lastInsertId
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return errors.Wrap(err, sqlText)
+		return fmt.Errorf("%s, %s", err, sqlText)
 	}
 	ins.rowsAffected = rowsAffected
 	return nil

--- a/mods/tql/fm_monad.go
+++ b/mods/tql/fm_monad.go
@@ -3,6 +3,7 @@ package tql
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -21,7 +22,6 @@ import (
 	"github.com/machbase/neo-server/v8/mods/nums/kalman/models"
 	"github.com/machbase/neo-server/v8/mods/util"
 	"github.com/machbase/neo-server/v8/mods/util/glob"
-	"github.com/pkg/errors"
 	"gonum.org/v1/gonum/interp"
 	"gonum.org/v1/gonum/stat"
 )

--- a/mods/tql/fm_script_bridge.go
+++ b/mods/tql/fm_script_bridge.go
@@ -3,10 +3,10 @@ package tql
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/d5/tengo/v2"
 	"github.com/machbase/neo-server/v8/mods/bridge"
-	"github.com/pkg/errors"
 )
 
 func tengof_print(node *Node) func(args ...tengo.Object) (tengo.Object, error) {
@@ -263,7 +263,7 @@ func scSqlBridge_query(c *scSqlBridge) func(args ...tengo.Object) (tengo.Object,
 		}
 		rows, err := c.conn.QueryContext(ctx, queryText, params...)
 		if err != nil {
-			return nil, errors.Wrap(err, "query failed")
+			return nil, fmt.Errorf("query failed, %s", err.Error())
 		}
 		c.node.AddCloser(rows)
 		return &scSqlRows{ctx: c.node, rows: rows}, nil

--- a/mods/tql/fm_time.go
+++ b/mods/tql/fm_time.go
@@ -10,7 +10,6 @@ import (
 	"github.com/machbase/neo-server/v8/mods/codec/opts"
 	"github.com/machbase/neo-server/v8/mods/nums/fft"
 	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/pkg/errors"
 	"gonum.org/v1/gonum/interp"
 	"gonum.org/v1/gonum/stat"
 )
@@ -274,11 +273,11 @@ func (x *Node) fmTimeAdd(tsExpr any, deltaExpr any) (time.Time, error) {
 	var err error
 	baseTime, err = util.ToTime(tsExpr)
 	if err != nil {
-		return baseTime, errors.Wrap(err, "invalid time expression")
+		return baseTime, fmt.Errorf("invalid time expression: %s", err.Error())
 	}
 	delta, err = util.ToDuration(deltaExpr)
 	if err != nil {
-		return baseTime, errors.Wrap(err, "invalid time expression")
+		return baseTime, fmt.Errorf("invalid time expression: %s", err.Error())
 	}
 	return baseTime.Add(delta), nil
 }

--- a/mods/tql/task.go
+++ b/mods/tql/task.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,7 +21,6 @@ import (
 	"github.com/machbase/neo-server/v8/mods/eventbus"
 	"github.com/machbase/neo-server/v8/mods/tql/internal/expression"
 	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/pkg/errors"
 )
 
 type Task struct {
@@ -266,7 +266,7 @@ func (x *Task) compile(codeReader io.Reader) error {
 			// sink
 			x.output, err = NewNode(x).compileSink(curLine)
 			if err != nil {
-				x.compileErr = errors.Wrapf(err, "line %d", curLine.line)
+				x.compileErr = fmt.Errorf("line %d: %s", curLine.line, err.Error())
 				return x.compileErr
 			}
 			x.output.pragma = pragmas

--- a/mods/tql/task_node.go
+++ b/mods/tql/task_node.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/machbase/neo-server/v8/mods/tql/internal/expression"
-	"github.com/pkg/errors"
 )
 
 type Closer interface {
@@ -46,7 +45,7 @@ var _ expression.Parameters = (*Node)(nil)
 func (node *Node) compile(code string) error {
 	expr, err := node.Parse(code)
 	if err != nil {
-		return errors.Wrapf(err, "at %s", code)
+		return fmt.Errorf("%s at %s", err.Error(), code)
 	}
 	if expr == nil {
 		return fmt.Errorf("compile error at %s", code)

--- a/mods/tql/task_output.go
+++ b/mods/tql/task_output.go
@@ -2,6 +2,7 @@ package tql
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"runtime/debug"
@@ -11,7 +12,6 @@ import (
 	"github.com/machbase/neo-server/v8/api"
 	"github.com/machbase/neo-server/v8/mods/codec"
 	"github.com/machbase/neo-server/v8/mods/codec/opts"
-	"github.com/pkg/errors"
 )
 
 type DatabaseSink interface {

--- a/mods/util/types.go
+++ b/mods/util/types.go
@@ -9,8 +9,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 func ErrIncompatible(dstType string, src any) error {
@@ -272,28 +270,28 @@ func ParseTime(strVal string, format string, location *time.Location) (time.Time
 	switch timeLayout {
 	case "s":
 		if ts, err = ToInt64(strVal); err != nil {
-			return time.Time{}, errors.Wrap(err, "unable parse time in timeformat")
+			return time.Time{}, fmt.Errorf("unable parse time in timeformat, %s", err.Error())
 		}
 		return time.Unix(ts, 0), nil
 	case "ms":
 		if ts, err = ToInt64(strVal); err != nil {
-			return time.Time{}, errors.Wrap(err, "unable parse time in timeformat")
+			return time.Time{}, fmt.Errorf("unable parse time in timeformat, %s", err.Error())
 		}
 		return time.Unix(0, ts*int64(time.Millisecond)), nil
 	case "us":
 		if ts, err = ToInt64(strVal); err != nil {
-			return time.Time{}, errors.Wrap(err, "unable parse time in timeformat")
+			return time.Time{}, fmt.Errorf("unable parse time in timeformat, %s", err.Error())
 		}
 		return time.Unix(0, ts*int64(time.Microsecond)), nil
 	case "ns":
 		if ts, err = ToInt64(strVal); err != nil {
-			return time.Time{}, errors.Wrap(err, "unable parse time in timeformat")
+			return time.Time{}, fmt.Errorf("unable parse time in timeformat, %s", err.Error())
 		}
 		return time.Unix(0, ts), nil
 	default:
 		baseTime, err = time.ParseInLocation(timeLayout, strVal, location)
 		if err != nil {
-			return baseTime, errors.Wrap(err, ErrIncompatible("time.Time", strVal).Error())
+			return baseTime, fmt.Errorf("%s, %s", ErrIncompatible("time.Time", strVal).Error(), err)
 		}
 	}
 	return baseTime, nil


### PR DESCRIPTION
This pull request primarily focuses on replacing the `github.com/pkg/errors` package with the standard library `errors` package and `fmt.Errorf` for error wrapping. Additionally, there are minor corrections in comments and variable names.

### Error Handling Changes:
* Replaced `github.com/pkg/errors` with `errors` and `fmt.Errorf` for error wrapping across multiple files:
  - [`api/do_tables.go`](diffhunk://#diff-8ad7c3419ef783424e47a642dfdec243faeec6991bb8fd1d38975899be008c57L145-R143): Updated error handling in `ExistsTableTruncate` function.
  - [`api/machrpc/machrpc.go`](diffhunk://#diff-2347df3cc5031cc5e372b85a7828eae9389a443a89c910907af3a94d02d9d37bL91-R91): Updated error handling in `NewClient` and `Appender` functions. [[1]](diffhunk://#diff-2347df3cc5031cc5e372b85a7828eae9389a443a89c910907af3a94d02d9d37bL91-R91) [[2]](diffhunk://#diff-2347df3cc5031cc5e372b85a7828eae9389a443a89c910907af3a94d02d9d37bL576-R576) [[3]](diffhunk://#diff-2347df3cc5031cc5e372b85a7828eae9389a443a89c910907af3a94d02d9d37bL596-R596)
  - [`booter/boot.go`](diffhunk://#diff-edec8cd089e9695c76131e99ba24e7c56ed2d5ddf89b2c5a38bc478f3fd51b02L69-R72): Updated error handling in `Startup` function. [[1]](diffhunk://#diff-edec8cd089e9695c76131e99ba24e7c56ed2d5ddf89b2c5a38bc478f3fd51b02L69-R72) [[2]](diffhunk://#diff-edec8cd089e9695c76131e99ba24e7c56ed2d5ddf89b2c5a38bc478f3fd51b02L108-R106)
  - [`booter/builder.go`](diffhunk://#diff-1a6a3d8c2207dc6696c41f1eb19884f04ba7e04afce29fecc3261b6f1fa47db3L80-R80): Updated error handling in `BuildWithFiles` function.
  - [`booter/definitions.go`](diffhunk://#diff-c394b3d7d4e786c120b0617abe294f85f3ab2228467288c1d890f9db395310dfL271-R271): Updated error handling in `EvalReflectValue` function.
  - [`mods/model/model.go`](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L71-R79): Updated error handling in `Start` and `SaveShell` functions. [[1]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L71-R79) [[2]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L304-R304)
  - [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL172-R172): Updated error handling in various functions including `Start`, `issueAccessToken`, and `NewWebTerm`. [[1]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL172-R172) [[2]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL510-R517) [[3]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL1532-R1539) [[4]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL1552-R1560) [[5]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL1570-R1578)

### Import Changes:
* Removed `github.com/pkg/errors` import and added `errors` import in several files:
  - `api/do_tables.go`
  - `api/machrpc/machrpc.go` [[1]](diffhunk://#diff-2347df3cc5031cc5e372b85a7828eae9389a443a89c910907af3a94d02d9d37bR10) [[2]](diffhunk://#diff-2347df3cc5031cc5e372b85a7828eae9389a443a89c910907af3a94d02d9d37bL18)
  - `api/machrpc/pbconv.go`
  - `booter/boot.go`
  - `booter/boot_test.go`
  - `booter/builder.go`
  - `booter/definitions.go` [[1]](diffhunk://#diff-c394b3d7d4e786c120b0617abe294f85f3ab2228467288c1d890f9db395310dfR4) [[2]](diffhunk://#diff-c394b3d7d4e786c120b0617abe294f85f3ab2228467288c1d890f9db395310dfL13)
  - `mods/codec/internal/json/json_decode.go`
  - `mods/model/model.go` [[1]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87R5) [[2]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L15)
  - `mods/server/http.go` [[1]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR9) [[2]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL44)

### Minor Corrections:
* Corrected typos and variable names in `mods/codec/internal/geomap/geomap.go`:
  - Fixed typo in comment: "excpet" to "except".
  - Renamed variable `varname` to `varName`. [[1]](diffhunk://#diff-3d20d0ac626742fb8d7fe2fe32ef49dd9ed2d7fee50cadceeca411e3f3c8edfdL332-R332) [[2]](diffhunk://#diff-3d20d0ac626742fb8d7fe2fe32ef49dd9ed2d7fee50cadceeca411e3f3c8edfdL350-R350)

### Dependency Management:
* Updated `go.mod` to remove and re-add indirect dependencies:
  - Removed `github.com/pkg/errors` and `golang.org/x/net` from direct dependencies. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L44) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L61)
  - Re-added `github.com/pkg/errors` and `golang.org/x/net` as indirect dependencies. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R137) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R156)