### PR TITLE
Implement dynamic loading for virtual files and shared file functionality

### DIFF
--- a/jsh/engine/virtual_fs.go
+++ b/jsh/engine/virtual_fs.go
@@ -27,8 +27,17 @@ type VirtualFS struct {
 }
 
 type virtualFileEntry struct {
-	data []byte
-	prop VirtualFileProperty
+	data   []byte
+	loader func() []byte
+	prop   VirtualFileProperty
+}
+
+// getData returns the file content, invoking the lazy loader if set.
+func (e *virtualFileEntry) getData() []byte {
+	if e.loader != nil {
+		return e.loader()
+	}
+	return e.data
 }
 
 var _ fs.FS = (*VirtualFS)(nil)
@@ -56,10 +65,14 @@ func (vfs *VirtualFS) Clone() *VirtualFS {
 		clone.dirs[dirPath] = prop
 	}
 	for filePath, entry := range vfs.files {
-		clone.files[filePath] = &virtualFileEntry{
-			data: cloneVirtualBytes(entry.data),
-			prop: entry.prop,
+		newEntry := &virtualFileEntry{
+			loader: entry.loader,
+			prop:   entry.prop,
 		}
+		if entry.loader == nil {
+			newEntry.data = cloneVirtualBytes(entry.data)
+		}
+		clone.files[filePath] = newEntry
 	}
 	return clone
 }
