### PR TITLE
add histogram with max bin count

### DIFF
--- a/mods/nums/histogram.go
+++ b/mods/nums/histogram.go
@@ -10,6 +10,14 @@ type Bin struct {
 	count float64
 }
 
+func (b Bin) Value() float64 {
+	return b.value
+}
+
+func (b Bin) Count() float64 {
+	return b.count
+}
+
 type Histogram struct {
 	sync.Mutex
 	MaxBins    int
@@ -19,9 +27,9 @@ type Histogram struct {
 
 func (h *Histogram) String() string {
 	return fmt.Sprintf(`{"p50": %f, "p90": %f, "p99": %f}`,
-		h.Quantile(0.5),
-		h.Quantile(0.9),
-		h.Quantile(0.99),
+		h.Quantile(0.5).Value(),
+		h.Quantile(0.9).Value(),
+		h.Quantile(0.99).Value(),
 	)
 }
 
@@ -75,7 +83,15 @@ func (h *Histogram) trim() {
 	}
 }
 
-func (h *Histogram) Bin(q float64) Bin {
+func (h *Histogram) Bins() []Bin {
+	h.Lock()
+	ret := make([]Bin, len(h.bins))
+	copy(ret, h.bins)
+	h.Unlock()
+	return ret
+}
+
+func (h *Histogram) Quantile(q float64) Bin {
 	h.Lock()
 	defer h.Unlock()
 
@@ -87,8 +103,4 @@ func (h *Histogram) Bin(q float64) Bin {
 		}
 	}
 	return Bin{}
-}
-
-func (h *Histogram) Quantile(q float64) float64 {
-	return h.Bin(q).value
 }

--- a/mods/nums/histogram.go
+++ b/mods/nums/histogram.go
@@ -10,10 +10,16 @@ type Bin struct {
 	count float64
 }
 
+// The value of the bin.
+// This is the average of the values that fall into this bin.
+// If you have 10 values that fall into this bin, the value will be the average of those 10 values.
+// So you can calculate the total value of the bin by multiplying the value by the count.
 func (b Bin) Value() float64 {
 	return b.value
 }
 
+// The count of the bin.
+// This is the number of values that fall into this bin.
 func (b Bin) Count() float64 {
 	return b.count
 }
@@ -91,6 +97,16 @@ func (h *Histogram) Bins() []Bin {
 	return ret
 }
 
+// Quantile returns the value of the quantile.
+// The quantile is a value that divides the data into two parts.
+// For example, the median is the 50th percentile.
+// It divides the data into two parts, with half of the data below the median and half above.
+// The 90th percentile divides the data into two parts, with 90% of the data below the 90th percentile and 10% above.
+// The 99th percentile divides the data into two parts, with 99% of the data below the 99th percentile and 1% above.
+// The value of the quantile is the value that divides the data into two parts.
+//
+// ex) h.Quantile(0.5) // 50th percentile
+// ex) h.Quantile(0.9) // 90th percentile
 func (h *Histogram) Quantile(q float64) Bin {
 	h.Lock()
 	defer h.Unlock()

--- a/mods/nums/histogram_test.go
+++ b/mods/nums/histogram_test.go
@@ -36,15 +36,15 @@ func TestHistogramNormalDist(t *testing.T) {
 		hist.Add(rand.Float64() * 10)
 	}
 
-	if v := hist.Quantile(0.5); math.Abs(v-5) > 0.5 {
+	if v := hist.Quantile(0.5); math.Abs(v.Value()-5) > 0.5 {
 		t.Fatalf("expected 5, got %f", v)
 	}
 
-	if v := hist.Quantile(0.9); math.Abs(v-9) > 0.5 {
+	if v := hist.Quantile(0.9); math.Abs(v.Value()-9) > 0.5 {
 		t.Fatalf("expected 9, got %f", v)
 	}
 
-	if v := hist.Quantile(0.99); math.Abs(v-10) > 0.5 {
+	if v := hist.Quantile(0.99); math.Abs(v.Value()-10) > 0.5 {
 		t.Fatalf("expected 10, got %f", v)
 	}
 }

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -1272,34 +1272,6 @@ func mkDirIfNotExistsMode(path string, mode fs.FileMode) error {
 	return nil
 }
 
-//lint:ignore U1000 ignore unused for now
-func makeListener(addr string) (net.Listener, error) {
-	if strings.HasPrefix(addr, "unix://") {
-		pwd, _ := os.Getwd()
-		if strings.HasPrefix(addr, "unix://../") {
-			addr = fmt.Sprintf("unix:///%s", filepath.Join(filepath.Dir(pwd), addr[len("unix://../"):]))
-		} else if strings.HasPrefix(addr, "../") {
-			addr = fmt.Sprintf("unix:///%s", filepath.Join(filepath.Dir(pwd), addr[len("../"):]))
-		} else if strings.HasPrefix(addr, "unix://./") {
-			addr = fmt.Sprintf("unix:///%s", filepath.Join(pwd, addr[len("unix://./"):]))
-		} else if strings.HasPrefix(addr, "./") {
-			addr = fmt.Sprintf("unix:///%s", filepath.Join(pwd, addr[len("./"):]))
-		} else if strings.HasPrefix(addr, "/") {
-			addr = fmt.Sprintf("unix://%s", addr)
-		}
-		path := addr[len("unix://"):]
-		// delete existing .sock file
-		if _, err := os.Stat(path); err == nil {
-			os.Remove(path)
-		}
-		return net.Listen("unix", path)
-	} else if strings.HasPrefix(addr, "tcp://") {
-		return net.Listen("tcp", addr[len("tcp://"):])
-	} else {
-		return nil, fmt.Errorf("unsupported listen scheme %s", addr)
-	}
-}
-
 // ////////////////////////////////
 // implements AuthServer interface
 

--- a/mods/tql/fm_script.go
+++ b/mods/tql/fm_script.go
@@ -459,15 +459,6 @@ func tengoSliceToAnySlice(arr []tengo.Object) []any {
 	return ret
 }
 
-//lint:ignore U1000 keep it for the future uses
-func anySliceToTengoSlice(arr []any) []tengo.Object {
-	ret := make([]tengo.Object, len(arr))
-	for i, o := range arr {
-		ret[i] = anyToTengoObject(o)
-	}
-	return ret
-}
-
 func tengoObjectToAny(obj tengo.Object) any {
 	switch o := obj.(type) {
 	case *tengo.String:

--- a/mods/tql/fm_stat.go
+++ b/mods/tql/fm_stat.go
@@ -158,9 +158,9 @@ type HistogramBuckets struct {
 	buckets       []HistogramBin
 }
 
-func (hcat *HistogramBuckets) Add(fv float64) {
-	n := hcat.bucketIndexer(fv)
-	hcat.buckets[n].count++
+func (histogramBuckets *HistogramBuckets) Add(fv float64) {
+	n := histogramBuckets.bucketIndexer(fv)
+	histogramBuckets.buckets[n].count++
 }
 
 // A histogram bin for a value in range [low, high)
@@ -355,7 +355,7 @@ func (node *Node) fmBoxplot(args ...any) (any, error) {
 				node.task.SetResultColumns(cols)
 
 				for i, result := range box.result {
-					// echart data [lower,  Q1,  median (or Q2),  Q3,  upper]
+					// echarts data [lower,  Q1,  median (or Q2),  Q3,  upper]
 					itm := []any{
 						result.lowerBound,
 						result.q1,

--- a/mods/tql/fm_stat.go
+++ b/mods/tql/fm_stat.go
@@ -236,18 +236,20 @@ type HistogramBin struct {
 	count int64
 }
 
-func (node *Node) fmMaxBins(max int) any {
-	return HistogramMaxBins(max)
-}
-
 type HistogramMaxBins int
 
-func (node *Node) fmBins(min, max, step float64) (any, error) {
-	return &HistogramStepBins{
-		min:  min,
-		max:  max,
-		step: step,
-	}, nil
+func (node *Node) fmBins(args ...float64) (any, error) {
+	if len(args) == 3 {
+		return &HistogramStepBins{
+			min:  args[0],
+			max:  args[1],
+			step: args[2],
+		}, nil
+	} else if len(args) == 1 {
+		return HistogramMaxBins(args[0]), nil
+	} else {
+		return nil, fmt.Errorf("f(%s) invalid number of args; expected 1 or 3, got %d", "bins", len(args))
+	}
 }
 
 type HistogramStepBins struct {

--- a/mods/tql/fm_stat_test.go
+++ b/mods/tql/fm_stat_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestHistogramOrder(t *testing.T) {
-	hist := &Histogram{}
+	hist := &HistogramPredictedBins{}
 
 	hist.buckets = map[StatCategoryName]*HistogramBuckets{}
 	hist.buckets["Cat.A"] = nil

--- a/mods/tql/fx_definitions.go
+++ b/mods/tql/fx_definitions.go
@@ -101,6 +101,7 @@ var FxDefinitions = []Definition{
 	// maps.stat
 	{"// maps.stat", nil},
 	{"HISTOGRAM", defTask.fmHistogram},
+	{"maxBins", defTask.fmMaxBins},
 	{"bins", defTask.fmBins},
 	{"BOXPLOT", defTask.fmBoxplot},
 	{"boxplotInterp", defTask.fmBoxplotInterp},

--- a/mods/tql/fx_definitions.go
+++ b/mods/tql/fx_definitions.go
@@ -101,7 +101,6 @@ var FxDefinitions = []Definition{
 	// maps.stat
 	{"// maps.stat", nil},
 	{"HISTOGRAM", defTask.fmHistogram},
-	{"maxBins", defTask.fmMaxBins},
 	{"bins", defTask.fmBins},
 	{"BOXPLOT", defTask.fmBoxplot},
 	{"boxplotInterp", defTask.fmBoxplotInterp},

--- a/mods/tql/fx_generate.gen.go
+++ b/mods/tql/fx_generate.gen.go
@@ -95,7 +95,6 @@ func NewNode(task *Task) *Node {
 		"ansiTimeformat": x.gen_ansiTimeformat,
 		// maps.stat
 		"HISTOGRAM":     x.gen_HISTOGRAM,
-		"maxBins":       x.gen_maxBins,
 		"bins":          x.gen_bins,
 		"BOXPLOT":       x.gen_BOXPLOT,
 		"boxplotInterp": x.gen_boxplotInterp,
@@ -1188,41 +1187,19 @@ func (x *Node) gen_HISTOGRAM(args ...any) (any, error) {
 	return x.fmHistogram(p0, p1...)
 }
 
-// gen_maxBins
-//
-// syntax: maxBins(int)
-func (x *Node) gen_maxBins(args ...any) (any, error) {
-	if len(args) != 1 {
-		return nil, ErrInvalidNumOfArgs("maxBins", 1, len(args))
-	}
-	p0, err := convInt(args, 0, "maxBins", "int")
-	if err != nil {
-		return nil, err
-	}
-	ret := x.fmMaxBins(p0)
-	return ret, nil
-}
-
 // gen_bins
 //
-// syntax: bins(float64, float64, float64)
+// syntax: bins(...float64)
 func (x *Node) gen_bins(args ...any) (any, error) {
-	if len(args) != 3 {
-		return nil, ErrInvalidNumOfArgs("bins", 3, len(args))
+	p0 := []float64{}
+	for n := 0; n < len(args); n++ {
+		argv, err := convFloat64(args, n, "bins", "...float64")
+		if err != nil {
+			return nil, err
+		}
+		p0 = append(p0, argv)
 	}
-	p0, err := convFloat64(args, 0, "bins", "float64")
-	if err != nil {
-		return nil, err
-	}
-	p1, err := convFloat64(args, 1, "bins", "float64")
-	if err != nil {
-		return nil, err
-	}
-	p2, err := convFloat64(args, 2, "bins", "float64")
-	if err != nil {
-		return nil, err
-	}
-	return x.fmBins(p0, p1, p2)
+	return x.fmBins(p0...)
 }
 
 // gen_BOXPLOT

--- a/mods/tql/fx_generate.gen.go
+++ b/mods/tql/fx_generate.gen.go
@@ -95,6 +95,7 @@ func NewNode(task *Task) *Node {
 		"ansiTimeformat": x.gen_ansiTimeformat,
 		// maps.stat
 		"HISTOGRAM":     x.gen_HISTOGRAM,
+		"maxBins":       x.gen_maxBins,
 		"bins":          x.gen_bins,
 		"BOXPLOT":       x.gen_BOXPLOT,
 		"boxplotInterp": x.gen_boxplotInterp,
@@ -1185,6 +1186,21 @@ func (x *Node) gen_HISTOGRAM(args ...any) (any, error) {
 		p1 = append(p1, argv)
 	}
 	return x.fmHistogram(p0, p1...)
+}
+
+// gen_maxBins
+//
+// syntax: maxBins(int)
+func (x *Node) gen_maxBins(args ...any) (any, error) {
+	if len(args) != 1 {
+		return nil, ErrInvalidNumOfArgs("maxBins", 1, len(args))
+	}
+	p0, err := convInt(args, 0, "maxBins", "int")
+	if err != nil {
+		return nil, err
+	}
+	ret := x.fmMaxBins(p0)
+	return ret, nil
 }
 
 // gen_bins

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -294,7 +294,7 @@ func TestHistogramUnpredictedBins(t *testing.T) {
 	codeLines := []string{
 		`FAKE( arrange(1, 100, 1) )`,
 		`MAPVALUE(0, (simplex(12, value(0)) + 1) * 100)`,
-		`HISTOGRAM(value(0), maxBins(10))`,
+		`HISTOGRAM(value(0), bins(10))`,
 		`CSV( header(true), precision(0) )`,
 	}
 	resultLines := []string{

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -290,6 +290,30 @@ func TestHistogram(t *testing.T) {
 	runTest(t, codeLines, resultLines)
 }
 
+func TestHistogramUnpredictedBins(t *testing.T) {
+	codeLines := []string{
+		`FAKE( arrange(1, 100, 1) )`,
+		`MAPVALUE(0, (simplex(12, value(0)) + 1) * 100)`,
+		`HISTOGRAM(value(0), maxBins(10))`,
+		`CSV( header(true), precision(0) )`,
+	}
+	resultLines := []string{
+		"value,count",
+		"23,1",
+		"44,6",
+		"59,12",
+		"80,26",
+		"99,20",
+		"113,18",
+		"129,5",
+		"141,2",
+		"153,7",
+		"170,3",
+		"",
+	}
+	runTest(t, codeLines, resultLines)
+}
+
 func TestBoxplot(t *testing.T) {
 	var codeLines, resultLines []string
 	src := `


### PR DESCRIPTION
This pull request introduces significant changes to the histogram functionality in the `mods/tql/fm_stat.go` file, including the addition of new methods and restructuring of existing code. The changes also include some code cleanup and the removal of unused functions in other files.

Histogram functionality improvements:

* Added `Value` and `Count` methods to the `Bin` struct in `mods/nums/histogram.go` to provide access to the bin's value and count.
* Modified the `Histogram` struct and related methods to use the new `Value` method for quantiles. [[1]](diffhunk://#diff-265785d22c6c64621cdd5c61d7d4e387309130634668526650aad5a7f8917694L22-R38) [[2]](diffhunk://#diff-265785d22c6c64621cdd5c61d7d4e387309130634668526650aad5a7f8917694L78-R110)
* Introduced new `HistogramUnpredictedBins` and `HistogramPredictedBins` types to handle different histogram configurations and added corresponding methods for managing bins and categories. [[1]](diffhunk://#diff-f0eaf9db183adff43c849a46ca057698eec12854780495939af24380b8d7880bL59-L79) [[2]](diffhunk://#diff-f0eaf9db183adff43c849a46ca057698eec12854780495939af24380b8d7880bL88-R200) [[3]](diffhunk://#diff-f0eaf9db183adff43c849a46ca057698eec12854780495939af24380b8d7880bL161-R229)

Code cleanup and removal of unused functions:

* Removed the unused `makeListener` function from `mods/server/server.go`.
* Removed the unused `anySliceToTengoSlice` function from `mods/tql/fm_script.go`.

Test updates:

* Updated tests in `mods/tql/fm_stat_test.go` and `mods/tql/task_test.go` to reflect the changes in histogram functionality. [[1]](diffhunk://#diff-c59f7ea6a67491f68a3a6320d01b3f1c8602071a0be8dba20401c1d3afd98b28L10-R10) [[2]](diffhunk://#diff-076220c4234b516f5e4b521a78b0d30f58ddb9cb42a72af199e1cb44707414fbR293-R316)