### PR TITLE
remove unsafe.Pointer and buffio

### DIFF
--- a/api/machnet/append_encode.go
+++ b/api/machnet/append_encode.go
@@ -12,7 +12,7 @@ const (
 	appendBindingArrival = -2
 )
 
-type appendBindings struct {
+type AppendBindings struct {
 	byColumn   []int
 	arrivalArg int
 }
@@ -26,7 +26,7 @@ func normalizeIdentifier(name string) string {
 	return strings.ToUpper(normalized)
 }
 
-func isAppendArrivalColumn(col columnMeta, idx int) bool {
+func isAppendArrivalColumn(col ColumnMeta, idx int) bool {
 	name := normalizeIdentifier(col.name)
 	if idx == 0 && name == "" {
 		return true
@@ -34,7 +34,7 @@ func isAppendArrivalColumn(col columnMeta, idx int) bool {
 	return name == "_ARRIVAL_TIME"
 }
 
-func buildAppendBindings(columns []columnMeta, names []string) (appendBindings, error) {
+func buildAppendBindings(columns []ColumnMeta, names []string) (AppendBindings, error) {
 	inputByName := make(map[string]int, len(names))
 	matched := make([]bool, len(names))
 	arrivalArg := -1
@@ -47,11 +47,11 @@ func buildAppendBindings(columns []columnMeta, names []string) (appendBindings, 
 			arrivalArg = idx
 		}
 		if _, exists := inputByName[key]; exists {
-			return appendBindings{}, fmt.Errorf("duplicate append column %s", name)
+			return AppendBindings{}, fmt.Errorf("duplicate append column %s", name)
 		}
 		inputByName[key] = idx
 	}
-	bindings := appendBindings{
+	bindings := AppendBindings{
 		byColumn:   make([]int, len(columns)),
 		arrivalArg: arrivalArg,
 	}
@@ -78,13 +78,13 @@ func buildAppendBindings(columns []columnMeta, names []string) (appendBindings, 
 			continue
 		}
 		if !matched[idx] {
-			return appendBindings{}, fmt.Errorf("append column %s is not accepted by server metadata", name)
+			return AppendBindings{}, fmt.Errorf("append column %s is not accepted by server metadata", name)
 		}
 	}
 	return bindings, nil
 }
 
-func encodeAppendRow(columns []columnMeta, bindings appendBindings, args []any, serverEndian uint32) ([]byte, error) {
+func encodeAppendRow(columns []ColumnMeta, bindings AppendBindings, args []any, serverEndian uint32) ([]byte, error) {
 	nullBytes := 0
 	if len(columns) > 0 {
 		nullBytes = (len(columns) / 8) + 1
@@ -186,7 +186,7 @@ func encodeAppendVarField(data []byte, serverEndian uint32) []byte {
 	return ret
 }
 
-func encodeAppendColumnValue(col columnMeta, value any, serverEndian uint32) ([]byte, error) {
+func encodeAppendColumnValue(col ColumnMeta, value any, serverEndian uint32) ([]byte, error) {
 	switch col.spinerType {
 	case cmdBoolType:
 		b, err := toAppendBool(value)

--- a/api/machnet/bind.go
+++ b/api/machnet/bind.go
@@ -10,13 +10,13 @@ import (
 	"time"
 )
 
-type boundParam struct {
+type BoundParam struct {
 	sqlType SqlType
 	value   any
 	isNull  bool
 }
 
-func encodeParams(params []boundParam) ([]byte, error) {
+func encodeParams(params []BoundParam) ([]byte, error) {
 	if len(params) == 0 {
 		return nil, nil
 	}
@@ -50,7 +50,7 @@ func encodeParams(params []boundParam) ([]byte, error) {
 	return buf, nil
 }
 
-func encodeBoundParam(p boundParam) (int, []byte, error) {
+func encodeBoundParam(p BoundParam) (int, []byte, error) {
 	cmdType := sqlTypeToCmdType(p.sqlType)
 	if p.isNull || p.value == nil {
 		switch p.sqlType {

--- a/api/machnet/cli.go
+++ b/api/machnet/cli.go
@@ -2,33 +2,40 @@ package machnet
 
 import (
 	"errors"
-	"fmt"
-	"net"
 	"sync"
 	"time"
-	"unsafe"
 )
 
-type envHandle struct {
+type EnvHandle struct {
 	mu      sync.Mutex
 	closed  bool
 	lastErr cliErrorState
-	conns   map[*connHandle]struct{}
+	conns   map[*ConnHandle]struct{}
 }
 
-type connHandle struct {
+// Error() returns the last error code and message for the environment handle.
+func (env *EnvHandle) Error() (int, string) {
+	return env.lastErr.code, env.lastErr.msg
+}
+
+type ConnHandle struct {
 	mu      sync.Mutex
-	env     *envHandle
-	native  *nativeConn
+	env     *EnvHandle
+	native  *NativeConn
 	closed  bool
 	lastErr cliErrorState
 }
 
-type appendState struct {
+// Error() returns the last error code and message for the connection handle.
+func (conn *ConnHandle) Error() (int, string) {
+	return conn.lastErr.code, conn.lastErr.msg
+}
+
+type AppendState struct {
 	table         string
 	errCheckCnt   int
-	columns       []columnMeta
-	bindings      appendBindings
+	columns       []ColumnMeta
+	bindings      AppendBindings
 	bindingsReady bool
 	addCount      int64
 	sentCount     int64
@@ -37,31 +44,33 @@ type appendState struct {
 	pendingRows   [][]byte
 	pendingBytes  int
 	firstQueuedAt time.Time
+
+	appendBatchMaxRows  int
+	appendBatchMaxBytes int
+	appendBatchMaxDelay time.Duration
 }
 
-const (
-	appendBatchMaxRows  = 512
-	appendBatchMaxBytes = 512 * 1024
-	appendBatchMaxDelay = 5 * time.Millisecond
-)
-
-type stmtHandle struct {
+type StmtHandle struct {
 	mu        sync.Mutex
-	conn      *connHandle
+	conn      *ConnHandle
 	id        uint32
 	closed    bool
 	prepared  bool
 	sql       string
 	stmtType  int
 	rowCount  int64
-	columns   []columnMeta
-	paramDesc []CliParamDesc
+	columns   []ColumnMeta
+	paramDesc []ParamDesc
 	rows      [][]any
 	rowPos    int
-	current   []any
-	bound     map[int]boundParam
-	app       *appendState
+	bound     map[int]BoundParam
+	app       *AppendState
 	lastErr   cliErrorState
+}
+
+// Error() returns the last error code and message for the statement handle.
+func (stmt *StmtHandle) Error() (int, string) {
+	return stmt.lastErr.code, stmt.lastErr.msg
 }
 
 func setErr(st *cliErrorState, err error) {
@@ -86,158 +95,121 @@ func setErr(st *cliErrorState, err error) {
 	st.msg = err.Error()
 }
 
-func CliInitialize(env *unsafe.Pointer) error {
-	e := &envHandle{conns: map[*connHandle]struct{}{}}
-	*env = unsafe.Pointer(e)
-	return nil
+func Initialize() (*EnvHandle, error) {
+	return &EnvHandle{conns: map[*ConnHandle]struct{}{}}, nil
 }
 
-func CliFinalize(env unsafe.Pointer) error {
+func (env *EnvHandle) Finalize() error {
 	if env == nil {
 		return nil
 	}
-	e := (*envHandle)(env)
-	e.mu.Lock()
-	if e.closed {
-		e.mu.Unlock()
+	env.mu.Lock()
+	if env.closed {
+		env.mu.Unlock()
 		return nil
 	}
-	e.closed = true
-	conns := make([]*connHandle, 0, len(e.conns))
-	for c := range e.conns {
+	env.closed = true
+	conns := make([]*ConnHandle, 0, len(env.conns))
+	for c := range env.conns {
 		conns = append(conns, c)
 	}
-	e.mu.Unlock()
+	env.mu.Unlock()
 	for _, c := range conns {
-		_ = CliDisconnect(unsafe.Pointer(c))
+		_ = c.Disconnect()
 	}
 	return nil
 }
 
-func CliConnect(env unsafe.Pointer, connStr string, conn *unsafe.Pointer) error {
+func (env *EnvHandle) Connect(connStr string) (*ConnHandle, error) {
 	if env == nil {
-		return makeClientErr("invalid environment")
+		return nil, makeClientErr("invalid environment")
 	}
-	e := (*envHandle)(env)
 	host, port, user, pass, alts, err := parseConnString(connStr)
 	if err != nil {
-		setErr(&e.lastErr, err)
-		return err
+		setErr(&env.lastErr, err)
+		return nil, err
 	}
 	nc, err := dialNative(host, port, user, pass, alts)
 	if err != nil {
-		setErr(&e.lastErr, err)
-		return err
+		setErr(&env.lastErr, err)
+		return nil, err
 	}
-	ch := &connHandle{env: e, native: nc}
-	e.mu.Lock()
-	if e.closed {
-		e.mu.Unlock()
+	ch := &ConnHandle{env: env, native: nc}
+	env.mu.Lock()
+	if env.closed {
+		env.mu.Unlock()
 		_ = nc.close()
 		err = makeClientErr("environment closed")
-		setErr(&e.lastErr, err)
-		return err
+		setErr(&env.lastErr, err)
+		return nil, err
 	}
-	e.conns[ch] = struct{}{}
-	e.mu.Unlock()
-	*conn = unsafe.Pointer(ch)
-	setErr(&e.lastErr, nil)
-	return nil
+	env.conns[ch] = struct{}{}
+	env.mu.Unlock()
+	setErr(&env.lastErr, nil)
+	return ch, nil
 }
 
-func CliDisconnect(conn unsafe.Pointer) error {
+func (conn *ConnHandle) Disconnect() error {
 	if conn == nil {
 		return nil
 	}
-	ch := (*connHandle)(conn)
-	ch.mu.Lock()
-	if ch.closed {
-		ch.mu.Unlock()
+	conn.mu.Lock()
+	if conn.closed {
+		conn.mu.Unlock()
 		return nil
 	}
-	ch.closed = true
-	nc := ch.native
-	ch.mu.Unlock()
+	conn.closed = true
+	nc := conn.native
+	conn.mu.Unlock()
 
 	err := nc.close()
-	setErr(&ch.lastErr, err)
-	if ch.env != nil {
-		ch.env.mu.Lock()
-		delete(ch.env.conns, ch)
-		ch.env.mu.Unlock()
+	setErr(&conn.lastErr, err)
+	if conn.env != nil {
+		conn.env.mu.Lock()
+		delete(conn.env.conns, conn)
+		conn.env.mu.Unlock()
 	}
 	return err
 }
 
-func CliError(handle unsafe.Pointer, handleType HandleType, code *int, msg *string) error {
-	if code == nil || msg == nil {
-		return makeClientErr("invalid CliError output")
-	}
-	*code = 0
-	*msg = ""
-	if handle == nil {
-		return nil
-	}
-	switch handleType {
-	case MACHCLI_HANDLE_ENV:
-		e := (*envHandle)(handle)
-		*code = e.lastErr.code
-		*msg = e.lastErr.msg
-	case MACHCLI_HANDLE_DBC:
-		c := (*connHandle)(handle)
-		*code = c.lastErr.code
-		*msg = c.lastErr.msg
-	case MACHCLI_HANDLE_STMT:
-		s := (*stmtHandle)(handle)
-		*code = s.lastErr.code
-		*msg = s.lastErr.msg
-	default:
-		return makeClientErr("unknown handle type")
-	}
-	return nil
-}
-
-func CliAllocStmt(conn unsafe.Pointer, stmt *unsafe.Pointer) error {
+func (conn *ConnHandle) AllocStmt() (*StmtHandle, error) {
 	if conn == nil {
-		return makeClientErr("invalid connection")
+		return nil, makeClientErr("invalid connection")
 	}
-	ch := (*connHandle)(conn)
-	ch.mu.Lock()
-	defer ch.mu.Unlock()
-	if ch.closed || ch.native == nil {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	if conn.closed || conn.native == nil {
 		err := makeClientErr("connection closed")
-		setErr(&ch.lastErr, err)
-		return err
+		setErr(&conn.lastErr, err)
+		return nil, err
 	}
-	id, err := ch.native.nextStmtID()
+	id, err := conn.native.nextStmtID()
 	if err != nil {
-		setErr(&ch.lastErr, err)
-		return err
+		setErr(&conn.lastErr, err)
+		return nil, err
 	}
-	s := &stmtHandle{
-		conn:  ch,
+	stmt := &StmtHandle{
+		conn:  conn,
 		id:    id,
-		bound: map[int]boundParam{},
+		bound: map[int]BoundParam{},
 	}
-	*stmt = unsafe.Pointer(s)
-	setErr(&ch.lastErr, nil)
-	return nil
+	setErr(&conn.lastErr, nil)
+	return stmt, nil
 }
 
-func CliFreeStmt(stmt unsafe.Pointer) error {
+func (stmt *StmtHandle) Free() error {
 	if stmt == nil {
 		return nil
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
+	stmt.mu.Lock()
+	if stmt.closed {
+		stmt.mu.Unlock()
 		return nil
 	}
-	s.closed = true
-	conn := s.conn
-	id := s.id
-	s.mu.Unlock()
+	stmt.closed = true
+	conn := stmt.conn
+	id := stmt.id
+	stmt.mu.Unlock()
 	var err error
 	if conn != nil && conn.native != nil {
 		err = conn.native.free(id)
@@ -245,256 +217,208 @@ func CliFreeStmt(stmt unsafe.Pointer) error {
 			conn.native.releaseStmtID(id)
 		}
 	}
-	setErr(&s.lastErr, err)
+	setErr(&stmt.lastErr, err)
 	if conn != nil {
 		setErr(&conn.lastErr, err)
 	}
 	return err
 }
 
-func CliPrepare(stmt unsafe.Pointer, query string) error {
+func (stmt *StmtHandle) Prepare(query string) error {
 	if stmt == nil {
 		return makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed || s.conn == nil || s.conn.native == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.closed || stmt.conn == nil || stmt.conn.native == nil {
 		err := makeClientErr("statement closed")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	res, err := s.conn.native.prepare(s.id, query)
-	setErr(&s.lastErr, err)
-	setErr(&s.conn.lastErr, err)
+	res, err := stmt.conn.native.prepare(stmt.id, query)
+	setErr(&stmt.lastErr, err)
+	setErr(&stmt.conn.lastErr, err)
 	if err != nil {
 		return err
 	}
-	s.prepared = true
-	s.sql = query
-	s.columns = res.columns
-	s.paramDesc = res.paramDescs
-	s.stmtType = res.stmtType
-	s.rowCount = res.rowCount
-	s.rows = nil
-	s.rowPos = 0
-	s.current = nil
+	stmt.prepared = true
+	stmt.sql = query
+	stmt.columns = res.columns
+	stmt.paramDesc = res.paramDescs
+	stmt.stmtType = res.stmtType
+	stmt.rowCount = res.rowCount
+	stmt.rows = nil
+	stmt.rowPos = 0
 	return nil
 }
 
-func CliExecute(stmt unsafe.Pointer) error {
+func (stmt *StmtHandle) Execute() error {
 	if stmt == nil {
 		return makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed || s.conn == nil || s.conn.native == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.closed || stmt.conn == nil || stmt.conn.native == nil {
 		err := makeClientErr("statement closed")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	if !s.prepared {
+	if !stmt.prepared {
 		err := makeClientErr("statement is not prepared")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	paramCnt := len(s.paramDesc)
+	paramCnt := len(stmt.paramDesc)
 	if paramCnt == 0 {
-		for idx := range s.bound {
+		for idx := range stmt.bound {
 			if idx+1 > paramCnt {
 				paramCnt = idx + 1
 			}
 		}
 	}
-	params := make([]boundParam, paramCnt)
+	params := make([]BoundParam, paramCnt)
 	for i := 0; i < paramCnt; i++ {
-		if b, ok := s.bound[i]; ok {
+		if b, ok := stmt.bound[i]; ok {
 			params[i] = b
 		} else {
-			params[i] = boundParam{sqlType: MACHCLI_SQL_TYPE_STRING, isNull: true}
+			params[i] = BoundParam{sqlType: MACHCLI_SQL_TYPE_STRING, isNull: true}
 		}
 	}
-	res, err := s.conn.native.executePrepared(s.id, s.sql, params, s.columns)
-	setErr(&s.lastErr, err)
-	setErr(&s.conn.lastErr, err)
+	res, err := stmt.conn.native.executePrepared(stmt.id, stmt.sql, params, stmt.columns)
+	setErr(&stmt.lastErr, err)
+	setErr(&stmt.conn.lastErr, err)
 	if err != nil {
 		return err
 	}
-	s.stmtType = res.stmtType
-	s.rowCount = res.rowCount
+	stmt.stmtType = res.stmtType
+	stmt.rowCount = res.rowCount
 	if len(res.columns) > 0 {
-		s.columns = res.columns
+		stmt.columns = res.columns
 	}
-	s.rows = res.rows
-	s.rowPos = 0
-	s.current = nil
+	stmt.rows = res.rows
+	stmt.rowPos = 0
 	return nil
 }
 
-func CliExecDirect(stmt unsafe.Pointer, query string) error {
+func (stmt *StmtHandle) ExecDirect(query string) error {
 	if stmt == nil {
 		return makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed || s.conn == nil || s.conn.native == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.closed || stmt.conn == nil || stmt.conn.native == nil {
 		err := makeClientErr("statement closed")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	res, err := s.conn.native.execDirect(s.id, query)
-	setErr(&s.lastErr, err)
-	setErr(&s.conn.lastErr, err)
+	res, err := stmt.conn.native.execDirect(stmt.id, query)
+	setErr(&stmt.lastErr, err)
+	setErr(&stmt.conn.lastErr, err)
 	if err != nil {
 		return err
 	}
-	s.prepared = false
-	s.sql = query
-	s.stmtType = res.stmtType
-	s.rowCount = res.rowCount
-	s.columns = res.columns
-	s.paramDesc = res.paramDescs
-	s.rows = res.rows
-	s.rowPos = 0
-	s.current = nil
+	stmt.prepared = false
+	stmt.sql = query
+	stmt.stmtType = res.stmtType
+	stmt.rowCount = res.rowCount
+	stmt.columns = res.columns
+	stmt.paramDesc = res.paramDescs
+	stmt.rows = res.rows
+	stmt.rowPos = 0
 	return nil
 }
 
-func CliExecuteClean(stmt unsafe.Pointer) error {
+func (stmt *StmtHandle) ExecuteClean() error {
 	if stmt == nil {
 		return nil
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.rows = nil
-	s.rowPos = 0
-	s.current = nil
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	stmt.rows = nil
+	stmt.rowPos = 0
 	return nil
 }
 
-func CliNumParam(stmt unsafe.Pointer) (int, error) {
+func (stmt *StmtHandle) NumParam() (int, error) {
 	if stmt == nil {
 		return 0, makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.paramDesc), nil
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	return len(stmt.paramDesc), nil
 }
 
-func CliDescribeParam(stmt unsafe.Pointer, paramNo int) (CliParamDesc, error) {
+func (stmt *StmtHandle) DescribeParam(paramNo int) (ParamDesc, error) {
 	if stmt == nil {
-		return CliParamDesc{}, makeClientErr("invalid statement")
+		return ParamDesc{}, makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if paramNo < 0 || paramNo >= len(s.paramDesc) {
-		return CliParamDesc{Type: MACHCLI_SQL_TYPE_STRING, Nullable: true}, makeClientErr("invalid parameter index")
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if paramNo < 0 || paramNo >= len(stmt.paramDesc) {
+		return ParamDesc{Type: MACHCLI_SQL_TYPE_STRING, Nullable: true}, makeClientErr("invalid parameter index")
 	}
-	return s.paramDesc[paramNo], nil
+	return stmt.paramDesc[paramNo], nil
 }
 
-func CliBindParam(stmt unsafe.Pointer, paramNo int, cType CType, sqlType SqlType, value unsafe.Pointer, valueLen int) error {
+func (stmt *StmtHandle) BindParam(paramNo int, sqlType SqlType, value any) error {
 	if stmt == nil {
 		return makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
 	if paramNo < 0 {
 		err := makeClientErr("invalid parameter index")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	bp := boundParam{sqlType: sqlType}
-	if value == nil {
-		bp.isNull = true
-		s.bound[paramNo] = bp
-		setErr(&s.lastErr, nil)
-		return nil
-	}
-	switch cType {
-	case MACHCLI_C_TYPE_INT16:
-		bp.value = *(*int16)(value)
-	case MACHCLI_C_TYPE_INT32:
-		bp.value = *(*int32)(value)
-	case MACHCLI_C_TYPE_INT64:
-		bp.value = *(*int64)(value)
-	case MACHCLI_C_TYPE_FLOAT:
-		bp.value = *(*float32)(value)
-	case MACHCLI_C_TYPE_DOUBLE:
-		bp.value = *(*float64)(value)
-	case MACHCLI_C_TYPE_CHAR:
-		data := make([]byte, valueLen)
-		copy(data, unsafe.Slice((*byte)(value), valueLen))
-		switch sqlType {
-		case MACHCLI_SQL_TYPE_BINARY:
-			bp.value = data
-		case MACHCLI_SQL_TYPE_IPV4, MACHCLI_SQL_TYPE_IPV6:
-			bp.value = string(data)
-		default:
-			bp.value = string(data)
-		}
-	default:
-		err := makeClientErr("unsupported c type")
-		setErr(&s.lastErr, err)
-		return err
-	}
-	s.bound[paramNo] = bp
-	setErr(&s.lastErr, nil)
+	bp := BoundParam{sqlType: sqlType, value: value, isNull: value == nil}
+	stmt.bound[paramNo] = bp
+	setErr(&stmt.lastErr, nil)
 	return nil
 }
 
-func CliRowCount(stmt unsafe.Pointer) (int64, error) {
+func (stmt *StmtHandle) RowCount() (int64, error) {
 	if stmt == nil {
 		return 0, makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.rowCount, nil
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	return stmt.rowCount, nil
 }
 
-func CliGetStmtType(stmt unsafe.Pointer) (int, error) {
+func (stmt *StmtHandle) GetStmtType() (int, error) {
 	if stmt == nil {
 		return 0, makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.stmtType == 0 {
-		return inferStmtType(s.sql), nil
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.stmtType == 0 {
+		return inferStmtType(stmt.sql), nil
 	}
-	return s.stmtType, nil
+	return stmt.stmtType, nil
 }
 
-func CliNumResultCol(stmt unsafe.Pointer) (int, error) {
+func (stmt *StmtHandle) NumResultCol() (int, error) {
 	if stmt == nil {
 		return 0, makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return len(s.columns), nil
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	return len(stmt.columns), nil
 }
 
-func CliDescribeCol(stmt unsafe.Pointer, columnNo int, pName *string, pType *SqlType, pSize *int, pScale *int, pNullable *bool) error {
+func (stmt *StmtHandle) DescribeCol(columnNo int, pName *string, pType *SqlType, pSize *int, pScale *int, pNullable *bool) error {
 	if stmt == nil {
 		return makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if columnNo < 0 || columnNo >= len(s.columns) {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if columnNo < 0 || columnNo >= len(stmt.columns) {
 		err := makeClientErr("invalid column index")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	col := s.columns[columnNo]
+	col := stmt.columns[columnNo]
 	if pName != nil {
 		*pName = col.name
 	}
@@ -522,357 +446,178 @@ func CliDescribeCol(stmt unsafe.Pointer, columnNo int, pName *string, pType *Sql
 	return nil
 }
 
-func CliFetch(stmt unsafe.Pointer) (bool, error) {
-	if stmt == nil {
-		return true, makeClientErr("invalid statement")
-	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.rowPos >= len(s.rows) {
-		s.current = nil
-		return true, nil
-	}
-	s.current = s.rows[s.rowPos]
-	s.rowPos++
-	return false, nil
-}
-
-func CliFetchCurrent(stmt unsafe.Pointer) ([]any, bool, error) {
-	if stmt == nil {
-		return nil, true, makeClientErr("invalid statement")
-	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.rowPos >= len(s.rows) {
-		s.current = nil
-		return nil, true, nil
-	}
-	row := s.rows[s.rowPos]
-	s.rowPos++
-	s.current = row
-	return row, false, nil
-}
-
-func CliCurrentRow(stmt unsafe.Pointer) ([]any, error) {
+func (stmt *StmtHandle) Fetch() ([]any, error) {
 	if stmt == nil {
 		return nil, makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.current == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.rowPos >= len(stmt.rows) {
 		return nil, nil
 	}
-	return s.current, nil
+	ret := stmt.rows[stmt.rowPos]
+	stmt.rowPos++
+	return ret, nil
 }
 
-func asInt64(v any) (int64, bool) {
-	switch x := v.(type) {
-	case int16:
-		return int64(x), true
-	case int32:
-		return int64(x), true
-	case int64:
-		return x, true
-	case int:
-		return int64(x), true
-	case uint:
-		return int64(x), true
-	case uint16:
-		return int64(x), true
-	case uint32:
-		return int64(x), true
-	case uint64:
-		return int64(x), true
-	case float32:
-		return int64(x), true
-	case float64:
-		return int64(x), true
-	default:
-		return 0, false
-	}
-}
-
-func asFloat64(v any) (float64, bool) {
-	switch x := v.(type) {
-	case float32:
-		return float64(x), true
-	case float64:
-		return x, true
-	case int16:
-		return float64(x), true
-	case int32:
-		return float64(x), true
-	case int64:
-		return float64(x), true
-	case int:
-		return float64(x), true
-	case uint:
-		return float64(x), true
-	case uint16:
-		return float64(x), true
-	case uint32:
-		return float64(x), true
-	case uint64:
-		return float64(x), true
-	default:
-		return 0, false
-	}
-}
-
-func CliGetData(stmt unsafe.Pointer, columnNo int, cType CType, buf unsafe.Pointer, bufLen int) (int64, error) {
-	if stmt == nil {
-		return 0, makeClientErr("invalid statement")
-	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.current == nil {
-		return -1, nil
-	}
-	if columnNo < 0 || columnNo >= len(s.current) {
-		err := makeClientErr("invalid column index")
-		setErr(&s.lastErr, err)
-		return 0, err
-	}
-	v := s.current[columnNo]
-	if v == nil {
-		return -1, nil
-	}
-	if buf == nil {
-		return 0, makeClientErr("invalid output buffer")
-	}
-
-	switch cType {
-	case MACHCLI_C_TYPE_INT16:
-		n, ok := asInt64(v)
-		if !ok {
-			return 0, makeClientErr("cannot convert value to int16")
-		}
-		*(*int16)(buf) = int16(n)
-		return 2, nil
-	case MACHCLI_C_TYPE_INT32:
-		n, ok := asInt64(v)
-		if !ok {
-			return 0, makeClientErr("cannot convert value to int32")
-		}
-		*(*int32)(buf) = int32(n)
-		return 4, nil
-	case MACHCLI_C_TYPE_INT64:
-		switch x := v.(type) {
-		case time.Time:
-			*(*int64)(buf) = x.UnixNano()
-			return 8, nil
-		default:
-			n, ok := asInt64(v)
-			if !ok {
-				return 0, makeClientErr("cannot convert value to int64")
-			}
-			*(*int64)(buf) = n
-			return 8, nil
-		}
-	case MACHCLI_C_TYPE_FLOAT:
-		f, ok := asFloat64(v)
-		if !ok {
-			return 0, makeClientErr("cannot convert value to float")
-		}
-		*(*float32)(buf) = float32(f)
-		return 4, nil
-	case MACHCLI_C_TYPE_DOUBLE:
-		f, ok := asFloat64(v)
-		if !ok {
-			return 0, makeClientErr("cannot convert value to double")
-		}
-		*(*float64)(buf) = f
-		return 8, nil
-	case MACHCLI_C_TYPE_CHAR:
-		var data []byte
-		switch x := v.(type) {
-		case string:
-			data = []byte(x)
-		case []byte:
-			data = x
-		case net.IP:
-			if ip4 := x.To4(); ip4 != nil {
-				data = ip4
-			} else if ip16 := x.To16(); ip16 != nil {
-				data = ip16
-			}
-		default:
-			data = []byte(fmt.Sprint(x))
-		}
-		if len(data) == 0 {
-			return -1, nil
-		}
-		if bufLen > 0 {
-			copy(unsafe.Slice((*byte)(buf), bufLen), data)
-		}
-		return int64(len(data)), nil
-	default:
-		return 0, makeClientErr("unsupported c type")
-	}
-}
-
-func CliAppendOpen(stmt unsafe.Pointer, tableName string, errCheckCount int) error {
+func (stmt *StmtHandle) AppendOpen(tableName string, errCheckCount int) error {
 	if stmt == nil {
 		return makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed || s.conn == nil || s.conn.native == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.closed || stmt.conn == nil || stmt.conn.native == nil {
 		err := makeClientErr("statement closed")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	res, err := s.conn.native.appendOpen(s.id, tableName, errCheckCount)
-	setErr(&s.lastErr, err)
-	setErr(&s.conn.lastErr, err)
+	res, err := stmt.conn.native.appendOpen(stmt.id, tableName, errCheckCount)
+	setErr(&stmt.lastErr, err)
+	setErr(&stmt.conn.lastErr, err)
 	if err != nil {
 		return err
 	}
-	s.app = &appendState{
+
+	stmt.app = &AppendState{
 		table:       tableName,
 		errCheckCnt: errCheckCount,
-		columns:     append([]columnMeta(nil), res.columns...),
-		bindings: appendBindings{
+		columns:     append([]ColumnMeta(nil), res.columns...),
+		bindings: AppendBindings{
 			arrivalArg: -1,
 		},
-		pendingRows: make([][]byte, 0, appendBatchMaxRows),
+		appendBatchMaxRows:  512,
+		appendBatchMaxBytes: 512 * 1024,
+		appendBatchMaxDelay: 5 * time.Millisecond,
 	}
+	stmt.app.pendingRows = make([][]byte, 0, stmt.app.appendBatchMaxRows)
 	return nil
 }
 
-func flushAppendBufferedLocked(s *stmtHandle, checkResponse bool) error {
-	if s == nil || s.app == nil || len(s.app.pendingRows) == 0 {
+func (stmt *StmtHandle) flushAppendBufferedLocked(checkResponse bool) error {
+	if stmt == nil || stmt.app == nil || len(stmt.app.pendingRows) == 0 {
 		return nil
 	}
-	pending := s.app.pendingRows
+	pending := stmt.app.pendingRows
 	pendingCount := len(pending)
-	s.app.pendingRows = s.app.pendingRows[:0]
-	s.app.pendingBytes = 0
-	s.app.firstQueuedAt = time.Time{}
+	stmt.app.pendingRows = stmt.app.pendingRows[:0]
+	stmt.app.pendingBytes = 0
+	stmt.app.firstQueuedAt = time.Time{}
 
-	err := s.conn.native.appendData(s.id, pending, checkResponse)
-	setErr(&s.lastErr, err)
-	setErr(&s.conn.lastErr, err)
+	err := stmt.conn.native.appendData(stmt.id, pending, checkResponse)
+	setErr(&stmt.lastErr, err)
+	setErr(&stmt.conn.lastErr, err)
 	if err != nil {
-		s.app.failCnt += int64(pendingCount)
+		stmt.app.failCnt += int64(pendingCount)
 		return err
 	}
-	s.app.sentCount += int64(pendingCount)
+	stmt.app.sentCount += int64(pendingCount)
 	return nil
 }
 
-func CliAppendData(stmt unsafe.Pointer, types []SqlType, names []string, args []any, formats []string) error {
+func (stmt *StmtHandle) AppendData(types []SqlType, names []string, args []any, formats []string) error {
 	_ = types
 	_ = formats
 	if stmt == nil {
 		return makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.closed || s.conn == nil || s.conn.native == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.closed || stmt.conn == nil || stmt.conn.native == nil {
 		err := makeClientErr("statement closed")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	if s.app == nil {
+	if stmt.app == nil {
 		err := makeClientErr("append not opened")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
 	if len(names) != len(args) {
 		err := makeClientErr("append argument mismatch")
-		setErr(&s.lastErr, err)
+		setErr(&stmt.lastErr, err)
 		return err
 	}
-	if !s.app.bindingsReady {
-		bindings, err := buildAppendBindings(s.app.columns, names)
+	if !stmt.app.bindingsReady {
+		bindings, err := buildAppendBindings(stmt.app.columns, names)
 		if err != nil {
-			setErr(&s.lastErr, err)
-			setErr(&s.conn.lastErr, err)
-			s.app.failCnt++
+			setErr(&stmt.lastErr, err)
+			setErr(&stmt.conn.lastErr, err)
+			stmt.app.failCnt++
 			return err
 		}
-		s.app.bindings = bindings
-		s.app.bindingsReady = true
+		stmt.app.bindings = bindings
+		stmt.app.bindingsReady = true
 	}
-	rowPayload, err := encodeAppendRow(s.app.columns, s.app.bindings, args, s.conn.native.serverEndian)
+	rowPayload, err := encodeAppendRow(stmt.app.columns, stmt.app.bindings, args, stmt.conn.native.serverEndian)
 	if err != nil {
-		setErr(&s.lastErr, err)
-		setErr(&s.conn.lastErr, err)
-		s.app.failCnt++
+		setErr(&stmt.lastErr, err)
+		setErr(&stmt.conn.lastErr, err)
+		stmt.app.failCnt++
 		return err
 	}
-	s.app.addCount++
-	if len(s.app.pendingRows) == 0 {
-		s.app.firstQueuedAt = time.Now()
+	stmt.app.addCount++
+	if len(stmt.app.pendingRows) == 0 {
+		stmt.app.firstQueuedAt = time.Now()
 	}
-	s.app.pendingRows = append(s.app.pendingRows, rowPayload)
-	s.app.pendingBytes += len(rowPayload)
+	stmt.app.pendingRows = append(stmt.app.pendingRows, rowPayload)
+	stmt.app.pendingBytes += len(rowPayload)
 
-	checkResponse := s.app.errCheckCnt > 0 && (s.app.addCount%int64(s.app.errCheckCnt) == 0)
+	checkResponse := stmt.app.errCheckCnt > 0 && (stmt.app.addCount%int64(stmt.app.errCheckCnt) == 0)
 	flushNow := checkResponse ||
-		len(s.app.pendingRows) >= appendBatchMaxRows ||
-		s.app.pendingBytes >= appendBatchMaxBytes
-	if !flushNow && !s.app.firstQueuedAt.IsZero() && time.Since(s.app.firstQueuedAt) >= appendBatchMaxDelay {
+		len(stmt.app.pendingRows) >= stmt.app.appendBatchMaxRows ||
+		stmt.app.pendingBytes >= stmt.app.appendBatchMaxBytes
+	if !flushNow && !stmt.app.firstQueuedAt.IsZero() && time.Since(stmt.app.firstQueuedAt) >= stmt.app.appendBatchMaxDelay {
 		flushNow = true
 	}
 	if flushNow {
-		if err := flushAppendBufferedLocked(s, checkResponse); err != nil {
+		if err := stmt.flushAppendBufferedLocked(checkResponse); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func CliAppendClose(stmt unsafe.Pointer) (int64, int64, error) {
+func (stmt *StmtHandle) AppendClose() (int64, int64, error) {
 	if stmt == nil {
 		return 0, 0, makeClientErr("invalid statement")
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.app == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.app == nil {
 		return 0, 0, nil
 	}
-	if err := flushAppendBufferedLocked(s, false); err != nil {
-		localSucc := s.app.sentCount - s.app.failCnt
+	if err := stmt.flushAppendBufferedLocked(false); err != nil {
+		localSucc := stmt.app.sentCount - stmt.app.failCnt
 		if localSucc < 0 {
 			localSucc = 0
 		}
-		return localSucc, s.app.failCnt, err
+		return localSucc, stmt.app.failCnt, err
 	}
 
-	succ, fail, err := s.conn.native.appendClose(s.id)
-	setErr(&s.lastErr, err)
-	setErr(&s.conn.lastErr, err)
+	succ, fail, err := stmt.conn.native.appendClose(stmt.id)
+	setErr(&stmt.lastErr, err)
+	setErr(&stmt.conn.lastErr, err)
 	if err != nil {
-		localSucc := s.app.sentCount - s.app.failCnt
+		localSucc := stmt.app.sentCount - stmt.app.failCnt
 		if localSucc < 0 {
 			localSucc = 0
 		}
-		return localSucc, s.app.failCnt, err
+		return localSucc, stmt.app.failCnt, err
 	}
-	s.app.successCnt = succ
-	s.app.failCnt = fail
-	s.app = nil
+	stmt.app.successCnt = succ
+	stmt.app.failCnt = fail
+	stmt.app = nil
 	return succ, fail, nil
 }
 
-func CliAppendFlush(stmt unsafe.Pointer) error {
+func (stmt *StmtHandle) AppendFlush() error {
 	if stmt == nil {
 		return nil
 	}
-	s := (*stmtHandle)(stmt)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.app == nil || s.conn == nil || s.conn.native == nil {
+	stmt.mu.Lock()
+	defer stmt.mu.Unlock()
+	if stmt.app == nil || stmt.conn == nil || stmt.conn.native == nil {
 		return nil
 	}
-	return flushAppendBufferedLocked(s, false)
+	return stmt.flushAppendBufferedLocked(false)
 }

--- a/api/machnet/types.go
+++ b/api/machnet/types.go
@@ -160,14 +160,6 @@ func align8(v int) int {
 	return (v + 7) &^ 7
 }
 
-type HandleType int
-
-const (
-	MACHCLI_HANDLE_ENV  HandleType = 1
-	MACHCLI_HANDLE_DBC  HandleType = 2
-	MACHCLI_HANDLE_STMT HandleType = 3
-)
-
 type SqlType int
 
 const (
@@ -205,7 +197,7 @@ func (typ StmtType) IsInsertSelect() bool { return typ == 519 }
 func (typ StmtType) IsUpdate() bool       { return typ == 520 }
 func (typ StmtType) IsExecRollup() bool   { return typ >= 522 && typ <= 524 }
 
-type CliParamDesc struct {
+type ParamDesc struct {
 	Type      SqlType
 	Precision int
 	Scale     int


### PR DESCRIPTION
This pull request refactors the `api/machgo/machgo.go` file to modernize the codebase by replacing low-level `unsafe.Pointer`-based handles and procedural API calls with type-safe, object-oriented handle types and method calls from the `machnet` package. This results in safer, clearer, and more maintainable code. The changes also simplify parameter binding and statement execution, removing manual memory management and buffer handling.

Key changes include:

### Transition to Type-Safe Handle Types and Methods

* Replaced all usage of `unsafe.Pointer` for database, connection, and statement handles with specific handle types (`*machnet.EnvHandle`, `*machnet.ConnHandle`, `*machnet.StmtHandle`). All procedural `machnet.Cli*` functions are replaced with corresponding methods on these handle types, improving type safety and code readability. [[1]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L130-R118) [[2]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L341-R333) [[3]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1111-R1048) [[4]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L147-R146) [[5]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L319-R320) [[6]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L998-R927) [[7]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L178-R168) [[8]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L374-R366) [[9]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L551-R567) [[10]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L738-R733) [[11]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1135-R1067) [[12]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1289-R1213) [[13]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1519-R1443)

### Simplification of Parameter Binding and Execution

* Refactored the parameter binding logic in `Stmt.bindParams` to remove manual buffer management, `unsafe.Pointer` usage, and explicit C-type handling. Now, parameter values are directly passed to the handle's `BindParam` method, making the code safer and easier to maintain.
* Removed manual buffer slices (`boundBuffers`) and related `runtime.KeepAlive` calls, as the new handle methods manage memory internally. [[1]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L808-L968) [[2]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L433) [[3]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L451) [[4]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L479-R469) [[5]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1135-R1067)

### Improved Error Handling

* Updated the `errorWithCause` function to use the new handle methods for retrieving error codes and messages, removing the need for global error-fetching functions and unsafe handle casting.

### General Code Modernization

* Removed the import of the `unsafe` package and all related usages, as they are no longer necessary with the new handle types.
* Updated all statement and connection lifecycle management (allocation, execution, cleanup, and freeing) to use the new object-oriented API, reducing boilerplate and potential for errors. [[1]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L998-R927) [[2]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L178-R168) [[3]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L374-R366) [[4]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1289-R1213)

### Query and Result Handling

* Refactored query execution, fetching, and result set handling to use the new handle methods, simplifying code paths and improving reliability. [[1]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L551-R567) [[2]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L589-R588) [[3]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L619-R614) [[4]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L660-R655) [[5]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L712-R707) [[6]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L749-R744) [[7]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1175-R1103) [[8]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1154-R1085) [[9]](diffhunk://#diff-4388de1b40f73548829c5242c25b0cacda89fca2d26db0cc840fedf83d0314a3L1519-R1443)

These changes collectively make the codebase safer, more idiomatic, and easier to maintain by leveraging Go's type system and encapsulation features.