### PR TITLE
feat: add system functions for garbage collection

### DIFF
--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -1555,6 +1555,28 @@ func TestScript(t *testing.T) {
 				require.Equal(t, `[[1,2.3,"3.4",true]]`, gjson.Get(result, "data.rows").Raw)
 			},
 		},
+		{
+			Name: "js-system-free-os-memory",
+			Script: `
+				SCRIPT("js", {
+					$.system().free_os_memory();
+					$.yield("ok");
+				})
+				CSV()
+			`,
+			ExpectCSV: []string{"ok", "\n"},
+		},
+		{
+			Name: "js-system-gc",
+			Script: `
+				SCRIPT("js", {
+					$.system().gc();
+					$.yield("ok");
+				})
+				CSV()
+			`,
+			ExpectCSV: []string{"ok", "\n"},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This pull request includes several changes to the `mods/tql/fm_script.go` file, focusing on enhancing system-related functionalities. The most important changes include adding new import statements, introducing a new `system` function, and implementing memory management functions within the `system` function.

### Enhancements to system functionalities:

* Added new import statements for `runtime` and `runtime/debug` to support system-related operations.
* Introduced a new `system` function in the `newOttoContext` function, allowing access to system-level operations.
* Implemented the `ottoFuncSystem` function, which includes:
  * `free_os_memory` function to free operating system memory using `debug.FreeOSMemory()`.
  * `gc` function to trigger garbage collection using `runtime.GC()`.

```js
SCRIPT("js", {
    $.system().free_os_memory();
    // $.system().gc();
})
DISCARD()
```