### PR TITLE
support jsh opcua datatype in children method

### DIFF
--- a/jsh/lib/opcua/opcua.go
+++ b/jsh/lib/opcua/opcua.go
@@ -147,6 +147,7 @@ type ChildrenResult struct {
 	DisplayName     string `json:"displayName"`
 	NodeClass       uint32 `json:"nodeClass"`
 	TypeDefinition  string `json:"typeDefinition"`
+	DataType        string `json:"dataType"`
 }
 
 type WriteValue struct {
@@ -397,7 +398,7 @@ func toBrowseResults(results []*ua.BrowseResult) []BrowseResult {
 			}
 			var typeDefStr string
 			if ref.TypeDefinition != nil && ref.TypeDefinition.NodeID != nil {
-				typeDefStr = ref.TypeDefinition.NodeID.String()
+				typeDefStr = id.Name(ref.TypeDefinition.NodeID.IntID())
 			}
 			refs = append(refs, BrowseReference{
 				ReferenceTypeId: ref.ReferenceTypeID.String(),
@@ -468,7 +469,21 @@ func (c *Client) Children(request ChildrenRequest) ([]ChildrenResult, error) {
 		}
 		var typeDefStr string
 		if ref.TypeDefinition != nil && ref.TypeDefinition.NodeID != nil {
-			typeDefStr = dataTypeNodeIDName(ref.TypeDefinition.NodeID)
+			typeDefStr = id.Name(ref.TypeDefinition.NodeID.IntID())
+		}
+		var dataType string
+		if ref.NodeID != nil && ref.NodeClass == ua.NodeClassVariable {
+			attrs, err := c.client.NodeFromExpandedNodeID(ref.NodeID).Attributes(c.ctx, ua.AttributeIDDataType)
+			if err == nil && len(attrs) > 0 {
+				if attrs[0].Status == ua.StatusOK {
+					switch v := attrs[0].Value.Value().(type) {
+					case *ua.ExpandedNodeID: // for TestServer
+						dataType = id.Name(v.NodeID.IntID())
+					case *ua.NodeID:
+						dataType = id.Name(v.IntID())
+					}
+				}
+			}
 		}
 
 		ret = append(ret, ChildrenResult{
@@ -479,64 +494,8 @@ func (c *Client) Children(request ChildrenRequest) ([]ChildrenResult, error) {
 			DisplayName:     displayName,
 			NodeClass:       uint32(ref.NodeClass),
 			TypeDefinition:  typeDefStr,
+			DataType:        dataType,
 		})
 	}
 	return ret, nil
-}
-
-func dataTypeNodeIDName(nodeID *ua.NodeID) string {
-	switch nodeID.String() {
-	case "i=1":
-		return "Boolean"
-	case "i=2":
-		return "SByte"
-	case "i=3":
-		return "Byte"
-	case "i=4":
-		return "Int16"
-	case "i=5":
-		return "UInt16"
-	case "i=6":
-		return "Int32"
-	case "i=7":
-		return "UInt32"
-	case "i=8":
-		return "Int64"
-	case "i=9":
-		return "UInt64"
-	case "i=10":
-		return "Float"
-	case "i=11":
-		return "Double"
-	case "i=12":
-		return "String"
-	case "i=13":
-		return "DateTime"
-	case "i=14":
-		return "Guid"
-	case "i=15":
-		return "ByteString"
-	case "i=16":
-		return "XmlElement"
-	case "i=17":
-		return "NodeId"
-	case "i=18":
-		return "ExpandedNodeId"
-	case "i=19":
-		return "StatusCode"
-	case "i=20":
-		return "QualifiedName"
-	case "i=21":
-		return "LocalizedText"
-	case "i=22":
-		return "ExtensionObject"
-	case "i=23":
-		return "DataValue"
-	case "i=24":
-		return "Variant"
-	case "i=25":
-		return "DiagnosticInfo"
-	default:
-		return nodeID.String()
-	}
 }

--- a/jsh/lib/opcua/opcua_internal_test.go
+++ b/jsh/lib/opcua/opcua_internal_test.go
@@ -67,44 +67,6 @@ func TestDecodeContinuationPoint(t *testing.T) {
 	}
 }
 
-func TestDataTypeNodeIDName(t *testing.T) {
-	set := map[string]string{
-		"i=1":  "Boolean",
-		"i=2":  "SByte",
-		"i=3":  "Byte",
-		"i=4":  "Int16",
-		"i=5":  "UInt16",
-		"i=6":  "Int32",
-		"i=7":  "UInt32",
-		"i=8":  "Int64",
-		"i=9":  "UInt64",
-		"i=10": "Float",
-		"i=11": "Double",
-		"i=12": "String",
-		"i=13": "DateTime",
-		"i=14": "Guid",
-		"i=15": "ByteString",
-		"i=16": "XmlElement",
-		"i=17": "NodeId",
-		"i=18": "ExpandedNodeId",
-		"i=19": "StatusCode",
-		"i=20": "QualifiedName",
-		"i=21": "LocalizedText",
-		"i=22": "ExtensionObject",
-		"i=23": "DataValue",
-		"i=24": "Variant",
-		"i=25": "DiagnosticInfo",
-	}
-
-	for id, want := range set {
-		nid := ua.MustParseNodeID(id)
-		exnid := ua.NewExpandedNodeID(nid, "", 0)
-		got := dataTypeNodeIDName(exnid.NodeID)
-		if got != want {
-			t.Fatalf("unexpected type definition(got=%s, want=%s)", got, want)
-		}
-	}
-}
 
 func TestCloseNilClient(t *testing.T) {
 	client := &Client{}

--- a/jsh/lib/opcua/opcua_test.go
+++ b/jsh/lib/opcua/opcua_test.go
@@ -190,7 +190,7 @@ func TestScriptOPCUA(t *testing.T) {
 						nodeClassMask: ua.NodeClass.Variable,
 					});
 					refs.sort((a,b) => a.browseName < b.browseName ? -1 : 1)
-						.forEach(r => console.println(r.browseName, r.nodeId, r.nodeClass));
+						.forEach(r => console.println(r.browseName, r.nodeId, r.nodeClass, r.dataType));
 				} catch(e) {
 					console.println("Error:", e);
 				} finally {
@@ -198,14 +198,14 @@ func TestScriptOPCUA(t *testing.T) {
 				}
 			`,
 			Output: []string{
-				"NoAccessVariable ns=1;s=NoAccessVariable 2",
-				"NoPermVariable ns=1;s=NoPermVariable 2",
-				"ReadOnlyVariable ns=1;s=ReadOnlyVariable 2",
-				"ReadWriteVariable ns=1;s=ReadWriteVariable 2",
-				"ro_bool ns=1;s=ro_bool 2",
-				"ro_int32 ns=1;s=ro_int32 2",
-				"rw_bool ns=1;s=rw_bool 2",
-				"rw_int32 ns=1;s=rw_int32 2",
+				"NoAccessVariable ns=1;s=NoAccessVariable 2 ",
+				"NoPermVariable ns=1;s=NoPermVariable 2 Int32",
+				"ReadOnlyVariable ns=1;s=ReadOnlyVariable 2 Double",
+				"ReadWriteVariable ns=1;s=ReadWriteVariable 2 Double",
+				"ro_bool ns=1;s=ro_bool 2 Boolean",
+				"ro_int32 ns=1;s=ro_int32 2 Int32",
+				"rw_bool ns=1;s=rw_bool 2 Boolean",
+				"rw_int32 ns=1;s=rw_int32 2 Int32",
 			},
 		},
 		{
@@ -419,14 +419,18 @@ func startOPCUAServer() *opc_server.Server {
 	// Create some nodes for it.
 	n := nodeNS.AddNewVariableStringNode("ro_bool", true)
 	n.SetAttribute(ua.AttributeIDUserAccessLevel, &ua.DataValue{EncodingMask: ua.DataValueValue, Value: ua.MustVariant(byte(1))})
+	n.SetAttribute(ua.AttributeIDDataType, opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 1)))
 	nns_obj.AddRef(n, id.HasComponent, true)
 	n = nodeNS.AddNewVariableStringNode("rw_bool", true)
+	n.SetAttribute(ua.AttributeIDDataType, opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 1)))
 	nns_obj.AddRef(n, id.HasComponent, true)
 
 	n = nodeNS.AddNewVariableStringNode("ro_int32", int32(5))
 	n.SetAttribute(ua.AttributeIDUserAccessLevel, &ua.DataValue{EncodingMask: ua.DataValueValue, Value: ua.MustVariant(byte(1))})
+	n.SetAttribute(ua.AttributeIDDataType, opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 6)))
 	nns_obj.AddRef(n, id.HasComponent, true)
 	n = nodeNS.AddNewVariableStringNode("rw_int32", int32(5))
+	n.SetAttribute(ua.AttributeIDDataType, opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 6)))
 	nns_obj.AddRef(n, id.HasComponent, true)
 
 	var3 := opc_server.NewNode(
@@ -434,6 +438,7 @@ func startOPCUAServer() *opc_server.Server {
 		map[ua.AttributeID]*ua.DataValue{
 			ua.AttributeIDBrowseName: opc_server.DataValueFromValue(attrs.BrowseName("NoPermVariable")),
 			ua.AttributeIDNodeClass:  opc_server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+			ua.AttributeIDDataType:   opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 6)),
 		},
 		nil,
 		func() *ua.DataValue { return opc_server.DataValueFromValue(int32(742)) },
@@ -448,6 +453,7 @@ func startOPCUAServer() *opc_server.Server {
 			ua.AttributeIDUserAccessLevel: opc_server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite)),
 			ua.AttributeIDBrowseName:      opc_server.DataValueFromValue(attrs.BrowseName("ReadWriteVariable")),
 			ua.AttributeIDNodeClass:       opc_server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+			ua.AttributeIDDataType:        opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 11)),
 		},
 		nil,
 		func() *ua.DataValue { return opc_server.DataValueFromValue(12.34) },
@@ -462,6 +468,7 @@ func startOPCUAServer() *opc_server.Server {
 			ua.AttributeIDUserAccessLevel: opc_server.DataValueFromValue(byte(ua.AccessLevelTypeCurrentRead)),
 			ua.AttributeIDBrowseName:      opc_server.DataValueFromValue(attrs.BrowseName("ReadOnlyVariable")),
 			ua.AttributeIDNodeClass:       opc_server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+			ua.AttributeIDDataType:        opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 11)),
 		},
 		nil,
 		func() *ua.DataValue { return opc_server.DataValueFromValue(9.87) },
@@ -476,6 +483,7 @@ func startOPCUAServer() *opc_server.Server {
 			ua.AttributeIDUserAccessLevel: opc_server.DataValueFromValue(byte(ua.AccessLevelTypeNone)),
 			ua.AttributeIDBrowseName:      opc_server.DataValueFromValue(attrs.BrowseName("NoAccessVariable")),
 			ua.AttributeIDNodeClass:       opc_server.DataValueFromValue(uint32(ua.NodeClassVariable)),
+			ua.AttributeIDDataType:        opc_server.DataValueFromValue(ua.NewNumericExpandedNodeID(0, 11)),
 		},
 		nil,
 		func() *ua.DataValue { return opc_server.DataValueFromValue(55.43) },


### PR DESCRIPTION
#383 에서 수정한 typeDef가 data type으로 생각하고 수정했으나 별도의 Attribute 로 존재해서 변경합니다.

## Summary

- `Browse` 응답의 `TypeDefinition` 필드에서 사용하던 `dataTypeNodeIDName` 삭제 후 `id.Name()` 적용
- `ChildrenResult`에 `DataType` 필드 추가 — Variable 노드에 한해 DataType Attribute 조회하여 `id.Name()`를 통해 반환
- DataType attribute 반환 타입이 서버 구현에 따라 `*ua.NodeID` 또는 `*ua.ExpandedNodeID` 로 달라질 수 있어 두 케이스 모두 처리 (OPC UA 스펙은 `NodeID` 이나 gopcua 서버는 `ExpandedNodeID` 반환)

## Test plan

- [x] `opcua-children-variables` 테스트에 `r.dataType` 출력 추가 및 expected output 업데이트
- [x] 테스트 서버 노드들에 `AttributeIDDataType` 명시적 설정 (`ua.NewNumericExpandedNodeID` 사용)
- [x] `TestDataTypeNodeIDName` 제거 (대상 함수 삭제됨)
- [x] `go test ./jsh/lib/opcua/...` 전체 통과 확인
