### PR TITLE
geomap opt includes initial position

### DIFF
--- a/mods/codec/internal/geomap/geomap.go
+++ b/mods/codec/internal/geomap/geomap.go
@@ -246,9 +246,11 @@ func (gm *GeoMap) Close() {
 	gm.appendJSCode(`}`)
 
 	if gm.Bound != nil && !gm.Bound.IsEmpty() && !gm.Bound.IsPoint() {
-		gm.appendJSCode(fmt.Sprintf("map.fitBounds(%s);", gm.Bound.String()))
+		gm.appendJSCode(fmt.Sprintf("opt.initBounds = %s;", gm.Bound.String()))
+		gm.appendJSCode("map.fitBounds(opt.initBounds);")
 	} else {
-		gm.appendJSCode(fmt.Sprintf("map.setView(%s,%d);", gm.InitialLatLon.String(), gm.InitialZoomLevel))
+		gm.appendJSCode(fmt.Sprintf("opt.initPoint = {center:%s, zoomLevel:%d};", gm.InitialLatLon.String(), gm.InitialZoomLevel))
+		gm.appendJSCode("map.setView(opt.initPoint.center, opt.initPoint.zoomLevel);")
 	}
 
 	for _, icn := range gm.icons {

--- a/mods/codec/internal/geomap/test/geomap_polygon.html
+++ b/mods/codec/internal/geomap/test/geomap_polygon.html
@@ -58,7 +58,8 @@ if (opt && opt.map) {
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
   opt.map = map;
 }
-map.setView([51.505,-0.09],13);
+opt.initPoint = {center:[51.505,-0.09], zoomLevel:13};
+map.setView(opt.initPoint.center, opt.initPoint.zoomLevel);
 var obj0 = L.polygon([[[[37,-109.05],[41,-109.03],[41,-102.05],[37,-102.04]],[[37.29,-108.58],[40.71,-108.58],[40.71,-102.5],[37.29,-102.5]]],[[[41,-111.03],[45,-111.04],[45,-104.05],[41,-104.05]]]],{}).addTo(map);
 })(WejMYXCGcYNL);
 </script>

--- a/mods/codec/internal/geomap/test/geomap_test.html
+++ b/mods/codec/internal/geomap/test/geomap_test.html
@@ -68,7 +68,8 @@ if (opt && opt.map) {
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
   opt.map = map;
 }
-map.fitBounds([[37.49785,127.018666],[37.503058,127.027756]]);
+opt.initBounds = [[37.49785,127.018666],[37.503058,127.027756]];
+map.fitBounds(opt.initBounds);
 var obj0 = L.marker([37.49785,127.027756],{}).addTo(map);
 var popup0 = obj0.bindPopup("<b>Gangname</b><br/>Hello World?", {}).openPopup();
 var obj1 = L.circleMarker([37.503058,127.018666],{radius:100}).addTo(map);

--- a/mods/codec/internal/geomap/test/geomap_test.js
+++ b/mods/codec/internal/geomap/test/geomap_test.js
@@ -47,7 +47,8 @@ if (opt && opt.map) {
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
   opt.map = map;
 }
-map.fitBounds([[37.49785,127.018666],[37.503058,127.027756]]);
+opt.initBounds = [[37.49785,127.018666],[37.503058,127.027756]];
+map.fitBounds(opt.initBounds);
 var obj0 = L.marker([37.49785,127.027756],{}).addTo(map);
 var popup0 = obj0.bindPopup("<b>Gangname</b><br/>Hello World?", {}).openPopup();
 var obj1 = L.circleMarker([37.503058,127.018666],{radius:100}).addTo(map);

--- a/mods/codec/internal/geomap/test/geomap_test_geojson.html
+++ b/mods/codec/internal/geomap/test/geomap_test_geojson.html
@@ -68,7 +68,8 @@ if (opt && opt.map) {
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
   opt.map = map;
 }
