### PR TITLE
 Update cmap dependency to v2 and adjust usage across the codebase

### DIFF
--- a/api/machsvr/mach_grpc.go
+++ b/api/machsvr/mach_grpc.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/machbase/neo-server/v8/api"
 	"github.com/machbase/neo-server/v8/api/machrpc"
-	cmap "github.com/orcaman/concurrent-map"
+	cmap "github.com/orcaman/concurrent-map/v2"
 	"golang.org/x/exp/rand"
 )
 
@@ -25,7 +25,7 @@ type RPCServer struct {
 	authProvider AuthProvider
 	sessions     map[string]*ConnParole
 	sessionsLock sync.Mutex
-	inflightMap  cmap.ConcurrentMap
+	inflightMap  cmap.ConcurrentMap[string, any]
 	idSerial     int64
 }
 
@@ -35,7 +35,7 @@ func NewRPCServer(db api.Database, opts ...RPCServerOption) *RPCServer {
 	s := &RPCServer{
 		db:          db,
 		sessions:    make(map[string]*ConnParole),
-		inflightMap: cmap.New(),
+		inflightMap: cmap.New[any](),
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/nats-io/nats.go v1.36.0
 	github.com/nyaosorg/go-box/v2 v2.1.4
 	github.com/nyaosorg/go-readline-ny v1.0.1
-	github.com/orcaman/concurrent-map v1.0.0
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/paulmach/orb v0.11.1
 	github.com/pkg/sftp v1.13.6

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,6 @@ github.com/nyaosorg/go-readline-ny v1.0.1 h1:btfsdjQTfciYcY5Rbds1nOsHuw1+fo6ageg
 github.com/nyaosorg/go-readline-ny v1.0.1/go.mod h1:/JojGEnLMPy6g+oHBMqy1/AEUDUgjiG2lUYOalhtQpY=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/orcaman/concurrent-map v1.0.0 h1:I/2A2XPCb4IuQWcQhBhSwGfiuybl/J0ev9HDbW65HOY=
-github.com/orcaman/concurrent-map v1.0.0/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
 github.com/paulmach/orb v0.11.1 h1:3koVegMC4X/WeiXYz9iswopaTwMem53NzTJuTF20JzU=

--- a/mods/bridge/bridge.go
+++ b/mods/bridge/bridge.go
@@ -5,13 +5,13 @@ import (
 	"github.com/machbase/neo-server/v8/api/schedule"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/model"
-	cmap "github.com/orcaman/concurrent-map"
+	cmap "github.com/orcaman/concurrent-map/v2"
 )
 
 func NewService(opts ...Option) Service {
 	s := &svr{
 		log:    logging.GetLog("bridge"),
-		ctxMap: cmap.New(),
+		ctxMap: cmap.New[*rowsWrap](),
 	}
 	for _, o := range opts {
 		o(s)
@@ -45,7 +45,7 @@ type svr struct {
 	Service
 
 	log    logging.Log
-	ctxMap cmap.ConcurrentMap
+	ctxMap cmap.ConcurrentMap[string, *rowsWrap]
 
 	schedMgmtImpl schedule.ManagementServer
 	models        model.BridgeProvider

--- a/mods/bridge/runtime.go
+++ b/mods/bridge/runtime.go
@@ -177,7 +177,7 @@ func (s *svr) querySqlBridge(br SqlBridge, req *bridgerpc.ExecRequest) (*bridger
 			enlistInfo: fmt.Sprintf("%s: %s", req.Name, cmd.SqlText),
 			enlistTime: time.Now(),
 			release: func() {
-				s.ctxMap.RemoveCb(handle, func(key string, v interface{}, exists bool) bool {
+				s.ctxMap.RemoveCb(handle, func(key string, v *rowsWrap, exists bool) bool {
 					rows.Close()
 					conn.Close()
 					return true
@@ -201,14 +201,9 @@ func (s *svr) SqlQueryResultFetch(ctx context.Context, cr *bridgerpc.SqlQueryRes
 		}
 		rsp.Elapse = time.Since(tick).String()
 	}()
-	rowsWrapVal, exists := s.ctxMap.Get(cr.Handle)
+	rowsWrap, exists := s.ctxMap.Get(cr.Handle)
 	if !exists {
 		rsp.Reason = fmt.Sprintf("handle '%s' not found", cr.Handle)
-		return rsp, nil
-	}
-	rowsWrap, ok := rowsWrapVal.(*rowsWrap)
-	if !ok {
-		rsp.Reason = fmt.Sprintf("handle '%s' is not valid", cr.Handle)
 		return rsp, nil
 	}
 	if rowsWrap.rows == nil || rowsWrap.conn == nil {
@@ -265,14 +260,9 @@ func (s *svr) SqlQueryResultClose(ctx context.Context, cr *bridgerpc.SqlQueryRes
 		}
 		rsp.Elapse = time.Since(tick).String()
 	}()
-	rowsWrapVal, exists := s.ctxMap.Get(cr.Handle)
+	rowsWrap, exists := s.ctxMap.Get(cr.Handle)
 	if !exists {
 		rsp.Reason = fmt.Sprintf("handle '%s' not found", cr.Handle)
-		return rsp, nil
-	}
-	rowsWrap, ok := rowsWrapVal.(*rowsWrap)
-	if !ok {
-		rsp.Reason = fmt.Sprintf("handle '%s' is not valid", cr.Handle)
 		return rsp, nil
 	}
 	rowsWrap.release()

--- a/mods/server/http.go
+++ b/mods/server/http.go
@@ -41,7 +41,7 @@ import (
 	"github.com/machbase/neo-server/v8/mods/util"
 	"github.com/machbase/neo-server/v8/mods/util/mdconv"
 	"github.com/machbase/neo-server/v8/mods/util/ssfs"
-	cmap "github.com/orcaman/concurrent-map"
+	cmap "github.com/orcaman/concurrent-map/v2"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
@@ -1475,11 +1475,11 @@ func (svr *httpd) handleTermWindowSize(ctx *gin.Context) {
 const termBuffSize = 4096
 
 var terminals = &Terminals{
-	list: cmap.New(),
+	list: cmap.New[*WebTerm](),
 }
 
 type Terminals struct {
-	list cmap.ConcurrentMap
+	list cmap.ConcurrentMap[string, *WebTerm]
 }
 
 func (terms *Terminals) Register(termKey string, term *WebTerm) {
@@ -1491,10 +1491,8 @@ func (terms *Terminals) Unregister(termKey string) {
 }
 
 func (terms *Terminals) Find(termKey string) (*WebTerm, bool) {
-	if v, ok := terms.list.Get(termKey); ok {
-		if term, ok := v.(*WebTerm); ok {
-			return term, true
-		}
+	if term, ok := terms.list.Get(termKey); ok {
+		return term, true
 	}
 	return nil, false
 }

--- a/mods/server/mqtt_write.go
+++ b/mods/server/mqtt_write.go
@@ -388,8 +388,7 @@ func (s *mqttd) handleAppend(cl *mqtt.Client, pk packets.Packet) {
 	}
 	var appenderName = tableUser + "." + wp.Table
 
-	if val, exists := s.appenders.Get(peerId); exists {
-		appenderSet = val.([]*AppenderWrapper)
+	if appenderSet, exists := s.appenders.Get(peerId); exists {
 		for _, a := range appenderSet {
 			if a.appender.TableName() == appenderName {
 				appender = a.appender


### PR DESCRIPTION
This pull request updates the `concurrent-map` dependency to version 2 and adjusts the codebase to accommodate the new generic types introduced in the updated library. The most important changes include updating import paths, modifying type declarations, and refactoring functions to use the new generic types.

Dependency Update:
* Updated import paths to `concurrent-map/v2` in multiple files (`mach_grpc.go`, `bridge.go`, `http.go`, `mqtt.go`). [[1]](diffhunk://#diff-756325d3b2ae2d35477aa93d4ba4cdacf7db6de805ec4c20a55238b8d3b7b2c8L17-R17) [[2]](diffhunk://#diff-aae85ced13cf7ceef9adb84ccf4d39e21223290614399d21e39553cf56faa1acL8-R14) [[3]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL44-R44) [[4]](diffhunk://#diff-59f449f082a182d1902fe3f734a5d88c1eb9b54dea80a527126557a32a2b611bL30-R30)

Type Declarations:
* Changed `cmap.ConcurrentMap` to use generic types, e.g., `cmap.ConcurrentMap[string, any]` in `mach_grpc.go` and `cmap.ConcurrentMap[string, *rowsWrap]` in `bridge.go`. [[1]](diffhunk://#diff-756325d3b2ae2d35477aa93d4ba4cdacf7db6de805ec4c20a55238b8d3b7b2c8L28-R28) [[2]](diffhunk://#diff-aae85ced13cf7ceef9adb84ccf4d39e21223290614399d21e39553cf56faa1acL48-R48)

Function Refactoring:
* Updated function calls to use the new generic types, e.g., `cmap.New[any]()` and `cmap.New[*rowsWrap]()` in `mach_grpc.go` and `bridge.go`. [[1]](diffhunk://#diff-756325d3b2ae2d35477aa93d4ba4cdacf7db6de805ec4c20a55238b8d3b7b2c8L38-R38) [[2]](diffhunk://#diff-aae85ced13cf7ceef9adb84ccf4d39e21223290614399d21e39553cf56faa1acL48-R48)
* Refactored callback functions to use the correct types, e.g., `func(key string, v *rowsWrap, exists bool)` in `runtime.go`.

Additional Changes:
* Removed unnecessary type assertions and simplified code logic, e.g., in `runtime.go` and `mqtt_write.go`. [[1]](diffhunk://#diff-875b0c4908c50acd8e5aff58df38583ad7826156d6438f5b5559cae86b64113dL204-L213) [[2]](diffhunk://#diff-f6065007a6d642585ae4e6482c6836b2ee53e92ca9a053ba1b4925c0535c00feL391-R391)