### PR TITLE
Improve logging messages for schedule and bridge operations

### DIFF
--- a/mods/bridge/mqtt.go
+++ b/mods/bridge/mqtt.go
@@ -153,6 +153,8 @@ func (c *MqttBridge) BeforeRegister() error {
 	c.clientOpts = cfg
 	if len(c.serverAddresses) > 0 {
 		go c.run()
+	} else {
+		c.log.Warnf("bridge '%s' no broker address", c.name)
 	}
 
 	return nil

--- a/mods/model/model.go
+++ b/mods/model/model.go
@@ -110,12 +110,12 @@ func (s *svr) LoadSchedule(name string) (*ScheduleDefinition, error) {
 	path := filepath.Join(s.schedDir, fmt.Sprintf("%s.json", name))
 	content, err := os.ReadFile(path)
 	if err != nil {
-		s.log.Warn("bridge def file", err.Error())
+		s.log.Warn("schedule load def file", err.Error())
 		return nil, err
 	}
 	def := &ScheduleDefinition{}
 	if err := json.Unmarshal(content, def); err != nil {
-		s.log.Warn("bridge def format", err.Error())
+		s.log.Warn("schedule load def format", err.Error())
 		return nil, err
 	}
 	def.Name = name
@@ -125,7 +125,7 @@ func (s *svr) LoadSchedule(name string) (*ScheduleDefinition, error) {
 func (s *svr) SaveSchedule(def *ScheduleDefinition) error {
 	buf, err := json.MarshalIndent(def, "", "\t")
 	if err != nil {
-		s.log.Warn("bridge def file", err.Error())
+		s.log.Warn("schedule save def file", err.Error())
 		return err
 	}
 	name := strings.ToUpper(def.Name)
@@ -169,12 +169,12 @@ func (s *svr) LoadBridge(name string) (*BridgeDefinition, error) {
 	path := filepath.Join(s.bridgeDir, fmt.Sprintf("%s.json", name))
 	content, err := os.ReadFile(path)
 	if err != nil {
-		s.log.Warn("bridge def file", err.Error())
+		s.log.Warn("bridge load def file", err.Error())
 		return nil, err
 	}
 	def := &BridgeDefinition{}
 	if err := json.Unmarshal(content, def); err != nil {
-		s.log.Warn("bridge def format", err.Error())
+		s.log.Warn("bridge load def format", err.Error())
 		return nil, err
 	}
 	return def, nil
@@ -183,7 +183,7 @@ func (s *svr) LoadBridge(name string) (*BridgeDefinition, error) {
 func (s *svr) SaveBridge(def *BridgeDefinition) error {
 	buf, err := json.MarshalIndent(def, "", "\t")
 	if err != nil {
-		s.log.Warn("bridge def file", err.Error())
+		s.log.Warn("bridge save def file", err.Error())
 		return err
 	}
 
@@ -435,12 +435,12 @@ func (s *svr) iterateScheduleDefs(cb func(*ScheduleDefinition) bool) error {
 		}
 		content, err := os.ReadFile(filepath.Join(s.schedDir, entry.Name()))
 		if err != nil {
-			s.log.Warn("schedule def file", err.Error())
+			s.log.Warn("schedule iterate def file", err.Error())
 			continue
 		}
 		def := &ScheduleDefinition{}
 		if err = json.Unmarshal(content, def); err != nil {
-			s.log.Warn("schedule def format", err.Error())
+			s.log.Warn("schedule iterate def format", err.Error())
 			continue
 		}
 		def.Name = strings.TrimSuffix(entry.Name(), ".json")

--- a/mods/scheduler/sched_subs.go
+++ b/mods/scheduler/sched_subs.go
@@ -35,13 +35,12 @@ type SubscriberEntry struct {
 	s   *svr
 	log logging.Log
 
-	didOnConnectSubscriber bool
-	shouldSubscribe        bool
-	ctx                    context.Context
-	ctxCancel              context.CancelFunc
-	conn                   api.Conn
-	appender               api.Appender
-	subscription           bridge.Subscription
+	shouldSubscribe bool
+	ctx             context.Context
+	ctxCancel       context.CancelFunc
+	conn            api.Conn
+	appender        api.Appender
+	subscription    bridge.Subscription
 
 	wd *util.WriteDescriptor
 }
@@ -69,10 +68,9 @@ func (ent *SubscriberEntry) Start() error {
 	ent.shouldSubscribe = true
 	ent.ctx, ent.ctxCancel = context.WithCancel(context.Background())
 
-	if ent.didOnConnectSubscriber {
-		return nil
-	}
+	ent.log.Infof("starting, bridge=%s, topic=%s", ent.Bridge, ent.Topic)
 	if br0, err := bridge.GetBridge(ent.Bridge); err != nil {
+		ent.log.Tracef("get bridge, %s", err.Error())
 		ent.state = FAILED
 		ent.err = err
 		return err
@@ -101,8 +99,22 @@ func (ent *SubscriberEntry) startMqtt(br *bridge.MqttBridge) error {
 		ent.err = fmt.Errorf("empty topic is not allowed, subscribe to %s", br.String())
 		return ent.err
 	}
-
-	ent.didOnConnectSubscriber = true
+	if br.IsConnected() {
+		ent.log.Tracef("bridge %s is already connected, renew subscription", br.String())
+		if subscription, err := br.Subscribe(ent.Topic, byte(ent.QoS), ent.doMqttTask); err != nil {
+			ent.state = FAILED
+			ent.err = err
+		} else {
+			if subscription == nil {
+				ent.state = FAILED
+				ent.err = fmt.Errorf("fail to subscribe %s %s", br.String(), ent.Topic)
+			} else {
+				ent.subscription = subscription
+				ent.state = RUNNING
+			}
+		}
+		return nil
+	}
 	br.OnConnect(func(bridge any) {
 		if !ent.shouldSubscribe {
 			return
@@ -160,6 +172,8 @@ func (ent *SubscriberEntry) startNats(br *bridge.NatsBridge) error {
 }
 
 func (ent *SubscriberEntry) Stop() error {
+	ent.log.Infof("stopping, bridge=%s, topic=%s", ent.Bridge, ent.Topic)
+
 	ent.state = STOPPING
 	ent.err = nil
 	ent.shouldSubscribe = false


### PR DESCRIPTION
This pull request includes several changes to improve logging messages and remove unnecessary code in the `mods` package. The most important changes are grouped by their themes: logging improvements and code cleanup.

Logging improvements:

* [`mods/bridge/mqtt.go`](diffhunk://#diff-195b5836d8218dcbfbf18d8151de0733f62ef7118b0babad155ba412f6aaade9R156-R157): Added a warning log when no broker address is provided in the `BeforeRegister` method.
* [`mods/model/model.go`](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L113-R118): Updated log messages to be more descriptive in the `LoadSchedule`, `SaveSchedule`, `LoadBridge`, `SaveBridge`, and `iterateScheduleDefs` methods. [[1]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L113-R118) [[2]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L128-R128) [[3]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L172-R177) [[4]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L186-R186) [[5]](diffhunk://#diff-9ddf7c2060457e261a4ff7cfe1e05e2c34aed2ca133b2e8f93066d60cb654d87L438-R443)
* [`mods/scheduler/sched_subs.go`](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bL72-R73): Added log messages for starting and stopping a subscriber entry, and for bridge connection status in the `Start`, `startMqtt`, and `startNats` methods. [[1]](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bL72-R73) [[2]](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bL104-R117) [[3]](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bR175-R176)

Fix re-starting subscriber and code cleanup:

* [`mods/scheduler/sched_subs.go`](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bL38): Removed the unnecessary `didOnConnectSubscriber` field and its associated logic from the `SubscriberEntry` struct and methods. [[1]](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bL38) [[2]](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bL104-R117)