### PR TITLE
HTTP TQL SRC

### DIFF
--- a/mods/codec/internal/box/box_encode.go
+++ b/mods/codec/internal/box/box_encode.go
@@ -42,7 +42,7 @@ func NewEncoder() *Exporter {
 }
 
 func (ex *Exporter) ContentType() string {
-	return "plain/text"
+	return "text/plain"
 }
 
 func (ex *Exporter) SetOutputStream(o io.Writer) {

--- a/mods/codec/internal/box/box_encode_test.go
+++ b/mods/codec/internal/box/box_encode_test.go
@@ -17,7 +17,7 @@ import (
 func TestBox1(t *testing.T) {
 	enc := box.NewEncoder()
 
-	require.Equal(t, "plain/text", enc.ContentType())
+	require.Equal(t, "text/plain", enc.ContentType())
 
 	w := &bytes.Buffer{}
 	enc.SetOutputStream(w)
@@ -120,7 +120,7 @@ func TestNano(t *testing.T) {
 func TestBoxFloat(t *testing.T) {
 	enc := box.NewEncoder()
 
-	require.Equal(t, "plain/text", enc.ContentType())
+	require.Equal(t, "text/plain", enc.ContentType())
 
 	w := &bytes.Buffer{}
 	enc.SetOutputStream(w)
@@ -157,7 +157,7 @@ func TestBoxFloat(t *testing.T) {
 func TestBoxFloat2(t *testing.T) {
 	enc := box.NewEncoder()
 
-	require.Equal(t, "plain/text", enc.ContentType())
+	require.Equal(t, "text/plain", enc.ContentType())
 
 	w := &bytes.Buffer{}
 	enc.SetOutputStream(w)
@@ -204,7 +204,7 @@ func TestBoxFloat2(t *testing.T) {
 func runTimeformat(t *testing.T, format string) string {
 	enc := box.NewEncoder()
 
-	require.Equal(t, "plain/text", enc.ContentType())
+	require.Equal(t, "text/plain", enc.ContentType())
 
 	w := &bytes.Buffer{}
 	enc.SetOutputStream(w)
@@ -272,7 +272,7 @@ func TestBoxWide(t *testing.T) {
 	}
 	enc := box.NewEncoder()
 
-	require.Equal(t, "plain/text", enc.ContentType())
+	require.Equal(t, "text/plain", enc.ContentType())
 
 	w := &bytes.Buffer{}
 	enc.SetOutputStream(w)

--- a/mods/server/http.go
+++ b/mods/server/http.go
@@ -307,6 +307,7 @@ func (svr *httpd) Router() *gin.Engine {
 			group.Any("/api/query", svr.handleQuery)
 			group.GET("/api/check", svr.handleCheck)
 			group.POST("/api/splitter/sql", svr.handleSplitSQL)
+			group.POST("/api/splitter/http", svr.handleSplitHTTP)
 			group.POST("/api/relogin", svr.handleReLogin)
 			group.POST("/api/logout", svr.handleLogout)
 			group.GET("/api/shell/:id", svr.handleGetShell)

--- a/mods/server/http_query.go
+++ b/mods/server/http_query.go
@@ -308,6 +308,32 @@ func (svr *httpd) handleSplitSQL(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, rsp)
 }
 
+type SplitHTTPResponse struct {
+	Success bool   `json:"success"`
+	Reason  string `json:"reason"`
+	Elapse  string `json:"elapse"`
+	Data    any    `json:"data,omitempty"`
+}
+
+func (svr *httpd) handleSplitHTTP(ctx *gin.Context) {
+	rsp := &SplitHTTPResponse{Success: false, Reason: "not specified"}
+	tick := time.Now()
+	stmts, err := util.SplitHttpStatements(ctx.Request.Body)
+	if err != nil {
+		rsp.Reason = err.Error()
+		rsp.Elapse = time.Since(tick).String()
+		ctx.JSON(http.StatusInternalServerError, rsp)
+		return
+	}
+	rsp.Success = true
+	rsp.Reason = "success"
+	rsp.Data = map[string]any{
+		"statements": stmts,
+	}
+	rsp.Elapse = time.Since(tick).String()
+	ctx.JSON(http.StatusOK, rsp)
+}
+
 func (svr *httpd) handleFileQuery(ctx *gin.Context) {
 	rsp := &QueryResponse{Success: false, Reason: "not specified"}
 	tick := time.Now()

--- a/mods/util/restclient/restclient.go
+++ b/mods/util/restclient/restclient.go
@@ -79,13 +79,13 @@ func (rc *RestClient) Do() *RestResult {
 }
 
 type RestResult struct {
-	StatusLine      string   `json:"statusLine"`
-	Header          []Header `json:"header"`
-	Body            *Body    `json:"body,omitempty"`
-	ContentType     string   `json:"contentType,omitempty"`
-	ContentEncoding string   `json:"contentEncoding,omitempty"`
-	Err             error    `json:"error,omitempty"`
-	dumpString      string   `json:"-"`
+	StatusLine      string `json:"statusLine"`
+	Header          Header `json:"header"`
+	Body            *Body  `json:"body,omitempty"`
+	ContentType     string `json:"contentType,omitempty"`
+	ContentEncoding string `json:"contentEncoding,omitempty"`
+	Err             error  `json:"error,omitempty"`
+	dumpString      string `json:"-"`
 }
 
 func (rr *RestResult) String() string {
@@ -170,7 +170,7 @@ func (rr *RestResult) loadHeader(r *http.Response) error {
 	// each header line
 	for _, k := range keys {
 		for _, v := range r.Header.Values(k) {
-			rr.Header = append(rr.Header, Header{Name: k, Value: v})
+			rr.Header = append(rr.Header, NameValue{Name: k, Value: v})
 		}
 	}
 	return nil
@@ -196,13 +196,26 @@ func (rr *RestResult) loadBody(r *http.Response) error {
 	return nil
 }
 
-type Header struct {
+type NameValue struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
-func (h *Header) String() string {
+func (h *NameValue) String() string {
 	return fmt.Sprintf("%s: %s", h.Name, h.Value)
+}
+
+type Header []NameValue
+
+func (h Header) String() string {
+	var sb strings.Builder
+	for i, header := range h {
+		if i > 0 {
+			sb.WriteString("\r\n")
+		}
+		sb.WriteString(header.String())
+	}
+	return sb.String()
 }
 
 type Body struct {

--- a/mods/util/restclient/restclient.go
+++ b/mods/util/restclient/restclient.go
@@ -229,6 +229,19 @@ var printableContentTypes = []string{
 	"text/*",
 	"application/json",
 	"application/javascript",
+	"application/x-ndjson",
+	"application/xml",
+	"application/xhtml+xml",
+	"application/x-www-form-urlencoded",
+	"application/atom+xml",
+	"application/rss+xml",
+	"application/geo+json",
+	"application/hal+json",
+	"application/hal+xml",
+	"application/ld+json",
+	"application/vnd.api+json",
+	"application/vnd.collection+json",
+	"application/vnd.geo+json",
 }
 
 func isPrintableContentType(contentType string) bool {

--- a/mods/util/restclient/restclient_test.go
+++ b/mods/util/restclient/restclient_test.go
@@ -59,7 +59,7 @@ func TestClient(t *testing.T) {
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
 				require.NoError(t, rr.Err)
-				body := rr.json()
+				body := rr.Body.String()
 				require.JSONEq(t,
 					`{"q": "SELECT * FROM users where name = 'John'", "format": "json"}`,
 					body, body)
@@ -75,8 +75,8 @@ func TestClient(t *testing.T) {
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
 				require.NoError(t, rr.Err)
-				require.Contains(t, rr.Dump, "X-Debug: 12345")
-				body := rr.json()
+				require.Contains(t, rr.String(), "X-Debug: 12345")
+				body := rr.Body.String()
 				require.JSONEq(t,
 					`{"q": "SELECT * FROM users where name = 'John'", "format": "json"}`,
 					body, body)
@@ -143,6 +143,7 @@ func TestMain(m *testing.M) {
 				o["q"] = r.URL.Query().Get("q")
 				o["format"] = r.URL.Query().Get("format")
 			}
+			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(o)
 		})
 		http.Serve(lsnr, nil)

--- a/mods/util/split_test.go
+++ b/mods/util/split_test.go
@@ -246,3 +246,29 @@ func ExampleParseNameValuePairs() {
 	// name4=
 	// log-level=info
 }
+
+func ExampleSplitHttpStatements() {
+	input := `
+POST /api/echo HTTP/1.1
+Content-Type: application/json
+
+{"key": "value"}
+`
+	statements, err := util.SplitHttpStatements(strings.NewReader(input))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	for n, stmt := range statements {
+		fmt.Println(n, stmt.BeginLine, stmt.EndLine)
+		fmt.Println(stmt.Text)
+	}
+	// Output:
+	//
+	// 0 1 5
+	//
+	// POST /api/echo HTTP/1.1
+	// Content-Type: application/json
+	//
+	// {"key": "value"}
+}


### PR DESCRIPTION
This pull request introduces several changes across multiple files to improve functionality and enhance HTTP request handling. The primary updates include fixing a content type string, adding support for parsing and splitting HTTP statements, and refactoring the `RestClient` to better handle headers and body content.

### Fixes and Enhancements to Content Type Handling:
* [`mods/codec/internal/box/box_encode.go`](diffhunk://#diff-2561269d0cd6f19a681846863fb72a0cdbf3c2ca955445222503b0bd8cd0e803L45-R45): Corrected the `ContentType` method to return `"text/plain"` instead of `"plain/text"`.
* [`mods/codec/internal/box/box_encode_test.go`](diffhunk://#diff-224f4658285a4aa0ad0959db9f76126f399d2120644459c7cf3f93c95c65c521L20-R20): Updated tests to reflect the corrected content type string. [[1]](diffhunk://#diff-224f4658285a4aa0ad0959db9f76126f399d2120644459c7cf3f93c95c65c521L20-R20) [[2]](diffhunk://#diff-224f4658285a4aa0ad0959db9f76126f399d2120644459c7cf3f93c95c65c521L123-R123) [[3]](diffhunk://#diff-224f4658285a4aa0ad0959db9f76126f399d2120644459c7cf3f93c95c65c521L160-R160) [[4]](diffhunk://#diff-224f4658285a4aa0ad0959db9f76126f399d2120644459c7cf3f93c95c65c521L207-R207) [[5]](diffhunk://#diff-224f4658285a4aa0ad0959db9f76126f399d2120644459c7cf3f93c95c65c521L275-R275)

### HTTP Statement Parsing and Handling:
* [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR310): Added a new route `/api/splitter/http` to handle HTTP statement splitting.
* [`mods/server/http_query.go`](diffhunk://#diff-7dbcb2816ab1b320be3db5cde03ad796cf3583ce6eb8375f49310162305408c0R311-R336): Implemented the `handleSplitHTTP` function to process HTTP statements and return structured responses.
* [`mods/server/http_test.go`](diffhunk://#diff-b19e214509fd4578d9238c3d67e3007e1ab38a34faf8032652c23887f06f54cbR1568-R1623): Added unit tests for the `handleSplitHTTP` functionality, including scenarios for single and multiple HTTP statements.
* [`mods/util/split.go`](diffhunk://#diff-58c6b36a4f0ba122c7daca6354b4368991db73215eaa112216d58451794b0963R356-R407): Introduced the `SplitHttpStatements` function to parse HTTP statements separated by `###`.
* [`mods/util/split_test.go`](diffhunk://#diff-b0be78dbc7f64b10d0bcbfb89df44b29efdfbca650022824b887137e98a593f4R249-R274): Added an example for `SplitHttpStatements` to demonstrate its usage.

### Refactoring and Enhancements to `RestClient`:
* [`mods/util/restclient/restclient.go`](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03R4-R5): Refactored the `RestResult` structure to use custom `Header` and `Body` types, added support for handling gzip-encoded responses, and improved content-type detection and body formatting. [[1]](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03R4-R5) [[2]](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03L81-R144) [[3]](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03L148-R311)
* [`mods/util/restclient/restclient_test.go`](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bL62-R62): Updated tests to validate the new `Body` structure and header handling in `RestResult`. [[1]](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bL62-R62) [[2]](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bL78-R79) [[3]](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bR146)