### PR TITLE
fix leak http client connections

### DIFF
--- a/mods/util/restclient/restclient.go
+++ b/mods/util/restclient/restclient.go
@@ -14,23 +14,29 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/machbase/neo-server/v8/mods/util/ssfs"
 )
+
+var DefaultTransport *http.Transport
+
+func init() {
+	DefaultTransport = http.DefaultTransport.(*http.Transport).Clone()
+	DefaultTransport.Proxy = http.ProxyFromEnvironment
+	DefaultTransport.DisableCompression = true
+	DefaultTransport.MaxIdleConns = 1
+	DefaultTransport.MaxConnsPerHost = 1
+	DefaultTransport.IdleConnTimeout = 5 * time.Second
+}
 
 func Parse(content string) (*RestClient, error) {
 	ret, err := parse(content)
 	if err != nil {
 		return nil, fmt.Errorf("restClient parse error: %w", err)
 	}
-
-	ret.Transport = &http.Transport{
-		Proxy:              http.ProxyFromEnvironment,
-		DisableCompression: true,
-	}
-	ret.Transport.CloseIdleConnections()
-
-	return ret, err
+	ret.Transport = DefaultTransport.Clone()
+	return ret, nil
 }
 
 type RestClient struct {

--- a/mods/util/restclient/restclient_test.go
+++ b/mods/util/restclient/restclient_test.go
@@ -30,7 +30,7 @@ func TestClient(t *testing.T) {
 				User-Agent: TestClient
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
+				require.NoError(t, rr.err)
 				data := rr.String()
 				require.Contains(t, data, "HTTP/1.1 200 OK")
 				require.Contains(t, data, "text/plain; charset=utf-8")
@@ -47,7 +47,7 @@ func TestClient(t *testing.T) {
 				User-Agent: TestClient
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
+				require.NoError(t, rr.err)
 				data := rr.String()
 				require.Contains(t, data, "HTTP/1.1 200 OK")
 				require.Contains(t, data, "text/plain; charset=utf-8")
@@ -63,8 +63,8 @@ func TestClient(t *testing.T) {
 					&format=json
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
-				body := rr.Body.String()
+				require.NoError(t, rr.err)
+				body := rr.body.String()
 				require.JSONEq(t,
 					`{"q": "SELECT * FROM users where name = 'John'", "format": "json"}`,
 					body, body)
@@ -79,9 +79,9 @@ func TestClient(t *testing.T) {
 				{"q": "SELECT * FROM users where name = 'John'", "format": "json"}
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
+				require.NoError(t, rr.err)
 				require.Contains(t, rr.String(), "X-Debug: 12345")
-				body := rr.Body.String()
+				body := rr.body.String()
 				require.JSONEq(t,
 					`{"q": "SELECT * FROM users where name = 'John'", "format": "json"}`,
 					body, body)
@@ -97,9 +97,9 @@ func TestClient(t *testing.T) {
 				&format=json
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
+				require.NoError(t, rr.err)
 				require.Contains(t, rr.String(), "X-Debug: 12345")
-				body := rr.Body.String()
+				body := rr.body.String()
 				require.JSONEq(t,
 					`{"q": "SELECT * FROM users where name = 'John'", "format": "json"}`,
 					body, body)
@@ -114,9 +114,9 @@ func TestClient(t *testing.T) {
 				{"q": "SELECT * FROM users where name = 'John'", "format": "json"}
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
-				body := rr.Body.String()
-				require.Equal(t, "HTTP/1.1 204 No Content", rr.StatusLine)
+				require.NoError(t, rr.err)
+				body := rr.body.String()
+				require.Equal(t, "HTTP/1.1 204 No Content", rr.statusLine)
 				require.Equal(t, ``, body, body)
 			},
 		},
@@ -129,8 +129,8 @@ func TestClient(t *testing.T) {
 				< @./test/1.json
 			`,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
-				body := rr.Body.String()
+				require.NoError(t, rr.err)
+				body := rr.body.String()
 				require.JSONEq(t,
 					`{"name": "John", "image": "figure.png", "doc": "doc.xml"}`,
 					body, body)
@@ -159,8 +159,8 @@ Content-Type: text/xml
 ------WebKitFormBoundary7MA4YWxkTrZu0gW--
 `,
 			expectedFunc: func(t *testing.T, rr *RestResult) {
-				require.NoError(t, rr.Err)
-				body := rr.Body.String()
+				require.NoError(t, rr.err)
+				body := rr.body.String()
 				require.JSONEq(t,
 					`{"name": "John", "image": "1.png", "doc": "1.xml"}`,
 					body, body)


### PR DESCRIPTION
This pull request introduces improvements to the HTTP transport configuration in the `mods/util/restclient/restclient.go` file. The main change is the introduction of a shared, pre-configured `DefaultTransport` for use by the `RestClient`, which helps standardize and optimize HTTP connection handling.

**HTTP Transport Configuration:**

* Introduced a package-level `DefaultTransport` variable, initialized in an `init()` function with custom settings such as disabling compression, limiting idle connections, and setting a short idle timeout. This ensures consistent and controlled HTTP behavior across all `RestClient` instances.
* Updated the `Parse` function to assign a clone of `DefaultTransport` to each new `RestClient`, replacing the previous ad-hoc transport creation and immediate idle connection closure. This change promotes reuse of transport settings and better connection management.