### PR TITLE
implement tail functionality with cross-platform support and add test…

### DIFF
--- a/mods/util/tail/tail.go
+++ b/mods/util/tail/tail.go
@@ -1,0 +1,324 @@
+package tail
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"time"
+)
+
+// Tail provides functionality to tail a file
+// it works similar to 'tail -F' command in unix,
+// which follows the file even if it is rotated
+type Tail struct {
+	filepath     string
+	c            chan string
+	stopChan     chan struct{}
+	pollInterval time.Duration
+	bufferSize   int
+	patterns     []Pattern
+	file         *os.File
+	lastSize     int64
+	lastInode    uint64
+	lastPos      int64
+}
+
+type Pattern []*regexp.Regexp
+
+func (p Pattern) Match(s string) bool {
+	matched := true
+	for _, re := range p {
+		if !re.MatchString(s) {
+			matched = false
+			break
+		}
+	}
+	return matched
+}
+
+// Option is a functional option for Tail
+type Option func(*Tail)
+
+// WithPollInterval sets the polling interval for checking file changes
+func WithPollInterval(d time.Duration) Option {
+	return func(t *Tail) {
+		t.pollInterval = d
+	}
+}
+
+func WithBufferSize(size int) Option {
+	return func(t *Tail) {
+		t.bufferSize = size
+	}
+}
+
+func WithPattern(patterns ...string) Option {
+	return func(t *Tail) {
+		var group Pattern
+		for _, pattern := range patterns {
+			re, err := regexp.Compile(pattern)
+			if err == nil {
+				group = append(group, re)
+			}
+		}
+		t.patterns = append(t.patterns, group)
+	}
+}
+
+// NewTail creates Tail instance
+func NewTail(filepath string, opts ...Option) *Tail {
+	t := &Tail{
+		filepath:     filepath,
+		bufferSize:   100,
+		stopChan:     make(chan struct{}),
+		pollInterval: 1 * time.Second,
+	}
+
+	for _, opt := range opts {
+		opt(t)
+	}
+
+	t.c = make(chan string, t.bufferSize)
+	return t
+}
+
+// Lines returns output channel
+// caller can read lines from this channel
+func (tail *Tail) Lines() <-chan string {
+	return tail.c
+}
+
+// Start begins tailing the file
+func (tail *Tail) Start() error {
+	// Open the file initially
+	if err := tail.openFile(); err != nil {
+		return err
+	}
+
+	// Seek to the end of the file to start tailing
+	pos, err := tail.file.Seek(0, io.SeekEnd)
+	if err != nil {
+		tail.file.Close()
+		return fmt.Errorf("failed to seek to end: %w", err)
+	}
+	tail.lastPos = pos
+
+	go tail.run()
+
+	return nil
+}
+
+// Stop stops tailing the file
+func (tail *Tail) Stop() error {
+	close(tail.stopChan)
+	close(tail.c)
+
+	if tail.file != nil {
+		return tail.file.Close()
+	}
+
+	return nil
+}
+
+// openFile opens the file for tailing
+func (tail *Tail) openFile() error {
+	file, err := os.Open(tail.filepath)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	tail.file = file
+	tail.lastSize = stat.Size()
+	tail.lastInode = getInode(stat)
+	tail.lastPos = 0
+
+	return nil
+}
+
+// run is the main loop that tails the file
+func (tail *Tail) run() {
+	ticker := time.NewTicker(tail.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-tail.stopChan:
+			return
+		case <-ticker.C:
+			if err := tail.checkAndRead(); err != nil {
+				// If there's an error, try to reopen the file (might be rotated)
+				if tail.file != nil {
+					tail.file.Close()
+				}
+
+				// Wait a bit and try to open again
+				time.Sleep(tail.pollInterval)
+				if err := tail.reopenIfNeeded(); err != nil {
+					// Still can't open, continue waiting
+					continue
+				}
+			}
+		}
+	}
+}
+
+// checkAndRead checks for file changes and reads new lines
+func (tail *Tail) checkAndRead() error {
+	// Check if file still exists and hasn't been rotated
+	stat, err := os.Stat(tail.filepath)
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	currentInode := getInode(stat)
+	currentSize := stat.Size()
+
+	// Check if file was rotated (inode changed)
+	if currentInode != tail.lastInode {
+		// File was rotated - read remaining content from old file then switch to new file
+		if _, err := tail.file.Seek(tail.lastPos, io.SeekStart); err == nil {
+			tail.readLines()
+		}
+
+		// Reopen the new file
+		if tail.file != nil {
+			tail.file.Close()
+		}
+
+		if err := tail.openFile(); err != nil {
+			return err
+		}
+
+		// Start from beginning of new file
+		tail.lastPos = 0
+		if _, err := tail.file.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("failed to seek to start: %w", err)
+		}
+
+		tail.readLines()
+		return nil
+	}
+
+	// Check if file was truncated
+	// This happens if: size decreased, OR our position is beyond current size
+	if currentSize < tail.lastSize || tail.lastPos > currentSize {
+		// File was truncated, seek to beginning
+		tail.lastPos = 0
+		tail.lastSize = 0
+		if _, err := tail.file.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("failed to seek to start: %w", err)
+		}
+
+		// Read all content from the beginning
+		if currentSize > 0 {
+			tail.readLines()
+		}
+		tail.lastSize = currentSize
+		return nil
+	}
+
+	// Check if file has new content
+	if currentSize > tail.lastSize {
+		// Seek to our last known position
+		if _, err := tail.file.Seek(tail.lastPos, io.SeekStart); err != nil {
+			return fmt.Errorf("failed to seek: %w", err)
+		}
+
+		tail.readLines()
+		tail.lastSize = currentSize
+	}
+
+	return nil
+}
+
+// readLines reads new lines from the file
+func (tail *Tail) readLines() {
+	buf := make([]byte, 4096)
+	var lineBuf []byte
+
+	for {
+		n, err := tail.file.Read(buf)
+		if n > 0 {
+			// Process the data we read
+			data := buf[:n]
+			for len(data) > 0 {
+				// Find newline
+				nlIdx := -1
+				for i, b := range data {
+					if b == '\n' {
+						nlIdx = i
+						break
+					}
+				}
+
+				if nlIdx >= 0 {
+					// Found a complete line
+					lineBuf = append(lineBuf, data[:nlIdx]...)
+
+					// Convert to string and trim \r if present
+					line := string(lineBuf)
+					if len(line) > 0 && line[len(line)-1] == '\r' {
+						line = line[:len(line)-1]
+					}
+
+					matched := false
+					if len(tail.patterns) > 0 {
+						for _, p := range tail.patterns {
+							if p.Match(line) {
+								matched = true
+								break
+							}
+						}
+					} else {
+						matched = true
+					}
+
+					if matched {
+						// Send the line
+						select {
+						case tail.c <- line:
+						case <-tail.stopChan:
+							return
+						}
+					}
+
+					// Move to next data
+					data = data[nlIdx+1:]
+					lineBuf = lineBuf[:0]
+					tail.lastPos += int64(nlIdx + 1)
+				} else {
+					// No newline found, save to buffer
+					lineBuf = append(lineBuf, data...)
+					tail.lastPos += int64(len(data))
+					break
+				}
+			}
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				// End of file, save position and return
+				return
+			}
+			// Other error, return
+			return
+		}
+
+		if n == 0 {
+			break
+		}
+	}
+}
+
+// reopenIfNeeded tries to reopen the file if it was rotated
+func (tail *Tail) reopenIfNeeded() error {
+	// Try to open the file
+	return tail.openFile()
+}

