### PR TITLE
fix returning error on rows.Next()

### DIFF
--- a/api/do_query.go
+++ b/api/do_query.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"io"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -156,7 +157,12 @@ func (qc *Query) Execute(ctx context.Context, conn Conn, sqlText string, args ..
 			break
 		}
 	}
-
+	if qc.err == nil && qc.rows != nil {
+		if rowsErr := qc.rows.Err(); rowsErr != io.EOF {
+			// to return error caused by rows.Next()
+			qc.err = rowsErr
+		}
+	}
 	return qc.err
 }
 

--- a/api/machrpc/machrpc.go
+++ b/api/machrpc/machrpc.go
@@ -393,6 +393,10 @@ func (rows *Rows) Columns() (api.Columns, error) {
 	}
 }
 
+func (rows *Rows) Err() error {
+	return rows.err
+}
+
 // Next returns true if there are at least one more record that can be fetchable
 // rows, _ := client.Query("select name, value from my_table")
 //

--- a/api/machsvr/mach_grpc.go
+++ b/api/machsvr/mach_grpc.go
@@ -387,6 +387,11 @@ func (s *RPCServer) RowsFetch(ctx context.Context, rows *machrpc.RowsHandle) (*m
 	}
 
 	if !rowsWrap.Rows.Next() {
+		if err := rowsWrap.Rows.Err(); err != nil {
+			rsp.Reason = err.Error()
+			rsp.HasNoRows = true
+			return rsp, nil
+		}
 		rsp.Success = true
 		rsp.Reason = "success"
 		rsp.HasNoRows = true

--- a/api/machsvr/mach_rows.go
+++ b/api/machsvr/mach_rows.go
@@ -419,7 +419,7 @@ func (rows *Rows) NextSync() bool {
 	return next
 }
 
-func (rows *Rows) FetchError() error {
+func (rows *Rows) Err() error {
 	return rows.fetchError
 }
 

--- a/api/sql_wrap.go
+++ b/api/sql_wrap.go
@@ -223,6 +223,10 @@ func (r *WrappedSqlRows) Message() string {
 	return "success"
 }
 
+func (r *WrappedSqlRows) Err() error {
+	return r.sqlRows.Err()
+}
+
 func scanTypeToDataType(sqlType string) DataType {
 	switch sqlType {
 	case "bool", "sql.NullBool":

--- a/api/types.go
+++ b/api/types.go
@@ -113,6 +113,9 @@ type Rows interface {
 	//	defer rows.Close()
 	Close() error
 
+	// Err returns the error, if any, that was encountered during the execution of the query.
+	Err() error
+
 	// IsFetchable returns true if the statement that produced this Rows is fetchable (e.g., a SELECT statement).
 	IsFetchable() bool
 

--- a/mods/bridge/internal/base.go
+++ b/mods/bridge/internal/base.go
@@ -170,6 +170,10 @@ func (r *Rows) Columns() (api.Columns, error) {
 	return ret, err
 }
 
+func (r *Rows) Err() error {
+	return r.sqlRows.Err()
+}
+
 func (r *Rows) IsFetchable() bool {
 	return true
 }


### PR DESCRIPTION
This pull request introduces a new `Err()` method to the `Rows` interface and its implementations, enhancing error handling for row-fetching operations. Additionally, it includes updates to test cases and query execution logic to leverage the new method for more robust error reporting.

### Enhancements to error handling:
* Added an `Err()` method to the `Rows` interface in `api/types.go`, allowing retrieval of errors encountered during query execution.
* Implemented the `Err()` method in various `Rows` implementations, including `api/machrpc/machrpc.go`, `api/machsvr/mach_rows.go`, `api/sql_wrap.go`, and `mods/bridge/internal/base.go`. [[1]](diffhunk://#diff-2347df3cc5031cc5e372b85a7828eae9389a443a89c910907af3a94d02d9d37bR396-R399) [[2]](diffhunk://#diff-718ecaf4d6dc7752cede9ddd02526a164bf72b1257718736c66855f1292a9c35L422-R422) [[3]](diffhunk://#diff-ff58cb8cc96b90c94c66d9d377ebee824ae58dc361308bfc4ac39ca7bec75192R226-R229) [[4]](diffhunk://#diff-ff02bc799808e1cae0cbd555012f059a155384fd8bcc975d2620d3080b5ecd26R173-R176)

### Query execution improvements:
* Updated `api/do_query.go` to check for errors using the new `Err()` method after row iteration, ensuring errors from `rows.Next()` are properly handled.

### Test case updates:
* Enhanced tests in `api/testsuite/tables.go` to validate error handling for mismatched data types in `BITAND` queries, utilizing the new `Err()` method for assertions.