### PR TITLE
Enhance explain command to support 'full' option in query syntax

### DIFF
--- a/api/do_test.go
+++ b/api/do_test.go
@@ -558,7 +558,7 @@ func tcCommands(t *testing.T) {
 		},
 		{
 			name:  "explain-full-select-all",
-			input: `explain -f -- select * from tag_data`,
+			input: `explain -- full select * from tag_data`,
 			expectFunc: func(t *testing.T, actual string) {
 				require.Greater(t, len(actual), 5000, actual)
 				require.Contains(t, actual, "EXECUTE")

--- a/mods/shell/internal/cmd/explain.go
+++ b/mods/shell/internal/cmd/explain.go
@@ -18,11 +18,9 @@ func init() {
 	})
 }
 
-const helpExplain string = `  explain <query>
+const helpExplain string = `  explain [full] <query>
   arguments:
-    query       query statement to display the execution plan
-  options:
-    --full      full explain`
+    query       query statement to display the execution plan`
 
 type ExplainCmd struct {
 	Help  bool     `kong:"-"`
@@ -51,6 +49,11 @@ func doExplain(ctx *action.ActionContext) {
 	}
 
 	tick := time.Now()
+	if len(cmd.Query) > 1 && strings.EqualFold(cmd.Query[0], "full") {
+		// it allows to use 'explain full select...' as well as 'explain --full select...'
+		cmd.Full = true
+		cmd.Query = cmd.Query[1:]
+	}
 	sqlText := util.StripQuote(strings.Join(cmd.Query, " "))
 	conn, err := ctx.BorrowConn()
 	if err != nil {


### PR DESCRIPTION
This pull request includes changes to the `explain` command in the `api` and `mods/shell/internal/cmd` packages to support the use of the keyword `full` as an argument instead of a flag. The most important changes include modifying the command usage, updating the command handler, and adjusting the tests accordingly.

Changes to command usage:

* [`api/commands.go`](diffhunk://#diff-f73fdf165d121c148f110057af5f70bc610d957b9d111adcc93e90c8a2c331a5L391-R395): Changed the `explain` command usage from `"explain <query>"` to `"explain [full] <query>"` and removed the `--full` flag.

Updates to command handler:

* [`api/commands.go`](diffhunk://#diff-f73fdf165d121c148f110057af5f70bc610d957b9d111adcc93e90c8a2c331a5L684-R683): Modified the `runExplain` function to handle the `full` keyword in the query arguments instead of using a boolean flag. [[1]](diffhunk://#diff-f73fdf165d121c148f110057af5f70bc610d957b9d111adcc93e90c8a2c331a5L684-R683) [[2]](diffhunk://#diff-f73fdf165d121c148f110057af5f70bc610d957b9d111adcc93e90c8a2c331a5L697-R704)

Adjustments to tests:

* [`api/do_test.go`](diffhunk://#diff-63a824ef7ef56a13d45377e0a5da351acd736dd30486b21dd22f224d3dc8298eL561-R561): Updated the test case `explain-full-select-all` to use the `full` keyword in the input query.

Changes to internal command:

* [`mods/shell/internal/cmd/explain.go`](diffhunk://#diff-04f8c60174c8f5d82d1bd2e9a540a40a6bfb1c1ebb431f79db7e2c70bae6dec5L21-R23): Updated the help text to reflect the new usage of the `explain` command and adjusted the `doExplain` function to handle the `full` keyword. [[1]](diffhunk://#diff-04f8c60174c8f5d82d1bd2e9a540a40a6bfb1c1ebb431f79db7e2c70bae6dec5L21-R23) [[2]](diffhunk://#diff-04f8c60174c8f5d82d1bd2e9a540a40a6bfb1c1ebb431f79db7e2c70bae6dec5R52-R56)