@@ -67,16 +80,25 @@ func (vfs *VirtualFS) Clone() *VirtualFS {
 type VirtualFileContent []byte
 
 // AddFile adds a virtual file entry with caller-provided content and metadata.
-// The content must be []byte or string.
+// The content must be []byte, string, or func() []byte.
+// If content is func() []byte, it is stored as a lazy loader and called on each Open or ReadFile.
 func (vfs *VirtualFS) AddFile(name string, content any, prop VirtualFileProperty) error {
 	rel, err := normalizeVirtualPath("create", name, false)
 	if err != nil {
 		return err
 	}
 
-	data, err := toVirtualBytes(content)
-	if err != nil {
-		return err
+	var (
+		data   []byte
+		loader func() []byte
+	)
+	if fn, ok := content.(func() []byte); ok {
+		loader = fn
+	} else {
+		data, err = toVirtualBytes(content)
+		if err != nil {
+			return err
+		}
 	}
 
 	vfs.mu.Lock()
@@ -111,7 +133,7 @@ func (vfs *VirtualFS) AddFile(name string, content any, prop VirtualFileProperty
 
 	prop = normalizeVirtualProperty(prop)
 	vfs.ensureParentDirsLocked(rel, prop.ModTime)
-	vfs.files[rel] = &virtualFileEntry{data: data, prop: prop}
+	vfs.files[rel] = &virtualFileEntry{data: data, loader: loader, prop: prop}
 	return nil
 }
 
@@ -135,6 +157,9 @@ func (vfs *VirtualFS) WriteFile(name string, data []byte) error {
 	stamp := defaultTimestamp
 	mode := fs.FileMode(0)
 	if entry, exists := vfs.files[rel]; exists {
+		if entry.loader != nil {
+			return &fs.PathError{Op: "writefile", Path: name, Err: fs.ErrPermission}
+		}
 		stamp = entry.prop.CreateTime
 		mode = entry.prop.Mode
 	}
@@ -212,6 +237,9 @@ func (vfs *VirtualFS) AppendFile(name string, data []byte) error {
 		}
 	}
 	if entry, exists := vfs.files[rel]; exists {
+		if entry.loader != nil {
+			return &fs.PathError{Op: "appendfile", Path: name, Err: fs.ErrPermission}
+		}
 		entry.data = append(entry.data, data...)
 		entry.prop.ModTime = defaultTimestamp
 		vfs.touchParentDirsLocked(rel, entry.prop.ModTime)
@@ -403,8 +431,9 @@ func (vfs *VirtualFS) Open(name string) (fs.File, error) {
 	defer vfs.mu.RUnlock()
 
 	if entry, ok := vfs.files[rel]; ok {
-		info := buildVirtualFileInfo(path.Base(rel), false, int64(len(entry.data)), entry.prop.ModTime, entry.prop.CreateTime, entry.prop.Mode)
-		return &virtualOpenFile{reader: bytes.NewReader(entry.data), info: info}, nil
+		d := entry.getData()
+		info := buildVirtualFileInfo(path.Base(rel), false, int64(len(d)), entry.prop.ModTime, entry.prop.CreateTime, entry.prop.Mode)
+		return &virtualOpenFile{reader: bytes.NewReader(d), info: info}, nil
 	}
 
 	if !vfs.hasDirLocked(rel) {
@@ -429,8 +458,9 @@ func (vfs *VirtualFS) ReadFile(name string) ([]byte, error) {
 	if !ok {
 		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
 	}
-	ret := make([]byte, len(entry.data))
-	copy(ret, entry.data)
+	d := entry.getData()
+	ret := make([]byte, len(d))
+	copy(ret, d)
 	return ret, nil
 }
 
@@ -444,7 +474,7 @@ func (vfs *VirtualFS) Stat(name string) (fs.FileInfo, error) {
 	defer vfs.mu.RUnlock()
 
 	if entry, ok := vfs.files[rel]; ok {
-		return buildVirtualFileInfo(path.Base(rel), false, int64(len(entry.data)), entry.prop.ModTime, entry.prop.CreateTime, entry.prop.Mode), nil
+		return buildVirtualFileInfo(path.Base(rel), false, int64(len(entry.getData())), entry.prop.ModTime, entry.prop.CreateTime, entry.prop.Mode), nil
 	}
 	if prop, ok := vfs.dirPropLocked(rel); ok {
 		return buildVirtualFileInfo(dirName(rel), true, 0, prop.ModTime, prop.CreateTime, prop.Mode), nil
@@ -552,7 +582,7 @@ func (vfs *VirtualFS) readDirLocked(rel string) []fs.DirEntry {
 			ret = append(ret, &virtualDirEntry{info: buildVirtualFileInfo(name, true, 0, prop.ModTime, prop.CreateTime, prop.Mode)})
 			continue
 		}
-		ret = append(ret, &virtualDirEntry{info: buildVirtualFileInfo(name, false, int64(len(c.entry.data)), c.entry.prop.ModTime, c.entry.prop.CreateTime, c.entry.prop.Mode)})
+		ret = append(ret, &virtualDirEntry{info: buildVirtualFileInfo(name, false, int64(len(c.entry.getData())), c.entry.prop.ModTime, c.entry.prop.CreateTime, c.entry.prop.Mode)})
 	}
 	return ret
 }

--- a/jsh/engine/virtual_fs_test.go
+++ b/jsh/engine/virtual_fs_test.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"fmt"
+	"io"
 	"io/fs"
 	"sort"
 	"testing"
@@ -261,5 +263,75 @@ func TestVirtualFS_MountedOnNewFS(t *testing.T) {
 	}
 	if len(rootBytes) == 0 {
 		t.Fatalf("root file is unexpectedly empty")
+	}
+}
+
+func TestVirtualFS_LazyLoaderFile(t *testing.T) {
+	vfs := NewVirtualFS()
+
+	counter := 0
+	loader := func() []byte {
+		counter++
+		return []byte(fmt.Sprintf("call-%d", counter))
+	}
+
+	if err := vfs.AddFile("dynamic.txt", loader, VirtualFileProperty{}); err != nil {
+		t.Fatalf("AddFile(loader) failed: %v", err)
+	}
+
+	// Each ReadFile call should invoke the loader freshly.
+	data1, err := fs.ReadFile(vfs, "dynamic.txt")
+	if err != nil {
+		t.Fatalf("ReadFile #1 failed: %v", err)
+	}
+	if string(data1) != "call-1" {
+		t.Fatalf("unexpected #1: %q", string(data1))
+	}
+
+	data2, err := fs.ReadFile(vfs, "dynamic.txt")
+	if err != nil {
+		t.Fatalf("ReadFile #2 failed: %v", err)
+	}
+	if string(data2) != "call-2" {
+		t.Fatalf("unexpected #2: %q", string(data2))
+	}
+
+	// Open + Read should also invoke the loader.
+	f, err := vfs.Open("dynamic.txt")
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if string(buf) != "call-3" {
+		t.Fatalf("unexpected open-read: %q", string(buf))
+	}
+
+	// Stat size reflects each invocation's returned length.
+	info, err := fs.Stat(vfs, "dynamic.txt")
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	// "call-4" is 6 bytes
+	if info.Size() != 6 {
+		t.Fatalf("unexpected stat size: %d", info.Size())
+	}
+
+	// WriteFile on a loader file must be rejected.
+	if err := vfs.WriteFile("dynamic.txt", []byte("x")); err == nil {
+		t.Fatal("WriteFile on loader file should fail")
+	}
+
+	// AppendFile on a loader file must be rejected.
+	if err := vfs.AppendFile("dynamic.txt", []byte("x")); err == nil {
+		t.Fatal("AppendFile on loader file should fail")
+	}
+
+	// AddFile duplicate must still fail.
+	if err := vfs.AddFile("dynamic.txt", loader, VirtualFileProperty{}); err == nil {
+		t.Fatal("duplicate AddFile should fail")
 	}
 }

--- a/jsh/sbin/servicectl.js
+++ b/jsh/sbin/servicectl.js
@@ -101,10 +101,10 @@
         console.println('  details delete <service_name> <key>');
         console.println('  controller [metrics|get|reset]');
         console.println('Examples:');
-        console.println('  servicectl --controller=127.0.0.1:1234 details get alpha --format json');
-        console.println('  servicectl --controller=127.0.0.1:1234 details set alpha retries 3 --detail-type number');
-        console.println('  servicectl --controller=127.0.0.1:1234 details set alpha enabled true --detail-type boolean');
-        console.println("  servicectl --controller=127.0.0.1:1234 details set alpha labels '{\"tier\":\"gold\"}' --detail-type object");
+        console.println('  servicectl details get alpha --format json');
+        console.println('  servicectl details set alpha retries 3 --detail-type number');
+        console.println('  servicectl details set alpha enabled true --detail-type boolean');
+        console.println("  servicectl details set alpha labels '{\"tier\":\"gold\"}' --detail-type object");
     }
 
     function fail(message) {

--- a/jsh/service/rpc.go
+++ b/jsh/service/rpc.go
@@ -949,6 +949,13 @@ func (ctl *Controller) SharedMountPoint() string {
 	return ctl.sharedMountPoint
 }
 
+func (ctl *Controller) AddSharedFile(name string, content any, prop engine.VirtualFileProperty) error {
+	path := engine.CleanPath(name)
+	ctl.sharedMu.Lock()
+	defer ctl.sharedMu.Unlock()
+	return ctl.sharedFS.AddFile(path, content, prop)
+}
+
 func (ctl *Controller) WriteSharedFileString(name string, str string) error {
 	return ctl.sharedWriteFile(name, []byte(str))
 }

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -271,14 +271,37 @@ func (s *Server) Start() error {
 	if err != nil {
 		return fmt.Errorf("best MACH port, %s", err.Error())
 	}
-	if err := s.writeSharedInfo("/share/db.json", map[string]any{
+	sharedInfo := map[string]any{
 		"host":     machHost,
 		"port":     machPort,
 		"user":     "sys",
 		"password": "manager",
-	}); err != nil {
+	}
+	if err := s.writeSharedInfo("/share/db.json", sharedInfo); err != nil {
 		return fmt.Errorf("write shared db info, %w", err)
 	}
+	sharedInfo = map[string]interface{}{
+		"machbase": map[string]any{
+			"home": s.Config.DataDir,
+		},
+		"http": map[string]any{
+			"listeners":         s.Config.Http.Listeners,
+			"enable-token-auth": s.Config.Http.EnableTokenAuth,
+		},
+		"mqtt": map[string]any{
+			"listeners":         s.Config.Mqtt.Listeners,
+			"enable-token-auth": s.Config.Mqtt.EnableTokenAuth,
+			"enable-tls":        s.Config.Mqtt.EnableTls,
+		},
+	}
+	if err := s.writeSharedInfo("/share/boot.json", sharedInfo); err != nil {
+		return fmt.Errorf("write shared boot options, %w", err)
+	}
+
+	s.addVStatFile("/share/now.json", func() []byte {
+		return []byte(fmt.Sprintf(`{"now":%q}`+"\n", time.Now().Format(time.RFC3339Nano)))
+	})
+
 	// ready message
 	svcPorts, err := s.getServicePorts("http")
 	if err != nil {
@@ -1063,6 +1086,15 @@ func (s *Server) initServiceController() error {
 
 	s.registerJsonRpcHandlers()
 	return nil
+}
+
+func (s *Server) addVStatFile(name string, fn func() []byte) {
+	prop := engine.VirtualFileProperty{
+		CreateTime: time.Now(),
+		ModTime:    time.Now(),
+		Mode:       0400,
+	}
+	s.serviceController.AddSharedFile(name, fn, prop)
 }
 
 func (s *Server) registerJsonRpcHandlers() {


### PR DESCRIPTION
This pull request introduces support for lazily-loaded virtual files in the `VirtualFS` system, allowing file contents to be generated dynamically each time they are accessed. It also adds robust tests for this feature, updates the server to use dynamic shared files, and makes minor improvements to documentation and usage examples.

**VirtualFS: Dynaic Loader Support**

* Added support for virtual files whose content is provided by a `func() []byte` loader. Such files generate their content on each access (`Open`, `ReadFile`, etc.), and cannot be modified via `WriteFile` or `AppendFile`. [[1]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711R31-R42) [[2]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711L59-R102) [[3]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711L114-R136) [[4]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711R160-R162) [[5]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711R240-R242) [[6]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711L406-R436) [[7]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711L432-R463) [[8]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711L447-R477) [[9]](diffhunk://#diff-e15703e5ade3cb6336e11a0158642ea942f218b878f49373e06c619a7c158711L555-R585)

* Comprehensive tests were added to verify lazy loader behavior, including dynamic content generation, correct file size reporting, and enforcement of immutability.

**Server Integration**

* The server now uses the new lazy loader mechanism to provide a dynamic `/share/now.json` file that always returns the current timestamp in JSON format. [[1]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL274-R304) [[2]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdR1091-R1099)

* Added a method to the service controller to allow adding shared files with arbitrary content providers, supporting the new loader feature.

**Other Improvements**

* Updated usage examples in `servicectl.js` to remove redundant controller address arguments for clarity.