### PR TITLE
Tql log mqtt bridge

### DIFF
--- a/mods/scheduler/sched_subs.go
+++ b/mods/scheduler/sched_subs.go
@@ -270,9 +270,7 @@ func (ent *SubscriberEntry) doNatsTask(natsMsg *nats.Msg) {
 			natsMsg.Ack()
 		}
 	}()
-	fmt.Println("-------------------")
 	if ent.wd.IsTqlDestination() {
-		fmt.Println("do tql")
 		ent.doTql(natsMsg.Data, natsMsg.Header, rsp)
 	} else {
 		if ent.wd.Method == "append" {


### PR DESCRIPTION
This pull request includes several changes to improve logging functionality and error handling in the `mods/scheduler/sched_subs.go` and `mods/tql/task.go` files. The most important changes include setting the log level and log writer for tasks, refining error handling in `doTql`, and integrating a new logging package.

Improvements to logging functionality:

* [`mods/scheduler/sched_subs.go`](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bR296-R297): Added `SetLogLevel` and `SetLogWriter` methods to the `task` object to configure logging.
* [`mods/tql/task.go`](diffhunk://#diff-ab9ac0ebdc5791bf4e6643c727147050054d7c4d2ac9cbf3f8e6a52f320e22beR22): Integrated the `logging` package to enhance logging capabilities. Added `LoggingLevel` method to map custom log levels to the `logging` package levels. [[1]](diffhunk://#diff-ab9ac0ebdc5791bf4e6643c727147050054d7c4d2ac9cbf3f8e6a52f320e22beR22) [[2]](diffhunk://#diff-ab9ac0ebdc5791bf4e6643c727147050054d7c4d2ac9cbf3f8e6a52f320e22beR671-R687)

Refinement of error handling:

* [`mods/scheduler/sched_subs.go`](diffhunk://#diff-d0d721333fdc4170308eb803a17edade483e190e5dcbee98d11645148d053e8bL308-R312): Improved error assignment in `doTql` by checking if `result.Err` is not nil before assigning it to `ent.err`.

Enhancements to logging methods:

* [`mods/tql/task.go`](diffhunk://#diff-ab9ac0ebdc5791bf4e6643c727147050054d7c4d2ac9cbf3f8e6a52f320e22beR620-R627): Updated `_log` and `_logf` methods to use the `logging` package's `Log` and `Logf` methods if the log writer supports it. [[1]](diffhunk://#diff-ab9ac0ebdc5791bf4e6643c727147050054d7c4d2ac9cbf3f8e6a52f320e22beR620-R627) [[2]](diffhunk://#diff-ab9ac0ebdc5791bf4e6643c727147050054d7c4d2ac9cbf3f8e6a52f320e22beR639-R645)