--- a/mods/util/tail/tail_test.go
+++ b/mods/util/tail/tail_test.go
@@ -1,0 +1,287 @@
+package tail
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTail(t *testing.T) {
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.log")
+
+	// Create and write initial content
+	f, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	fmt.Fprintln(f, "line 1")
+	fmt.Fprintln(f, "line 2")
+	f.Close()
+
+	// Start tailing
+	tail := NewTail(testFile, WithPollInterval(100*time.Millisecond))
+	if err := tail.Start(); err != nil {
+		t.Fatalf("Failed to start tail: %v", err)
+	}
+	defer tail.Stop()
+
+	// Append new lines
+	f, err = os.OpenFile(testFile, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+
+	fmt.Fprintln(f, "line 3")
+	fmt.Fprintln(f, "line 4")
+	f.Close()
+
+	// Read the new lines
+	timeout := time.After(2 * time.Second)
+	lines := []string{}
+
+	for i := 0; i < 2; i++ {
+		select {
+		case line := <-tail.Lines():
+			lines = append(lines, line)
+		case <-timeout:
+			t.Fatal("Timeout waiting for lines")
+		}
+	}
+
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 lines, got %d", len(lines))
+	}
+
+	if lines[0] != "line 3" {
+		t.Errorf("Expected 'line 3', got '%s'", lines[0])
+	}
+
+	if lines[1] != "line 4" {
+		t.Errorf("Expected 'line 4', got '%s'", lines[1])
+	}
+}
+
+func TestTailRotation(t *testing.T) {
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.log")
+
+	// Create and write initial content
+	f, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	fmt.Fprintln(f, "line 1")
+	f.Close()
+
+	// Start tailing
+	tail := NewTail(testFile, WithPollInterval(100*time.Millisecond))
+	if err := tail.Start(); err != nil {
+		t.Fatalf("Failed to start tail: %v", err)
+	}
+	defer tail.Stop()
+
+	// Append a line
+	f, err = os.OpenFile(testFile, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+	fmt.Fprintln(f, "line 2")
+	f.Close()
+
+	// Simulate log rotation
+	rotatedFile := filepath.Join(tmpDir, "test.log.old")
+	if err := os.Rename(testFile, rotatedFile); err != nil {
+		t.Fatalf("Failed to rotate file: %v", err)
+	}
+
+	// Create new file with same name
+	f, err = os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Failed to create new file: %v", err)
+	}
+	fmt.Fprintln(f, "line 3 (new file)")
+	f.Close()
+
+	// Wait a bit for rotation detection
+	time.Sleep(300 * time.Millisecond)
+
+	// Append more lines to new file
+	f, err = os.OpenFile(testFile, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open new file: %v", err)
+	}
+	fmt.Fprintln(f, "line 4 (new file)")
+	f.Close()
+
+	// Read the lines
+	timeout := time.After(2 * time.Second)
+	lines := []string{}
+
+	for i := 0; i < 3; i++ {
+		select {
+		case line := <-tail.Lines():
+			lines = append(lines, line)
+		case <-timeout:
+			t.Logf("Got %d lines so far: %v", len(lines), lines)
+			t.Fatal("Timeout waiting for lines")
+		}
+	}
+
+	// Should have read line 2 from old file, and lines from new file
+	if len(lines) < 2 {
+		t.Fatalf("Expected at least 2 lines, got %d: %v", len(lines), lines)
+	}
+
+	// Check that we got line 2
+	foundLine2 := false
+	foundLine3 := false
+	foundLine4 := false
+
+	for _, line := range lines {
+		if line == "line 2" {
+			foundLine2 = true
+		}
+		if line == "line 3 (new file)" {
+			foundLine3 = true
+		}
+		if line == "line 4 (new file)" {
+			foundLine4 = true
+		}
+	}
+
+	if !foundLine2 {
+		t.Error("Did not find 'line 2' from old file")
+	}
+	if !foundLine3 {
+		t.Error("Did not find 'line 3 (new file)' from new file")
+	}
+	if !foundLine4 {
+		t.Error("Did not find 'line 4 (new file)' from new file")
+	}
+}
+
+func TestTailTruncation(t *testing.T) {
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.log")
+
+	// Create and write initial content
+	f, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	fmt.Fprintln(f, "line 1")
+	fmt.Fprintln(f, "line 2")
+	f.Close()
+
+	// Start tailing
+	tail := NewTail(testFile, WithPollInterval(100*time.Millisecond))
+	if err := tail.Start(); err != nil {
+		t.Fatalf("Failed to start tail: %v", err)
+	}
+	defer tail.Stop()
+
+	// Truncate and write new content
+	// First truncate the file
+	f, err = os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Failed to truncate file: %v", err)
+	}
+	f.Close()
+
+	// Wait for tail to detect the truncation
+	time.Sleep(150 * time.Millisecond)
+
+	// Now write new content
+	f, err = os.OpenFile(testFile, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	fmt.Fprintln(f, "line 3 (after truncate)")
+	f.Sync() // Ensure data is written to disk
+	f.Close()
+
+	// Wait for the data to be read
+	time.Sleep(150 * time.Millisecond)
+
+	// Read the new line
+	timeout := time.After(2 * time.Second)
+
+	select {
+	case line := <-tail.Lines():
+		if line != "line 3 (after truncate)" {
+			t.Errorf("Expected 'line 3 (after truncate)', got '%s'", line)
+		}
+	case <-timeout:
+		t.Fatal("Timeout waiting for line after truncation")
+	}
+}
+
+func TestTailGrepPattern(t *testing.T) {
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.log")
+
+	// Create and write initial content
+	f, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	fmt.Fprintln(f, "info: all is well")
+	f.Close()
+
+	tail := NewTail(testFile, WithPollInterval(100*time.Millisecond), WithPattern("error", "thing"), WithPattern("info:"))
+	if err := tail.Start(); err != nil {
+		t.Fatalf("Failed to start tail: %v", err)
+	}
+	defer tail.Stop()
+
+	// Append new lines
+	f, err = os.OpenFile(testFile, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("Failed to open test file: %v", err)
+	}
+
+	fmt.Fprintln(f, "error: something went wrong")
+	fmt.Fprintln(f, "warning: check this out")
+	fmt.Fprintln(f, "warning: otherthing")
+	fmt.Fprintln(f, "error: another thing error occurred")
+	fmt.Fprintln(f, "info: just an informational message")
+	fmt.Fprintln(f, "warning: be cautious")
+	f.Close()
+
+	// Read the filtered lines
+	timeout := time.After(2 * time.Second)
+	lines := []string{}
+
+	for i := 0; i < 3; i++ {
+		select {
+		case line := <-tail.Lines():
+			lines = append(lines, line)
+		case <-timeout:
+			fmt.Println("Lines received so far:", lines)
+			t.Fatal("Timeout waiting for lines")
+		}
+	}
+
+	expectedLines := []string{
+		"error: something went wrong",
+		"error: another thing error occurred",
+		"info: just an informational message",
+	}
+
+	if len(lines) != len(expectedLines) {
+		t.Fatalf("Expected %d lines, got %d", len(expectedLines), len(lines))
+	}
+
+	for i, expected := range expectedLines {
+		if lines[i] != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, lines[i])
+		}
+	}
+}

