### PR TITLE
ignore EOF during server shutting down

### DIFF
--- a/mods/shell/internal/action/actor.go
+++ b/mods/shell/internal/action/actor.go
@@ -225,6 +225,9 @@ func (act *Actor) ShutdownServer() error {
 	defer cancel()
 	rsp, err := mgmtcli.Shutdown(ctx, &mgmt.ShutdownRequest{})
 	if err != nil {
+		if strings.Contains(err.Error(), "EOF") {
+			return nil
+		}
 		return err
 	}
 	if !rsp.Success {


### PR DESCRIPTION
This pull request includes a change to the `ShutdownServer` function in the `actor.go` file. The change ensures that if an "EOF" error occurs during the shutdown process, it is treated as a successful shutdown.

* [`mods/shell/internal/action/actor.go`](diffhunk://#diff-8d0c8358b1955c9940c5689743895aebbded0bad55f741cfd969520c61a326c7R228-R230): Modified the `ShutdownServer` function to return `nil` if the error message contains "EOF", indicating a successful shutdown despite the error.