### PR TITLE
http-client as MAP and markdown

### DIFF
--- a/mods/tql/task.go
+++ b/mods/tql/task.go
@@ -341,11 +341,11 @@ var srcOnlyFunctions = map[string]bool{
 	"BYTES()":      true,
 	"STRING()":     true,
 	"ARGS()":       true,
-	"HTTP()":       true,
 }
 
 var srcOrMapFunctions = map[string]bool{
 	"SCRIPT()": true,
+	"HTTP()":   true,
 }
 
 var srcOrSinkFunctions = map[string]bool{


### PR DESCRIPTION
This pull request introduces functionality to handle HTTP code blocks in Markdown files and updates the classification of the `HTTP()` function in `mods/tql/task.go`. The most important changes include the addition of a new helper function, `replaceHttpClient`, the integration of `restclient` for processing HTTP blocks, and the reclassification of `HTTP()` as a source-or-map function.

### Markdown HTTP processing enhancements:
* [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR1127-R1167): Added the `replaceHttpClient` function to process HTTP code blocks in Markdown files. This function uses the `restclient` package to parse and execute HTTP requests, replacing the block content with the response in HTML format.
* [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR1115): Integrated the `replaceHttpClient` function into the `handleMarkdown` method to automatically process HTTP code blocks during Markdown handling.
* [`mods/server/http.go`](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR45): Imported the `restclient` package to support HTTP request parsing and execution.

### TQL function classification update:
* [`mods/tql/task.go`](diffhunk://#diff-ab9ac0ebdc5791bf4e6643c727147050054d7c4d2ac9cbf3f8e6a52f320e22beL344-R348): Reclassified the `HTTP()` function from a source-only function to a source-or-map function, reflecting its updated behavior and usage scope.