--- a/mods/util/tail/tail_unix.go
+++ b/mods/util/tail/tail_unix.go
@@ -1,0 +1,17 @@
+//go:build darwin || linux || freebsd || openbsd || netbsd
+
+package tail
+
+import (
+	"os"
+	"syscall"
+)
+
+// getInode returns the inode number of a file
+// This is used to detect when a file has been rotated
+func getInode(stat os.FileInfo) uint64 {
+	if sys, ok := stat.Sys().(*syscall.Stat_t); ok {
+		return sys.Ino
+	}
+	return 0
+}

--- a/mods/util/tail/tail_windows.go
+++ b/mods/util/tail/tail_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package tail
+
+import (
+	"os"
+	"syscall"
+)
+
+// getInode returns a unique file identifier on Windows
+// Windows doesn't have inodes, but we can use the file index which serves a similar purpose
+func getInode(stat os.FileInfo) uint64 {
+	if sys, ok := stat.Sys().(*syscall.Win32FileAttributeData); ok {
+		// On Windows, we can use a combination of VolumeSerialNumber and FileIndex
+		// to uniquely identify a file
+		return uint64(sys.FileSizeHigh)<<32 | uint64(sys.FileSizeLow)
+	}
+	return 0
+}
+
+// getFileID returns the actual file ID on Windows
+func getFileID(f *os.File) (uint64, error) {
+	var info syscall.ByHandleFileInformation
+	err := syscall.GetFileInformationByHandle(syscall.Handle(f.Fd()), &info)
+	if err != nil {
+		return 0, err
+	}
+
+	// Combine FileIndexHigh and FileIndexLow to create a unique identifier
+	fileID := uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow)
+	return fileID, nil
+}


### PR DESCRIPTION
This pull request introduces a new cross-platform file tailing utility in Go, similar to the Unix `tail -F` command, with support for file rotation, truncation, and pattern-based filtering. The implementation is split into platform-specific files for inode detection and includes a comprehensive test suite.

**Core implementation:**

* Added a new `tail` package with the main implementation in `tail.go`, providing a `Tail` struct for tailing files, supporting log rotation, truncation, and pattern-based filtering, with configurable polling interval and buffer size.

**Platform-specific support:**

* Added `tail_unix.go` for Unix-like systems, implementing `getInode` to detect file rotation using inode numbers.
* Added `tail_windows.go` for Windows, implementing `getInode` and `getFileID` to uniquely identify files using Windows-specific file attributes.

**Testing:**

* Added `tail_test.go` with tests for tailing new lines, handling file rotation, truncation, and pattern-based filtering to ensure robust functionality across scenarios.…s for file tailing and rotation