### PR TITLE
Improve file input

### DIFF
--- a/mods/tql/fm_encoder.go
+++ b/mods/tql/fm_encoder.go
@@ -1,16 +1,13 @@
 package tql
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"slices"
 	"time"
 
 	"github.com/machbase/neo-server/v8/mods/codec/opts"
 	"github.com/machbase/neo-server/v8/mods/util/restclient"
-	"github.com/machbase/neo-server/v8/mods/util/ssfs"
 )
 
 func newEncoder(format string, args ...any) (*Encoder, error) {
@@ -170,16 +167,6 @@ func (node *Node) fmHttp(args ...any) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("HTTP parse error: %w", err)
 	}
-	rcli.SetFileLoader(func(path string) (io.ReadCloser, error) {
-		def := ssfs.Default()
-		ent, err := def.Get(path)
-		if err != nil {
-			return nil, err
-		}
-
-		return io.NopCloser(bytes.NewBuffer(ent.Content)), nil
-
-	})
 	result := rcli.Do()
 	NewRecord(0, result).Tell(node.next)
 	return nil, nil

--- a/mods/tql/tqlcache.go
+++ b/mods/tql/tqlcache.go
@@ -29,7 +29,7 @@ var (
 type CacheOption struct {
 	MaxCapacity uint64 // max number of items
 	// TODO: ttlcache.WithMaxCost has a bug that introduces deadlock
-	// MaxCost     uint64 // max cost (memory consumptio in Bytes) of items
+	// MaxCost     uint64 // max cost (memory consumption in Bytes) of items
 }
 
 func StartCache(cap CacheOption) {

--- a/mods/util/restclient/parser_test.go
+++ b/mods/util/restclient/parser_test.go
@@ -16,6 +16,15 @@ func TestParser(t *testing.T) {
 		expectedContent []string
 	}{
 		{
+			name:            "basic_get_simple",
+			content:         `GET /api/data`,
+			expectedMethod:  "GET",
+			expectedPath:    "/api/data",
+			expectedVersion: "",
+			expectedHeaders: http.Header{},
+			expectedContent: []string{},
+		},
+		{
 			name: "basic_get",
 			content: `
 				GET /api/data HTTP/1.1

--- a/mods/util/restclient/restclient_test.go
+++ b/mods/util/restclient/restclient_test.go
@@ -105,6 +105,22 @@ func TestClient(t *testing.T) {
 			},
 		},
 		{
+			name: "do_post_by_file",
+			content: `
+				POST http://{{ .HostPort }}/api/echo
+				Content-Type: application/json
+
+				< 1.json
+			`,
+			expectedFunc: func(t *testing.T, rr *RestResult) {
+				require.NoError(t, rr.Err)
+				body := rr.Body.String()
+				require.JSONEq(t,
+					`{"name": "John", "image": "figure.png", "doc": "doc.xml"}`,
+					body, body)
+			},
+		},
+		{
 			name: "do_post_multipart",
 			content: `
 				POST http://{{ .HostPort }}/api/upload

--- a/mods/util/restclient/test/1.json
+++ b/mods/util/restclient/test/1.json
@@ -1,0 +1,5 @@
+{
+    "name": "John",
+    "image": "figure.png",
+    "doc": "doc.xml"
+}


### PR DESCRIPTION
This pull request refactors the `RestClient` implementation and improves file handling logic, while also updating related tests and dependencies. The changes streamline the code by removing redundant methods, introducing a unified file loader mechanism, and enhancing test coverage for file-based operations.

### Refactoring and File Handling Improvements:

* [`mods/util/restclient/restclient.go`](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03L40-L48): Removed the `SetFileLoader` method and the `fileLoader` field from the `RestClient` struct. Introduced a new `paseFileLine` method to handle file parsing and loading logic, supporting both OS-based and server-side file systems (`SSFS_FileLoader`). [[1]](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03L40-L48) [[2]](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03R142-R189)
* [`mods/util/restclient/restclient.go`](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03L90-R122): Replaced inline file loader logic in `Do()` with calls to `paseFileLine`, improving readability and modularity.

### Dependency Updates:

* [`mods/util/restclient/restclient.go`](diffhunk://#diff-b123a26d479dafb5d0dd37a6645bbd7e459c95a7e259645108ec7d42b9768d03R17-R18): Added the `ssfs` package import to enable server-side file system operations.

### Test Enhancements:

* [`mods/util/restclient/restclient_test.go`](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bR108-R123): Added new test cases to validate file-based POST requests (`do_post_by_file`) and multipart form submissions using server-side file paths. [[1]](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bR108-R123) [[2]](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bL121-R143)
* [`mods/util/restclient/test/1.json`](diffhunk://#diff-000b54223b69a3e3151bdf8a8ebe7591b3fd0b9948c0395f934aecdbcf801f22R1-R5): Introduced a sample JSON file for testing file-based POST requests.
* [`mods/util/restclient/restclient_test.go`](diffhunk://#diff-04ca204ca8b7525b5f92334384d21bde9938af0d0f7c9e9e3d00e1e3882e2d6bR187-R188): Configured a server-side file system (`ssfs`) in `TestMain` to support file-based tests.

### Minor Fixes:

* [`mods/tql/tqlcache.go`](diffhunk://#diff-bbd5dc679782832979f461e4ced2b2404e3d6ffb81d2acfce65f00123d8bae1dL32-R32): Corrected a typo in a comment (`consumptio` → `consumption`).