-map.fitBounds([[0,100],[20.1,135.7]]);
+opt.initBounds = [[0,100],[20.1,135.7]];
+map.fitBounds(opt.initBounds);
 var obj0 = L.geoJSON({features:[{geometry:{coordinates:[102,0.5],type:"Point"},properties:{prop0:"value0"},type:"Feature"},{geometry:{coordinates:[[102,0],[103,1],[104,0],[105,1]],type:"LineString"},properties:{prop0:"value0",prop1:0},type:"Feature"},{geometry:{coordinates:[[[100,0],[101,0],[101,1],[100,1],[100,0]]],type:"Polygon"},properties:{prop0:"value0",prop1:{this:"that"}},type:"Feature"}],popup:{content:"<b>GeoJSON</b>",open:0},type:"FeatureCollection"},opt.geojson).addTo(map);
 var obj1 = L.geoJSON({geometry:{coordinates:[125.6,10.1],type:"Point"},properties:{name:"Dinagat Islands",popup:{content:"<b>Dinagat Islands</b>",open:true}},type:"Feature"},opt.geojson).addTo(map);
 var popup1 = obj1.bindPopup("<b>Dinagat Islands</b>", {}).openPopup();

--- a/mods/codec/internal/geomap/test/geomap_test_geojson.js
+++ b/mods/codec/internal/geomap/test/geomap_test_geojson.js
@@ -47,7 +47,8 @@ if (opt && opt.map) {
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
   opt.map = map;
 }
-map.fitBounds([[0,100],[20.1,135.7]]);
+opt.initBounds = [[0,100],[20.1,135.7]];
+map.fitBounds(opt.initBounds);
 var obj0 = L.geoJSON({features:[{geometry:{coordinates:[102,0.5],type:"Point"},properties:{prop0:"value0"},type:"Feature"},{geometry:{coordinates:[[102,0],[103,1],[104,0],[105,1]],type:"LineString"},properties:{prop0:"value0",prop1:0},type:"Feature"},{geometry:{coordinates:[[[100,0],[101,0],[101,1],[100,1],[100,0]]],type:"Polygon"},properties:{prop0:"value0",prop1:{this:"that"}},type:"Feature"}],popup:{content:"<b>GeoJSON</b>",open:0},type:"FeatureCollection"},opt.geojson).addTo(map);
 var obj1 = L.geoJSON({geometry:{coordinates:[125.6,10.1],type:"Point"},properties:{name:"Dinagat Islands",popup:{content:"<b>Dinagat Islands</b>",open:true}},type:"Feature"},opt.geojson).addTo(map);
 var popup1 = obj1.bindPopup("<b>Dinagat Islands</b>", {}).openPopup();

--- a/mods/tql/test/js-geojson-point.js
+++ b/mods/tql/test/js-geojson-point.js
@@ -47,6 +47,7 @@ if (opt && opt.map) {
   L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png").addTo(map);
   opt.map = map;
 }
-map.setView([37.49785,127.027756],13);
+opt.initPoint = {center:[37.49785,127.027756], zoomLevel:13};
+map.setView(opt.initPoint.center, opt.initPoint.zoomLevel);
 var obj0 = L.geoJSON({geometry:{coordinates:[127.027756,37.49785],type:"Point"},type:"Feature"},opt.geojson).addTo(map);
 })(MTY3NzQ2MDY4NzQyNTc4MTc2);


### PR DESCRIPTION
This pull request focuses on refactoring the way initial map bounds and view settings are applied in the `GeoMap` module and its related test files. The changes involve using an `opt` object to store initialization parameters for better organization and maintainability.

Key changes include:

### Refactoring map initialization:

* [`mods/codec/internal/geomap/geomap.go`](diffhunk://#diff-3d20d0ac626742fb8d7fe2fe32ef49dd9ed2d7fee50cadceeca411e3f3c8edfdL249-R253): Modified the `Close` method to use `opt.initBounds` and `opt.initPoint` for setting map bounds and view.

### Updates in test files:

* [`mods/codec/internal/geomap/test/geomap_polygon.html`](diffhunk://#diff-1006ca46257e00d0b117b9cb07800fa40e16c76876b5f5e2818e7e697ec3bfd8L61-R62): Updated to use `opt.initPoint` for setting the initial map view.
* [`mods/codec/internal/geomap/test/geomap_test.html`](diffhunk://#diff-02b39438b9cc4f1d47d1b39c8037d25e1d7b0f20beedff75d60101c6693ea8eaL71-R72): Changed to use `opt.initBounds` for fitting map bounds.
* [`mods/codec/internal/geomap/test/geomap_test_geojson.html`](diffhunk://#diff-db455c6a661cd883c52987305a445401a6a4bee67ea26035fa24f6627273ad02L71-R72): Refactored to use `opt.initBounds` for fitting map bounds.
* [`mods/tql/test/js-geojson-point.js`](diffhunk://#diff-21c301670b67c9a052a44a0b359decc79a53e192aca474c0aa47507c3c389e2eL50-R51): Updated to use `opt.initPoint` for setting the initial map view.