### PR TITLE
upgrade neo-engine

### DIFF
--- a/api/do_tables.go
+++ b/api/do_tables.go
@@ -391,7 +391,9 @@ func ListRollupGapWalk(ctx context.Context, conn Conn, callback func(*RollupGapI
 		V$STORAGE_TAG_TABLES B,
 		V$ROLLUP C
 	WHERE
-		A.ID=B.ID
+		A.DATABASE_ID=C.DATABASE_ID
+	AND A.DATABASE_ID=-1
+	AND	A.ID=B.ID
 	AND A.NAME=C.SOURCE_TABLE
 	ORDER BY SRC_TABLE`)
 

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.8
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/lib/pq v1.10.9
-	github.com/machbase/neo-engine/v8 v8.0.46
+	github.com/machbase/neo-engine/v8 v8.0.47
 	github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b
 	github.com/magefile/mage v1.15.0
 	github.com/mark3labs/mcp-go v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
-github.com/machbase/neo-engine/v8 v8.0.46 h1:JSBIAbrn4aImTaOwUDeg3zc9ibWMmfIeuCmn33Ae6u8=
-github.com/machbase/neo-engine/v8 v8.0.46/go.mod h1:Z2Ey5LqiXunFTTBsPBeeuoeQEJ/Rky92flsHyo6MkfA=
+github.com/machbase/neo-engine/v8 v8.0.47 h1:Ny5ATarer97ZHFMg4o1IwSzC3AckFGiMkQlFzE4qJD0=
+github.com/machbase/neo-engine/v8 v8.0.47/go.mod h1:Z2Ey5LqiXunFTTBsPBeeuoeQEJ/Rky92flsHyo6MkfA=
 github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b h1:yVScvJT9bIGaJmajia+/xz5tkOpRQ5utmpXstV2C37k=
 github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b/go.mod h1:69acURVmR+iJA1WFXOrwJntcRxLoTp9i1s/F/qhePjQ=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=


### PR DESCRIPTION
This pull request includes a minor dependency update and a small change to the SQL query logic in the `ListRollupGapWalk` function. The update ensures compatibility with the latest version of the `neo-engine` library, and the query change refines the join conditions for retrieving rollup gap data.

Dependency update:

* Updated the `github.com/machbase/neo-engine/v8` dependency from version `v8.0.46` to `v8.0.47` in `go.mod`.

SQL query logic refinement:

* Modified the join conditions in the SQL query within the `ListRollupGapWalk` function in `api/do_tables.go` to join on `A.DATABASE_ID=C.DATABASE_ID`, filter by `A.DATABASE_ID=-1`, and maintain the existing join on `A.ID=B.ID`.