### PR TITLE
Refactor error handling and enhance entry validation in filesystem, cleaning process meta

### DIFF
--- a/jsh/engine/fs_controller.go
+++ b/jsh/engine/fs_controller.go
@@ -191,7 +191,11 @@ func (cfs *ControllerFS) Mkdir(name string) error {
 }
 
 func (cfs *ControllerFS) Remove(name string) error {
-	path, err := normalizeControllerFSPath("remove", name, true)
+	trimmed := strings.TrimPrefix(name, "/")
+	if name == "" || trimmed == "" || trimmed == "." {
+		return &fs.PathError{Op: "remove", Path: name, Err: fs.ErrPermission}
+	}
+	path, err := normalizeControllerFSPath("remove", name, false)
 	if err != nil {
 		return err
 	}
@@ -457,6 +461,14 @@ func controllerSnapshotToFileInfo(snapshot controllerFSInfoSnapshot) fs.FileInfo
 	return controllerFSFileInfo{snapshot: snapshot}
 }
 
+// controllerFSRPCErrorCodes mirrors the error codes defined in the service package.
+// These must stay in sync with the server-side constants in jsh/service/rpc.go.
+const (
+	controllerFSRPCForbidden = -32003 // fs.ErrPermission
+	controllerFSRPCNotFound  = -32004 // fs.ErrNotExist
+	controllerFSRPCConflict  = -32009 // ECONFLICT (file locked / busy)
+)
+
 func controllerFSPathError(method string, params any, code int, message string) error {
 	path := "/"
 	if typed, ok := params.(map[string]any); ok {
@@ -466,15 +478,16 @@ func controllerFSPathError(method string, params any, code int, message string) 
 			path = value
 		}
 	}
