### PR TITLE
enhance test cases for script execution

### DIFF
--- a/mods/tql/fm_script_es6.go
+++ b/mods/tql/fm_script_es6.go
@@ -448,8 +448,8 @@ func (ctx *GojaContext) gojaFuncRequest(reqUrl string, reqOpt map[string]any) go
 				case "json":
 					dec := json.NewDecoder(httpResponse.Body)
 					for {
-						data := new(any)
-						err := dec.Decode(data)
+						data := map[string]any{}
+						err := dec.Decode(&data)
 						if err == io.EOF {
 							break
 						} else if err != nil {


### PR DESCRIPTION
This pull request includes changes to improve the handling of JSON decoding in `gojaFuncRequest` and adds several new test cases to `fm_script_test.go`.

Improvements to JSON decoding:

* [`mods/tql/fm_script_es6.go`](diffhunk://#diff-2c6dcaed15cb3030a95ce4d854d944d428512edd7f157f4d984cd745d4eedfbcL451-R452): Updated JSON decoding to use a map instead of a generic `any` type for better type safety.

Additions to test cases:

* [`mods/tql/fm_script_test.go`](diffhunk://#diff-e50f22fe2e561cd02986241050ce0c049ccf8e43fcac585c4c8da1d347a9e327R239-R308): Added a new test case `js-payload-csv` to validate the processing of CSV payloads.
* [`mods/tql/fm_script_test.go`](diffhunk://#diff-e50f22fe2e561cd02986241050ce0c049ccf8e43fcac585c4c8da1d347a9e327R239-R308): Added a new test case `js-compile-err` to check for JavaScript compilation errors.
* [`mods/tql/fm_script_test.go`](diffhunk://#diff-e50f22fe2e561cd02986241050ce0c049ccf8e43fcac585c4c8da1d347a9e327R239-R308): Added a new test case `js-params` to test the handling of script parameters.
* [`mods/tql/fm_script_test.go`](diffhunk://#diff-e50f22fe2e561cd02986241050ce0c049ccf8e43fcac585c4c8da1d347a9e327R239-R308): Added a new test case `js-request` to test HTTP requests within scripts.
* [`mods/tql/fm_script_test.go`](diffhunk://#diff-e50f22fe2e561cd02986241050ce0c049ccf8e43fcac585c4c8da1d347a9e327R239-R308): Added a new test case `js-request-json` to validate JSON responses from HTTP requests.