### PR TITLE
Http append worker and tql pragma

### DIFF
--- a/mods/server/http_query.go
+++ b/mods/server/http_query.go
@@ -687,6 +687,7 @@ const TqlHeaderChartType = "X-Chart-Type"
 const TqlHeaderChartOutput = "X-Chart-Output"
 const TqlHeaderTqlOutput = "X-Tql-Output"
 const TqlHeaderConsoleId = "X-Console-Id"
+const TqlHeaderAppendWorker = "X-Append-Worker"
 
 type ConsoleInfo struct {
 	consoleId       string

--- a/mods/server/http_test.go
+++ b/mods/server/http_test.go
@@ -698,6 +698,7 @@ func TestHttpWrite(t *testing.T) {
 			req, _ := http.NewRequest(http.MethodPost, httpServerAddress+"/db/write/test_w"+tc.queryParams, payload)
 			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", at))
 			req.Header.Set("Content-Type", tc.payloadType)
+			req.Header.Set(TqlHeaderAppendWorker, "false")
 			if compressed {
 				req.Header.Set("Content-Encoding", "gzip")
 			}

--- a/mods/server/http_write.go
+++ b/mods/server/http_write.go
@@ -123,7 +123,8 @@ func (svr *httpd) handleWrite(ctx *gin.Context) {
 		if svr.useAppendWroker {
 			svr.appendersLock.Lock()
 			defer svr.appendersLock.Unlock()
-			if aw, exists := svr.appenders.Get(tableName); exists {
+			if aw, exists := svr.appenders[tableName]; exists {
+				aw.lastTime = time.Now()
 				appender = aw.appender
 				desc = aw.tableDesc
 			}
@@ -149,9 +150,10 @@ func (svr *httpd) handleWrite(ctx *gin.Context) {
 					conn:      appendConn,
 					appender:  appender,
 					tableDesc: desc,
+					lastTime:  time.Now(),
 				}
 				aw.ctx, aw.ctxCancel = context.WithCancel(context.Background())
-				svr.appenders.Set(tableName, aw)
+				svr.appenders[tableName] = aw
 			}
 		} else {
 			if tableDesc, err := api.DescribeTable(ctx, conn, tableName, false); err != nil {

--- a/mods/server/mqtt_write.go
+++ b/mods/server/mqtt_write.go
@@ -311,6 +311,9 @@ type AppenderWrapper struct {
 	appender  api.Appender
 	ctx       context.Context
 	ctxCancel context.CancelFunc
+
+	// currently use by only http write?method=append
+	tableDesc *api.TableDescription
 }
 
 func (s *mqttd) handleAppend(cl *mqtt.Client, pk packets.Packet) {

--- a/mods/server/mqtt_write.go
+++ b/mods/server/mqtt_write.go
@@ -314,6 +314,7 @@ type AppenderWrapper struct {
 
 	// currently use by only http write?method=append
 	tableDesc *api.TableDescription
+	lastTime  time.Time
 }
 
 func (s *mqttd) handleAppend(cl *mqtt.Client, pk packets.Packet) {

--- a/mods/tql/task_node.go
+++ b/mods/tql/task_node.go
@@ -92,13 +92,13 @@ func (node *Node) SetEOF(f func(*Node)) {
 	node.eofCallback = f
 }
 
-func (node *Node) Pragma(name string) string {
+func (node *Node) Pragma(name string) (string, bool) {
 	if node.pragma != nil {
 		if v, ok := node.pragma[name]; ok {
-			return v
+			return v, true
 		}
 	}
-	return ""
+	return "", false
 }
 
 func (node *Node) PragmaBool(name string) bool {

--- a/mods/tql/tql_pragma_test.go
+++ b/mods/tql/tql_pragma_test.go
@@ -1,0 +1,64 @@
+package tql
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPragma2(t *testing.T) {
+	tests := []struct {
+		Name       string
+		Script     string
+		ExpectFunc func(t *testing.T, task *Task)
+	}{
+		{
+			Name: "pragma-log-level-bang",
+			Script: `
+				#pragma log-level=warn
+				FAKE( linspace(1, 5, 5))
+				JSON()`,
+			ExpectFunc: func(t *testing.T, task *Task) {
+				require.Equal(t, ParseLogLevel("warn"), task.logLevel)
+			},
+		},
+		{
+			Name: "pragma-log-level",
+			Script: `
+				//+ log-level=trace sql-thread-lock
+				SQL( 'select count(*) from example' )
+				JSON()`,
+			ExpectFunc: func(t *testing.T, task *Task) {
+				require.Equal(t, ParseLogLevel("trace"), task.logLevel)
+				require.Equal(t, true, task.nodes[0].PragmaBool(PRAGMA_SQL_THREAD_LOCK))
+			},
+		},
+		{
+			Name: "pragma-sql-thread-lock-bang",
+			Script: `
+				#pragma sql-thread-lock=0
+				SQL( 'select count(*) from example' )
+				JSON()`,
+			ExpectFunc: func(t *testing.T, task *Task) {
+				require.Equal(t, ParseLogLevel("error"), task.logLevel)
+				require.Equal(t, false, task.nodes[0].PragmaBool(PRAGMA_SQL_THREAD_LOCK))
+			},
+		},
+	}
+	ctx := context.Background()
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			task := NewTaskContext(ctx)
+			task.SetLogWriter(os.Stdout)
+			if err := task.CompileString(tc.Script); err != nil {
+				t.Log("ERROR:", tc.Name, err.Error())
+				t.Fail()
+				return
+			}
+			tc.ExpectFunc(t, task)
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple files in the project. The most significant changes include the addition of an append worker mechanism in the HTTP server, modifications to the `handleWrite` function to utilize this new mechanism, and updates to the TQL package to handle pragma settings more robustly.

### Enhancements to HTTP server:

* [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR92-R97): Added new fields to the `httpd` struct to support append worker functionality, including `appenders`, `appendersLock`, `appendersFlusher`, `appendersFlusherWg`, and `useAppendWroker`. (`[mods/server/http.goR92-R97](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR92-R97)`)
* [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR189-R219): Updated the `Start` function to initialize and manage the append worker if enabled. (`[mods/server/http.goR189-R219](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR189-R219)`)
* [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR236-R245): Updated the `Stop` function to gracefully shut down the append worker and close all appenders. (`[mods/server/http.goR236-R245](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR236-R245)`)

### Modifications to handleWrite function:

* [`mods/server/http_write.go`](diffhunk://#diff-1052c4d89cd222dc9d84c2f24c064bade1be414b9a81006e30e44d57b8241dcfL85-L100): Enhanced the `handleWrite` function to use the append worker for the "append" method, including handling the new `X-Append-Worker` HTTP header. (`[[1]](diffhunk://#diff-1052c4d89cd222dc9d84c2f24c064bade1be414b9a81006e30e44d57b8241dcfL85-L100)`, `[[2]](diffhunk://#diff-1052c4d89cd222dc9d84c2f24c064bade1be414b9a81006e30e44d57b8241dcfR110-R165)`, `[[3]](diffhunk://#diff-1052c4d89cd222dc9d84c2f24c064bade1be414b9a81006e30e44d57b8241dcfR179-R185)`)

### Updates to TQL package:

* [`mods/tql/fm_dbsrc.go`](diffhunk://#diff-ca904daacbca593f92b0f26bdf32204ba2cdc1a0ab71b59216df7c7c7f733b6fL400-R410): Improved the handling of the `PRAGMA_SQL_THREAD_LOCK` pragma to support probabilistic locking based on a float value. (`[mods/tql/fm_dbsrc.goL400-R410](diffhunk://#diff-ca904daacbca593f92b0f26bdf32204ba2cdc1a0ab71b59216df7c7c7f733b6fL400-R410)`)
* [`mods/tql/task_node.go`](diffhunk://#diff-2b8b9c4c0f0e45876a7a2521af5a1bec2973387a5e2297a467dac3c07fc1713fL95-R101): Modified the `Pragma` function to return a boolean indicating if the pragma was found. (`[mods/tql/task_node.goL95-R101](diffhunk://#diff-2b8b9c4c0f0e45876a7a2521af5a1bec2973387a5e2297a467dac3c07fc1713fL95-R101)`)
* [`mods/tql/tql_pragma_test.go`](diffhunk://#diff-1e764295f643203c460ef6c2ba8a4b162cba41736fcf2f541df6ff3c4666ede1R1-R64): Added new tests to verify the behavior of pragma settings, including `log-level` and `sql-thread-lock`. (`[mods/tql/tql_pragma_test.goR1-R64](diffhunk://#diff-1e764295f643203c460ef6c2ba8a4b162cba41736fcf2f541df6ff3c4666ede1R1-R64)`)