### PR TITLE
set/get metrics output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
-	github.com/OutOfBedlam/metric v0.0.0-20250825052035-c1bd8b1a2f74
+	github.com/OutOfBedlam/metric v0.0.0-20250827024906-c71e3eb33a75
 	github.com/alecthomas/chroma/v2 v2.18.0
 	github.com/alecthomas/kong v0.8.0
 	github.com/atotto/clipboard v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYr
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
-github.com/OutOfBedlam/metric v0.0.0-20250825052035-c1bd8b1a2f74 h1:SRYfdWHc5VEkTcq1tx8YUgYl6vV3UyVhF/6lMyC4rZw=
-github.com/OutOfBedlam/metric v0.0.0-20250825052035-c1bd8b1a2f74/go.mod h1:utCPVqpc0xv/lZOrNP1CPpl+Fot5DjWdWsBSx3iYCfo=
+github.com/OutOfBedlam/metric v0.0.0-20250827024906-c71e3eb33a75 h1:VUI5msfo7klNBRfFawXqDBAhtXAG+wMnWjW19Uinrnw=
+github.com/OutOfBedlam/metric v0.0.0-20250827024906-c71e3eb33a75/go.mod h1:utCPVqpc0xv/lZOrNP1CPpl+Fot5DjWdWsBSx3iYCfo=
 github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXxPxCFk=
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbavY5Wv4=

--- a/mods/server/svrmetric.go
+++ b/mods/server/svrmetric.go
@@ -18,13 +18,15 @@ import (
 var statzLog = logging.GetLog("server-statz")
 
 func startServerMetrics(s *Server) {
-	api.StartMetrics(s.Config.StatzOut)
+	api.StartMetrics()
 	api.AddMetricsFunc(collectSysStatz)
 	api.AddMetricsFunc(collectMachSvrStatz)
 	api.AddMetricsFunc(collectMqttStatz(s))
 	api.AddMetricsFunc(collectPsStatz)
 
 	util.AddShutdownHook(func() { stopServerMetrics() })
+
+	api.SetMetricsDestTable(s.Config.StatzOut)
 }
 
 func stopServerMetrics() {

--- a/mods/server/svrmetric.go
+++ b/mods/server/svrmetric.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/OutOfBedlam/metric"
 	mach "github.com/machbase/neo-engine/v8"
@@ -10,6 +11,8 @@ import (
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/util"
 	"github.com/machbase/neo-server/v8/mods/util/jemalloc"
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/mem"
 )
 
 var statzLog = logging.GetLog("server-statz")
@@ -19,12 +22,40 @@ func startServerMetrics(s *Server) {
 	api.AddMetricsFunc(collectSysStatz)
 	api.AddMetricsFunc(collectMachSvrStatz)
 	api.AddMetricsFunc(collectMqttStatz(s))
+	api.AddMetricsFunc(collectPsStatz)
 
 	util.AddShutdownHook(func() { stopServerMetrics() })
 }
 
 func stopServerMetrics() {
 	api.StopMetrics()
+}
+
+func collectPsStatz() (metric.Measurement, error) {
+	m := metric.Measurement{Name: "ps"}
+
+	cpuPercent, err := cpu.Percent(0, false)
+	if err != nil {
+		return m, fmt.Errorf("failed to collect CPU percent: %w", err)
+	}
+	m.Fields = append(m.Fields, metric.Field{
+		Name:  "cpu_percent",
+		Value: cpuPercent[0],
+		Unit:  metric.UnitPercent,
+		Type:  metric.FieldTypeMeter,
+	})
+
+	memStat, err := mem.VirtualMemory()
+	if err != nil {
+		return m, fmt.Errorf("failed to collect memory percent: %w", err)
+	}
+	m.Fields = append(m.Fields, metric.Field{
+		Name:  "mem_percent",
+		Value: memStat.UsedPercent,
+		Unit:  metric.UnitPercent,
+		Type:  metric.FieldTypeMeter,
+	})
+	return m, nil
 }
 
 func collectSysStatz() (metric.Measurement, error) {

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 	api.SetDefault(db)
 	api.StartAppendWorkers()
 
-	api.StartMetrics("")
+	api.StartMetrics()
 
 	f, _ := ssfs.NewServerSideFileSystem([]string{"/=test"})
 	ssfs.SetDefault(f)


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the server's metrics collection and configuration system. The key changes include making the metrics destination table dynamically configurable at runtime, refactoring the metrics collection startup process, and adding new system-level metrics for CPU and memory usage. Additionally, an HTTP API endpoint was added to allow querying and updating the metrics destination table configuration.

**Metrics configuration and runtime control:**

* Added `MetricsDestTable()` and `SetMetricsDestTable()` functions to allow getting and setting the metrics destination table at runtime, including automatic creation of the table if it does not exist. (`api/metrics.go`)
* Introduced a new HTTP endpoint `/api/statz/config` (supporting GET and POST) to retrieve and update the metrics destination table from the API, with appropriate validation and error handling. (`mods/server/http.go`) [[1]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR348) [[2]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR894-R940)

**Metrics collection refactoring:**

* Refactored `StartMetrics()` to remove the destination table parameter and use the new runtime configuration instead. The metrics collector is now started without a destination, and the destination is set separately. (`api/metrics.go`, `mods/server/svrmetric.go`, `mods/tql/tql_test.go`) [[1]](diffhunk://#diff-ffb09227a043a8b68ade16603539951b8e216f71125de14b6919ab63fee86bc5R305-R310) [[2]](diffhunk://#diff-d525fde897d7e0cab825fd599cb4533404f3410097040abb6b120f6450cfdafbR6-R62) [[3]](diffhunk://#diff-a506b05e7ab53f45329a482649de0f6366bcb0aa88017ba2ff72496da349a6b0L39-R39)
* Changed the metrics product handling logic to use `Samples` instead of `Count` for consistency and accuracy across all metric types. (`api/metrics.go`) [[1]](diffhunk://#diff-ffb09227a043a8b68ade16603539951b8e216f71125de14b6919ab63fee86bc5L133-R133) [[2]](diffhunk://#diff-ffb09227a043a8b68ade16603539951b8e216f71125de14b6919ab63fee86bc5L371-R409) [[3]](diffhunk://#diff-ffb09227a043a8b68ade16603539951b8e216f71125de14b6919ab63fee86bc5L405-R418) [[4]](diffhunk://#diff-ffb09227a043a8b68ade16603539951b8e216f71125de14b6919ab63fee86bc5L414-R427) [[5]](diffhunk://#diff-ffb09227a043a8b68ade16603539951b8e216f71125de14b6919ab63fee86bc5L431-R454)

**System metrics enhancements:**

* Added a new metrics function to collect system CPU and memory usage statistics using `gopsutil`, and included it in the server's metrics collection. (`mods/server/svrmetric.go`)

**Dependency updates:**

* Updated the `github.com/OutOfBedlam/metric` dependency to a newer version. (`go.mod`)