-	err := fs.ErrInvalid
-	msg := strings.ToLower(message)
-	if strings.Contains(msg, "not found") || strings.Contains(msg, "no such") {
-		err = fs.ErrNotExist
-	}
-	if code == -32009 {
+	switch code {
+	case controllerFSRPCForbidden:
+		return &fs.PathError{Op: method, Path: path, Err: fmt.Errorf("%w: %s", fs.ErrPermission, message)}
+	case controllerFSRPCNotFound:
+		return &fs.PathError{Op: method, Path: path, Err: fmt.Errorf("%w: %s", fs.ErrNotExist, message)}
+	case controllerFSRPCConflict:
 		return &fs.PathError{Op: method, Path: path, Err: fmt.Errorf("ECONFLICT: %s", message)}
+	default:
+		return &fs.PathError{Op: method, Path: path, Err: fmt.Errorf("%w: %s", fs.ErrInvalid, message)}
 	}
-	return &fs.PathError{Op: method, Path: path, Err: fmt.Errorf("%w: %s", err, message)}
 }
 
 func (fi controllerFSFileInfo) Name() string {
@@ -569,3 +582,4 @@ func (fd *controllerFSRemoteFD) Chmod(mode fs.FileMode) error {
 func (fd *controllerFSRemoteFD) Chown(uid, gid int) error {
 	return fd.fs.call("fs.fchown", map[string]any{"fd": fd.id, "uid": uid, "gid": gid}, nil)
 }
+

--- a/jsh/engine/proc_process.go
+++ b/jsh/engine/proc_process.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -129,7 +130,15 @@ func (jr *JSRuntime) cleanupStaleProcessEntries(mountPoint string) error {
 		if entry == nil || !entry.IsDir() {
 			continue
 		}
-		pidDir := pathpkg.Join(rootDir, entry.Name())
+		entryName := strings.TrimSpace(entry.Name())
+		// Accept only numeric PID directories to avoid path traversal or synthetic entries like "."/"..".
+		if entryName == "" || entryName == "." || entryName == ".." || strings.Contains(entryName, "/") {
+			continue
+		}
+		if _, convErr := strconv.Atoi(entryName); convErr != nil {
+			continue
+		}
+		pidDir := pathpkg.Join(rootDir, entryName)
 		metaBytes, metaErr := jr.filesystem.ReadFile(pathpkg.Join(pidDir, "meta.json"))
 		statusBytes, statusErr := jr.filesystem.ReadFile(pathpkg.Join(pidDir, "status.json"))
 		if metaErr != nil || statusErr != nil {
@@ -210,11 +219,11 @@ func (jr *JSRuntime) removeProcessEntryDir(name string) error {
 		".status.json.tmp",
 	} {
 		childPath := pathpkg.Join(name, child)
-		if err := jr.filesystem.Remove(childPath); err != nil && err != fs.ErrNotExist {
+		if err := jr.filesystem.Remove(childPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}
 	}
-	if err := jr.filesystem.Remove(name); err != nil && err != fs.ErrNotExist {
+	if err := jr.filesystem.Remove(name); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
 	return nil

--- a/jsh/service/rpc.go
+++ b/jsh/service/rpc.go
@@ -23,6 +23,7 @@ const (
 	jsonRPCMethodMiss   = -32601
 	jsonRPCInvalidParam = -32602
 	jsonRPCInternal     = -32603
+	jsonRPCForbidden    = -32003
 	jsonRPCNotFound     = -32004
 	jsonRPCConflict     = -32009
 )
@@ -851,6 +852,9 @@ func mapSharedFSError(err error) *controllerRPCError {
 	if errors.Is(err, fs.ErrNotExist) {
 		return &controllerRPCError{Code: jsonRPCNotFound, Message: err.Error()}
 	}
+	if errors.Is(err, fs.ErrPermission) {
+		return &controllerRPCError{Code: jsonRPCForbidden, Message: err.Error()}
+	}
 	return invalidParamsError(err)
 }
 
@@ -973,11 +977,12 @@ func (ctl *Controller) sharedWriteFileRPC(name string, encoded string) (SharedFi
 
 func (ctl *Controller) sharedWriteFile(name string, data []byte) error {
 	path := engine.CleanPath(name)
-	return ctl.mutateSharedFS(func(vfs *engine.VirtualFS) error {
+	err := ctl.mutateSharedFS(func(vfs *engine.VirtualFS) error {
 		return vfs.WriteFile(path, data)
 	}, func() error {
 		return ctl.persistSharedWriteFile(path, data)
 	})
+	return err
 }
 
 func (ctl *Controller) sharedWriteFileMode(name string, data []byte, mode uint32) error {
@@ -1026,11 +1031,15 @@ func (ctl *Controller) sharedMkdir(name string) error {
 
 func (ctl *Controller) sharedRemove(name string) error {
 	path := engine.CleanPath(name)
-	return ctl.mutateSharedFS(func(vfs *engine.VirtualFS) error {
+	if path == "/" {
+		return fmt.Errorf("%w: remove /: operation not permitted", fs.ErrPermission)
+	}
+	err := ctl.mutateSharedFS(func(vfs *engine.VirtualFS) error {
 		return vfs.Remove(path)
 	}, func() error {
 		return ctl.persistSharedRemove(path)
 	})
+	return err
 }
 
 func (ctl *Controller) sharedRename(oldName string, newName string) error {

--- a/mods/server/http_public.go
+++ b/mods/server/http_public.go
@@ -150,8 +150,18 @@ func (svr *httpd) handlePublic(ctx *gin.Context) {
 
 		env := contextToCGIEnv(ctx, path)
 		// ServiceController
-		env[engine.ControllerSharedMountEnv] = svr.authServer.serviceController.SharedMountPoint()
-		env[engine.ControllerAddressEnv] = svr.authServer.serviceController.Address()
+		controllerAddr := ""
+		sharedMount := engine.DefaultControllerSharedMount
+		if svr.authServer != nil && svr.authServer.serviceController != nil {
+			controllerAddr = svr.authServer.serviceController.Address()
+			sharedMount = svr.authServer.serviceController.SharedMountPoint()
+		}
+		if controllerAddr == "" {
+			handleError(ctx, http.StatusInternalServerError, "service controller is not available", tick)
+			return
+		}
+		env[engine.ControllerSharedMountEnv] = sharedMount
+		env[engine.ControllerAddressEnv] = controllerAddr
 		// Common env
 		env["HOME"] = "/work"
 		env["PWD"] = mountPoint + filepath.Dir(cgiPath)

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -262,19 +262,23 @@ func (s *Server) Start() error {
 	// This code for the shared info is temporary.
 	// We need to consider more about what information
 	// should be shared and how to share it in the future.
-	s.writeSharedInfo("/share/ports.json", sharedPorts)
+	if err := s.writeSharedInfo("/share/ports.json", sharedPorts); err != nil {
+		return fmt.Errorf("write shared ports info, %w", err)
+	}
 	// TODO: remove the default credential info from shared info
 	// This can not work well. Becuase the password can be changed by users.
 	machHost, machPort, err := s.getBestMachPort()
 	if err != nil {
 		return fmt.Errorf("best MACH port, %s", err.Error())
 	}
-	s.writeSharedInfo("/share/db.json", map[string]any{
+	if err := s.writeSharedInfo("/share/db.json", map[string]any{
 		"host":     machHost,
 		"port":     machPort,
 		"user":     "sys",
 		"password": "manager",
-	})
+	}); err != nil {
+		return fmt.Errorf("write shared db info, %w", err)
+	}
 	// ready message
 	svcPorts, err := s.getServicePorts("http")
 	if err != nil {
@@ -307,13 +311,18 @@ func (s *Server) Start() error {
 
 // write virtual files on shared dir, for example, for cli configuration
 func (s *Server) writeSharedInfo(filename string, data any) error {
+	if s.serviceController == nil {
+		return fmt.Errorf("service controller is not initialized")
+	}
 	filename = "/" + strings.TrimPrefix(filename, "/")
+	var err error
 	switch val := data.(type) {
 	case string:
-		return s.serviceController.WriteSharedFileString(filename, val)
+		err = s.serviceController.WriteSharedFileString(filename, val)
 	default:
-		return s.serviceController.WriteSharedFileJSON(filename, val)
+		err = s.serviceController.WriteSharedFileJSON(filename, val)
 	}
+	return err
 }
 
 func (s *Server) StartHeadless() error {

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -356,6 +356,38 @@ func TestWriteSharedInfo(t *testing.T) {
 	require.Contains(t, string(configBody), "\"port\": 5656")
 }
 
+func TestWriteSharedInfoWithoutBackend(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, "services"), 0o755))
+
+	ctl, err := service.NewController(&service.ControllerConfig{
+		ConfigDir: "/work/services",
+		Mounts: []engine.FSTab{
+			{MountPoint: "/work", FS: os.DirFS(tmpDir)},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, ctl.Start(nil))
+	defer ctl.Stop(nil)
+
+	svr := &Server{serviceController: ctl}
+	require.NoError(t, svr.writeSharedInfo("/share/db.json", map[string]any{
+		"host": "127.0.0.1",
+		"port": 5656,
+		"user": "sys",
+	}))
+
+	cfs, err := engine.NewControllerFS(ctl.Address())
+	require.NoError(t, err)
+	defer cfs.Close()
+
+	body, err := cfs.ReadFile("/share/db.json")
+	require.NoError(t, err)
+	require.Contains(t, string(body), "\"host\": \"127.0.0.1\"")
+	require.Contains(t, string(body), "\"port\": 5656")
+	require.Contains(t, string(body), "\"user\": \"sys\"")
+}
+
 type ShellTestCase struct {
 	name      string
 	args      []string


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to filesystem path validation, error handling, and service initialization robustness. The main themes are enhanced security for filesystem operations, improved error mapping and reporting, and more reliable service startup. Below are the most important changes:

**Filesystem Path Validation and Security:**
* Strengthened validation in `ControllerFS.Remove` to prevent invalid or dangerous path removals (e.g., empty, root, or current directory), returning a permission error for such cases (`jsh/engine/fs_controller.go`).
* Updated process entry cleanup to only accept numeric PID directories, avoiding path traversal and synthetic entries like `"."` or `".."` (`jsh/engine/proc_process.go`).

**Error Handling and Mapping:**
* Introduced explicit error codes for forbidden, not found, and conflict errors in both the engine and service layers, ensuring consistent error mapping between server and client (`jsh/engine/fs_controller.go`, `jsh/service/rpc.go`) [[1]](diffhunk://#diff-bf2167d12a82282468c66385f9792a808e6338a5768abbe6281f593debe37575R464-R471) [[2]](diffhunk://#diff-bf2167d12a82282468c66385f9792a808e6338a5768abbe6281f593debe37575L469-L477) [[3]](diffhunk://#diff-159194f11ed75d11fa502b08b96920b836c581398d20523666f6ed2afea278c2R26) [[4]](diffhunk://#diff-159194f11ed75d11fa502b08b96920b836c581398d20523666f6ed2afea278c2R855-R857).
* Improved error handling in process entry removal to use `errors.Is` for better compatibility with wrapped errors (`jsh/engine/proc_process.go`).
* Modified the shared filesystem remove operation to explicitly forbid removing the root directory, returning a permission error (`jsh/service/rpc.go`).

**Service Initialization and Robustness:**
* Enhanced `Server.Start()` and `writeSharedInfo` to check for service controller initialization and propagate errors, preventing nil pointer dereferences and improving startup reliability (`mods/server/server.go`) [[1]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL265-R281) [[2]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdR314-R325).
* Improved error handling in public HTTP handler to check for service controller availability before setting environment variables, returning a 500 error if unavailable (`mods/server/http_public.go`).

**Testing:**
* Added a new test to verify `writeSharedInfo` works correctly even when the backend is not fully initialized, increasing test coverage for edge cases (`mods/server/server_test.go`).

These changes collectively improve the security, reliability, and maintainability of the filesystem and service controller subsystems.…ystem operations