### PR TITLE
Fix service state management and enhance context handling

### DIFF
--- a/jsh/engine/engine.go
+++ b/jsh/engine/engine.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"runtime"
 	"runtime/debug"
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dop251/goja"
@@ -40,6 +42,9 @@ type JSRuntime struct {
 	procCommand     string
 	procArgs        []string
 	nowFunc         func() time.Time
+	// vmRef holds the goja.Runtime set right before the script runs so that
+	// RunContext can call vm.Interrupt() from a goroutine (goroutine-safe).
+	vmRef atomic.Pointer[goja.Runtime]
 }
 
 type ExecOptions struct {
@@ -71,9 +76,21 @@ func (jr *JSRuntime) RunContext(ctx context.Context) error {
 	go func() {
 		select {
 		case <-ctx.Done():
-			jr.eventLoop.Run(func(vm *goja.Runtime) {
+			// Wait for the vm reference to become available (set at the start of
+			// the event loop callback in Run, typically within nanoseconds).
+			for jr.vmRef.Load() == nil {
+				select {
+				case <-done:
+					return
+				default:
+					runtime.Gosched()
+				}
+			}
+			// vm.Interrupt is goroutine-safe and works even while the JS runtime
+			// is blocked in a tight loop (checked on every backward jump).
+			if vm := jr.vmRef.Load(); vm != nil {
 				vm.Interrupt(ctx.Err())
-			})
+			}
 		case <-done:
 		}
 	}()
@@ -128,6 +145,8 @@ func (jr *JSRuntime) Run() error {
 	}
 	var retErr error = nil
 	jr.eventLoop.Run(func(vm *goja.Runtime) {
+		// Store vm reference so RunContext can call vm.Interrupt() from a goroutine.
+		jr.vmRef.Store(vm)
 		buffer.Enable(vm)
 		url.Enable(vm)
 		vm.SetFieldNameMapper(goja.UncapFieldNameMapper())

--- a/jsh/engine/engine.go
+++ b/jsh/engine/engine.go
@@ -60,6 +60,33 @@ func (jr *JSRuntime) EventLoop() *eventloop.EventLoop {
 	return jr.eventLoop
 }
 
+func (jr *JSRuntime) RunContext(ctx context.Context) error {
+	if ctx == nil {
+		return jr.Run()
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			jr.eventLoop.Run(func(vm *goja.Runtime) {
+				vm.Interrupt(ctx.Err())
+			})
+		case <-done:
+		}
+	}()
+
+	err := jr.Run()
+	if err != nil {
+		if _, ok := err.(*goja.InterruptedError); ok && ctx.Err() != nil {
+			return ctx.Err()
+		}
+	}
+	return err
+}
+
 func (jr *JSRuntime) Run() error {
 	if jr.Env == nil {
 		jr.Env = &Env{}

--- a/jsh/engine/engine_test.go
+++ b/jsh/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/machbase/neo-server/v8/jsh/engine"
 	"github.com/machbase/neo-server/v8/jsh/lib"
@@ -391,4 +393,83 @@ func TestEventLoop(t *testing.T) {
 	for _, tc := range testCases {
 		test_engine.RunTest(t, tc)
 	}
+}
+func TestRunContext(t *testing.T) {
+	t.Run("nil ctx falls through to Run", func(t *testing.T) {
+		var buf bytes.Buffer
+		jr, err := engine.New(engine.Config{
+			Code:   `console.println("ok")`,
+			Writer: &buf,
+		})
+		if err != nil {
+			t.Fatalf("engine.New: %v", err)
+		}
+		if err := jr.RunContext(nil); err != nil {
+			t.Fatalf("RunContext(nil): %v", err)
+		}
+		if got := strings.TrimSpace(buf.String()); got != "ok" {
+			t.Fatalf("output=%q, want %q", got, "ok")
+		}
+	})
+
+	t.Run("normal completion returns nil", func(t *testing.T) {
+		ctx := context.Background()
+		var buf bytes.Buffer
+		jr, err := engine.New(engine.Config{
+			Code:   `console.println("done")`,
+			Writer: &buf,
+		})
+		if err != nil {
+			t.Fatalf("engine.New: %v", err)
+		}
+		if err := jr.RunContext(ctx); err != nil {
+			t.Fatalf("RunContext: %v", err)
+		}
+		if got := strings.TrimSpace(buf.String()); got != "done" {
+			t.Fatalf("output=%q, want %q", got, "done")
+		}
+	})
+
+	t.Run("cancelled ctx returns ctx error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		jr, err := engine.New(engine.Config{
+			// Script loops indefinitely; cancellation interrupts it.
+			Code: `while(true) {}`,
+		})
+		if err != nil {
+			t.Fatalf("engine.New: %v", err)
+		}
+
+		go func() {
+			// Give the event loop a moment to start before cancelling.
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+
+		runErr := jr.RunContext(ctx)
+		if runErr == nil {
+			t.Fatal("RunContext should return an error when ctx is cancelled")
+		}
+		if runErr != context.Canceled {
+			t.Fatalf("RunContext error = %v, want context.Canceled", runErr)
+		}
+	})
+
+	t.Run("script error propagates when ctx is still active", func(t *testing.T) {
+		ctx := context.Background()
+		jr, err := engine.New(engine.Config{
+			Code: `throw new Error("boom")`,
+		})
+		if err != nil {
+			t.Fatalf("engine.New: %v", err)
+		}
+		runErr := jr.RunContext(ctx)
+		if runErr == nil {
+			t.Fatal("RunContext should return an error for a thrown exception")
+		}
+		if strings.Contains(runErr.Error(), "boom") == false {
+			t.Fatalf("RunContext error = %v, want it to contain 'boom'", runErr)
+		}
+	})
 }

--- a/jsh/service/controller.go
+++ b/jsh/service/controller.go
@@ -407,10 +407,15 @@ func (ctl *Controller) startServiceInstance(svc *Service, sc *Config) {
 	svc.startCh = make(chan struct{})
 	svc.stopCh = make(chan struct{})
 	clientID := svc.sharedClientID
+	// Capture channels and cmd by value so that the goroutine never reads
+	// svc.stopCh/startCh/cmd after they may have been replaced by a concurrent
+	// restart (e.g. inside Update or Reload which hold ctl.mu).
+	myCmd := svc.cmd
+	myStartCh := svc.startCh
+	myStopCh := svc.stopCh
 	go func() {
-		close(svc.startCh)
-		defer close(svc.stopCh)
-		err := svc.cmd.Wait()
+		close(myStartCh)
+		err := myCmd.Wait()
 		stdoutWriter.Flush()
 		stderrWriter.Flush()
 		exitCode := 0
@@ -421,14 +426,22 @@ func (ctl *Controller) startServiceInstance(svc *Service, sc *Config) {
 				exitCode = -1
 			}
 		}
+		// Signal waiters before acquiring controller lock to avoid lock-wait cycles.
+		close(myStopCh)
 		ctl.mu.Lock()
 		defer ctl.mu.Unlock()
 		ctl.cleanupSharedFDsByOwner(clientID)
+		// Only update service state when we are still the active instance.
+		// If Update/Reload re-started the service while we were waiting, svc.stopCh
+		// will point to a newer channel and we must not clobber the new state.
+		if svc.stopCh != myStopCh {
+			return
+		}
 		svc.ExitCode = exitCode
 		svc.Status = ServiceStatusStopped
 		svc.sharedClientID = ""
 	}()
-	<-svc.startCh
+	<-myStartCh
 }
 
 func (ctl *Controller) stopServiceInstance(svc *Service, sc *Config) {
@@ -461,6 +474,7 @@ func (ctl *Controller) stopServiceInstance(svc *Service, sc *Config) {
 		return
 	}
 	<-svc.stopCh
+	svc.Status = ServiceStatusStopped
 	svc.Error = nil
 }
 

--- a/jsh/service/controller_test.go
+++ b/jsh/service/controller_test.go
@@ -148,6 +148,50 @@ func TestControllerStopServiceReturnsUpdatedStatus(t *testing.T) {
 	}
 }
 
+func TestControllerStopServiceNoDeadlockOnWaitGoroutineLockContention(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skip on windows due to sleep command compatibility")
+	}
+
+	ctl := &Controller{
+		launcher: []string{"env"},
+		services: map[string]*Service{
+			"svc-a": {
+				Config: Config{Name: "svc-a", Enable: true, Executable: "sleep", Args: []string{"30"}},
+				Status: ServiceStatusStopped,
+			},
+		},
+	}
+
+	svc, err := ctl.StartService("svc-a")
+	if err != nil {
+		t.Fatalf("StartService() error: %v", err)
+	}
+	if svc == nil || svc.cmd == nil || svc.cmd.Process == nil {
+		t.Fatal("StartService() did not create a running process")
+	}
+	defer func() {
+		if svc.cmd != nil && svc.cmd.Process != nil {
+			_ = svc.cmd.Process.Kill()
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, stopErr := ctl.StopService("svc-a")
+		done <- stopErr
+	}()
+
+	select {
+	case stopErr := <-done:
+		if stopErr != nil {
+			t.Fatalf("StopService() error: %v", stopErr)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("StopService() blocked (possible deadlock)")
+	}
+}
+
 func TestControllerStartServiceReturnsUpdatedStatus(t *testing.T) {
 	ctl := &Controller{
 		services: map[string]*Service{
@@ -2310,4 +2354,129 @@ func TestRPCUtilityFunctionsAndDispatchErrors(t *testing.T) {
 			t.Fatalf("reloadSnapshot services=%v, want 2 services", result.Services)
 		}
 	})
+}
+
+// TestControllerUpdateDoesNotClobberRestartedService reproduces the state-clobber
+// bug where the wait goroutine from the previous run (G1) acquires ctl.mu AFTER
+// Update() has already re-started the service (G2) and overwrites the running
+// status back to Stopped, effectively making the service invisible as running.
+//
+// The root cause is that startServiceInstance captures svc by pointer in the
+// goroutine closure. When Update() stops and immediately restarts the service while
+// holding ctl.mu, the old goroutine (G1) eventually acquires the lock and writes
+// svc.Status = ServiceStatusStopped over the newly running G2.
+//
+// Expected before fix: status is Stopped (clobbered) or sharedClientID is empty
+// Expected after fix:  status remains Running
+func TestControllerUpdateDoesNotClobberRestartedService(t *testing.T) {
+	ctl := &Controller{
+		launcher: []string{"env"},
+		services: map[string]*Service{
+			"svc-a": {
+				Config: Config{Name: "svc-a", Enable: true, Executable: "sleep", Args: []string{"30"}},
+				Status: ServiceStatusStopped,
+			},
+		},
+	}
+
+	// Start the service so a wait goroutine (G1) is running.
+	_, err := ctl.StartService("svc-a")
+	if err != nil {
+		t.Fatalf("StartService: %v", err)
+	}
+
+	// Confirm it's running.
+	snap := ctl.StatusOf("svc-a")
+	if snap.Status != ServiceStatusRunning {
+		t.Fatalf("before Update: status=%s, want running", snap.Status)
+	}
+
+	// Trigger an Update with the same service marked as "Updated" (config unchanged
+	// content-wise but present in reread.Updated simulates a config reload).
+	updatedCfg := Config{Name: "svc-a", Enable: true, Executable: "sleep", Args: []string{"30"}}
+	ctl.mu.Lock()
+	ctl.reread = &ServiceList{
+		Updated: []*Config{&updatedCfg},
+	}
+	ctl.mu.Unlock()
+
+	ctl.Update(nil)
+
+	// Give G1 (the goroutine from the first run) enough time to acquire ctl.mu
+	// and potentially clobber the state.  100 ms is ample for a goroutine that is
+	// only blocked on a mutex.
+	time.Sleep(100 * time.Millisecond)
+
+	snap = ctl.StatusOf("svc-a")
+	if snap == nil {
+		t.Fatal("after Update: service not found")
+	}
+	if snap.Status != ServiceStatusRunning {
+		t.Fatalf("after Update: status=%s, want running (old goroutine clobbered state)", snap.Status)
+	}
+	// sharedClientID is not included in the StatusOf snapshot; access live svc directly.
+	ctl.mu.RLock()
+	clientID := ctl.services["svc-a"].sharedClientID
+	ctl.mu.RUnlock()
+	if clientID == "" {
+		t.Fatal("after Update: sharedClientID is empty (old goroutine cleared it)")
+	}
+
+	// Cleanup: stop the restarted service.
+	ctl.StopService("svc-a") //nolint:errcheck
+}
+
+// TestControllerReloadDoesNotClobberRestartedServices is the same scenario for
+// the Reload() path, which stops all running services then re-starts them in one
+// locked call.
+func TestControllerReloadDoesNotClobberRestartedServices(t *testing.T) {
+	ctl := &Controller{
+		launcher: []string{"env"},
+		services: map[string]*Service{
+			"svc-a": {
+				Config: Config{Name: "svc-a", Enable: true, Executable: "sleep", Args: []string{"30"}},
+				Status: ServiceStatusStopped,
+			},
+		},
+	}
+
+	_, err := ctl.StartService("svc-a")
+	if err != nil {
+		t.Fatalf("StartService: %v", err)
+	}
+
+	snap := ctl.StatusOf("svc-a")
+	if snap.Status != ServiceStatusRunning {
+		t.Fatalf("before Reload: status=%s, want running", snap.Status)
+	}
+
+	// Simulate a Reload that keeps svc-a (Unchanged) — Reload stops all running
+	// services and restarts all enabled ones, so G1 is spawned before Reload and
+	// G2 is spawned inside Reload.
+	ctl.mu.Lock()
+	ctl.reread = &ServiceList{
+		Unchanged: []*Config{{Name: "svc-a", Enable: true, Executable: "sleep", Args: []string{"30"}}},
+	}
+	ctl.mu.Unlock()
+
+	ctl.Reload(nil)
+
+	time.Sleep(100 * time.Millisecond)
+
+	snap = ctl.StatusOf("svc-a")
+	if snap == nil {
+		t.Fatal("after Reload: service not found")
+	}
+	if snap.Status != ServiceStatusRunning {
+		t.Fatalf("after Reload: status=%s, want running (old goroutine clobbered state)", snap.Status)
+	}
+	// sharedClientID is not included in the StatusOf snapshot; access live svc directly.
+	ctl.mu.RLock()
+	clientID := ctl.services["svc-a"].sharedClientID
+	ctl.mu.RUnlock()
+	if clientID == "" {
+		t.Fatal("after Reload: sharedClientID is empty (old goroutine cleared it)")
+	}
+
+	ctl.StopService("svc-a") //nolint:errcheck
 }

--- a/mods/server/http_public.go
+++ b/mods/server/http_public.go
@@ -84,6 +84,7 @@ This is an implementation-defined extension and is not part of standard parsed C
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -205,7 +206,11 @@ func (svr *httpd) handlePublic(ctx *gin.Context) {
 			return
 		}
 		lib.Enable(jr)
-		if err := jr.Run(); err != nil {
+		if err := jr.RunContext(ctx.Request.Context()); err != nil {
+			if errors.Is(ctx.Request.Context().Err(), context.Canceled) ||
+				errors.Is(ctx.Request.Context().Err(), context.DeadlineExceeded) {
+				return
+			}
 			msg := "engine run error: " + err.Error()
 			msg = appendCgiDiagnostic(msg, stdoutCapture.String(), stderrCapture.String())
 			handleError(ctx, http.StatusInternalServerError, msg, tick)

--- a/mods/tql/fm_script.go
+++ b/mods/tql/fm_script.go
@@ -163,7 +163,7 @@ func newJSContext(node *Node, initCode string, mainCode string, deinitCode strin
 	}
 
 	// it should run before the init code, so that the init code can use the native modules.
-	if err := jr.Run(); err != nil {
+	if err := jr.RunContext(node.task.ctx); err != nil {
 		return nil, fmt.Errorf("SCRIPT runtime, %s", err.Error())
 	}
 


### PR DESCRIPTION
This pull request addresses concurrency bugs and improves the reliability of the service controller, particularly around service restarts, state management, and context-aware JavaScript runtime execution. It introduces fixes to prevent race conditions and state clobbering when services are updated or reloaded, and adds tests to ensure these scenarios are handled correctly. Additionally, it improves the integration between HTTP request contexts and the JavaScript runtime.

**Service Controller Concurrency Fixes and State Management:**

* Refactored `startServiceInstance` in `controller.go` to capture channels and command objects by value in goroutines, preventing race conditions where a restarted service's state could be incorrectly overwritten by an old goroutine. The goroutine now checks if it is still the active instance before updating service state. [[1]](diffhunk://#diff-aa03d124ed24eb08ee7265daac00576f50014d3135c494bd0d2753af3e29d93cR410-R418) [[2]](diffhunk://#diff-aa03d124ed24eb08ee7265daac00576f50014d3135c494bd0d2753af3e29d93cR429-R444)
* Ensured `stopServiceInstance` sets the service status to `Stopped` only after the stop channel is closed, preventing premature or incorrect status updates.

**Testing for Concurrency and State Issues:**

* Added `TestControllerStopServiceNoDeadlockOnWaitGoroutineLockContention` to verify that stopping a service does not deadlock even when goroutines contend for controller locks.
* Added `TestControllerUpdateDoesNotClobberRestartedService` and `TestControllerReloadDoesNotClobberRestartedServices` to reproduce and verify fixes for state clobbering bugs during service update and reload operations.

**JavaScript Runtime and HTTP Integration:**

* Added a `RunContext` method to `JSRuntime` that allows the runtime to be interrupted via a `context.Context`, enabling graceful cancellation of long-running scripts.
* Updated HTTP handler to use `RunContext` and properly handle request cancellation and deadline errors, improving robustness for long-running HTTP requests. [[1]](diffhunk://#diff-86c559b19c30f65de08dec033c83bf4f414ca18ad814285b3e5a057e7936c50eR87) [[2]](diffhunk://#diff-86c559b19c30f65de08dec033c83bf4f414ca18ad814285b3e5a057e7936c50eL208-R213)