### PR TITLE
add opcua Attributes API and clean up ReadResult fields

### DIFF
--- a/jsh/lib/opcua/opcua.go
+++ b/jsh/lib/opcua/opcua.go
@@ -118,6 +118,7 @@ type ReadRequest struct {
 
 type ReadResult struct {
 	Status          uint32 `json:"status"`
+	StatusCode      string `json:"statusCode"`
 	Value           any    `json:"value"`
 	Type            string `json:"type"`
 	SourceTimestamp int64  `json:"sourceTimestamp"`
@@ -280,10 +281,15 @@ func (c *Client) Read(request ReadRequest) ([]ReadResult, error) {
 	}
 	ret := make([]ReadResult, 0, len(rsp.Results))
 	for _, data := range rsp.Results {
+		code := ""
+		if c, ok := ua.StatusCodes[data.Status]; ok {
+			code = c.Name
+		}
 		val := data.Value.Value()
 		typ := strings.TrimPrefix(data.Value.Type().String(), "TypeID")
 		ret = append(ret, ReadResult{
 			Status:          uint32(data.Status),
+			StatusCode:      code,
 			Value:           val,
 			Type:            typ,
 			SourceTimestamp: data.SourceTimestamp.UnixMilli(),

--- a/jsh/lib/opcua/opcua.go
+++ b/jsh/lib/opcua/opcua.go
@@ -78,6 +78,30 @@ func Module(ctx context.Context, rt *goja.Runtime, module *goja.Object) {
 		"Neither": ua.TimestampsToReturnNeither,
 		"Invalid": ua.TimestampsToReturnInvalid,
 	}))
+	// AttributeID
+	o.Set("AttributeID", rt.ToValue(map[string]any{
+		"NodeClass":       ua.AttributeIDNodeClass,
+		"BrowseName":      ua.AttributeIDBrowseName,
+		"DisplayName":     ua.AttributeIDDisplayName,
+		"Description":     ua.AttributeIDDescription,
+		"DataType":        ua.AttributeIDDataType,
+		"AccessLevel":     ua.AttributeIDAccessLevel,
+		"UserAccessLevel": ua.AttributeIDUserAccessLevel,
+	}))
+	// StatusCode
+	o.Set("StatusCode", rt.ToValue(map[string]any{
+		"Good":                   ua.StatusOK,
+		"Uncertain":              ua.StatusUncertain,
+		"BadNodeIdUnknown":       ua.StatusBadNodeIDUnknown,
+		"BadNodeIdInvalid":       ua.StatusBadNodeIDInvalid,
+		"BadAttributeIdInvalid":  ua.StatusBadAttributeIDInvalid,
+		"BadNotReadable":         ua.StatusBadNotReadable,
+		"BadUserAccessDenied":    ua.StatusBadUserAccessDenied,
+		"BadTimeout":             ua.StatusBadTimeout,
+		"BadConnectionRejected":  ua.StatusBadConnectionRejected,
+		"BadSessionIdInvalid":    ua.StatusBadSessionIDInvalid,
+		"BadSecureChannelClosed": ua.StatusBadSecureChannelClosed,
+	}))
 }
 
 type ClientOptions struct {
@@ -94,8 +118,6 @@ type ReadRequest struct {
 
 type ReadResult struct {
 	Status          uint32 `json:"status"`
-	StatusText      string `json:"statusText"`
-	StatusCode      string `json:"statusCode"`
 	Value           any    `json:"value"`
 	Type            string `json:"type"`
 	SourceTimestamp int64  `json:"sourceTimestamp"`
@@ -119,7 +141,6 @@ type BrowseNextRequest struct {
 
 type BrowseResult struct {
 	Status            uint32            `json:"status"`
-	StatusText        string            `json:"statusText"`
 	ContinuationPoint string            `json:"continuationPoint"`
 	References        []BrowseReference `json:"references"`
 }
@@ -147,7 +168,20 @@ type ChildrenResult struct {
 	DisplayName     string `json:"displayName"`
 	NodeClass       uint32 `json:"nodeClass"`
 	TypeDefinition  string `json:"typeDefinition"`
-	DataType        string `json:"dataType"`
+}
+
+type AttributeRequest struct {
+	Node        string `json:"node"`
+	AttributeId uint32 `json:"attributeId"`
+}
+
+type AttributesRequest struct {
+	Requests []AttributeRequest `json:"requests"`
+}
+
+type AttributeResult struct {
+	Status uint32 `json:"status"`
+	Value  string `json:"value"`
 }
 
 type WriteValue struct {
@@ -246,16 +280,10 @@ func (c *Client) Read(request ReadRequest) ([]ReadResult, error) {
 	}
 	ret := make([]ReadResult, 0, len(rsp.Results))
 	for _, data := range rsp.Results {
-		code := ""
-		if c, ok := ua.StatusCodes[data.Status]; ok {
-			code = c.Name
-		}
 		val := data.Value.Value()
 		typ := strings.TrimPrefix(data.Value.Type().String(), "TypeID")
 		ret = append(ret, ReadResult{
 			Status:          uint32(data.Status),
-			StatusText:      data.Status.Error(),
-			StatusCode:      code,
 			Value:           val,
 			Type:            typ,
 			SourceTimestamp: data.SourceTimestamp.UnixMilli(),
@@ -412,7 +440,6 @@ func toBrowseResults(results []*ua.BrowseResult) []BrowseResult {
 		}
 		ret = append(ret, BrowseResult{
 			Status:            uint32(result.StatusCode),
-			StatusText:        result.StatusCode.Error(),
 			ContinuationPoint: encodeContinuationPoint(result.ContinuationPoint),
 			References:        refs,
 		})
@@ -436,6 +463,75 @@ func decodeContinuationPoint(point string) ([]byte, error) {
 		return nil, err
 	}
 	return decoded, nil
+}
+
+func (c *Client) Attributes(request AttributesRequest) ([]AttributeResult, error) {
+	if len(request.Requests) == 0 {
+		return nil, errors.New("missing requests")
+	}
+
+	req := &ua.ReadRequest{
+		NodesToRead: make([]*ua.ReadValueID, len(request.Requests)),
+	}
+
+	for i, r := range request.Requests {
+		nodeID, err := ua.ParseNodeID(r.Node)
+		if err != nil {
+			return nil, err
+		}
+
+		req.NodesToRead[i] = &ua.ReadValueID{
+			NodeID:      nodeID,
+			AttributeID: ua.AttributeID(r.AttributeId),
+		}
+	}
+
+	rsp, err := c.client.Read(c.ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]AttributeResult, len(request.Requests))
+	for i, data := range rsp.Results {
+		ret[i].Status = uint32(data.Status)
+		if data.Status == ua.StatusOK && data.Value != nil {
+			ret[i].Value = parseAttributeValue(req.NodesToRead[i].AttributeID, data)
+		}
+	}
+
+	return ret, nil
+}
+
+func parseAttributeValue(attrID ua.AttributeID, data *ua.DataValue) string {
+	switch attrID {
+	case ua.AttributeIDDataType:
+		switch n := data.Value.Value().(type) {
+		case *ua.NodeID:
+			return id.Name(n.IntID())
+		case *ua.ExpandedNodeID:
+			return id.Name(n.NodeID.IntID())
+		}
+	case ua.AttributeIDDisplayName, ua.AttributeIDDescription:
+		if t, ok := data.Value.Value().(*ua.LocalizedText); ok {
+			return t.Text
+		}
+	case ua.AttributeIDBrowseName:
+		if q, ok := data.Value.Value().(*ua.QualifiedName); ok {
+			return q.Name
+		}
+	case ua.AttributeIDNodeClass:
+		return ua.NodeClass(data.Value.Int()).String()
+	case ua.AttributeIDAccessLevel:
+		if lev, ok := data.Value.Value().(uint8); ok {
+			return ua.AccessLevelType(lev).String()
+		}
+	case ua.AttributeIDUserAccessLevel:
+		if lev, ok := data.Value.Value().(uint8); ok {
+			return ua.AccessLevelType(lev).String()
+		}
+	}
+
+	return ""
 }
 
 func (c *Client) Children(request ChildrenRequest) ([]ChildrenResult, error) {
@@ -471,20 +567,6 @@ func (c *Client) Children(request ChildrenRequest) ([]ChildrenResult, error) {
 		if ref.TypeDefinition != nil && ref.TypeDefinition.NodeID != nil {
 			typeDefStr = id.Name(ref.TypeDefinition.NodeID.IntID())
 		}
-		var dataType string
-		if ref.NodeID != nil && ref.NodeClass == ua.NodeClassVariable {
-			attrs, err := c.client.NodeFromExpandedNodeID(ref.NodeID).Attributes(c.ctx, ua.AttributeIDDataType)
-			if err == nil && len(attrs) > 0 {
-				if attrs[0].Status == ua.StatusOK {
-					switch v := attrs[0].Value.Value().(type) {
-					case *ua.ExpandedNodeID: // for TestServer
-						dataType = id.Name(v.NodeID.IntID())
-					case *ua.NodeID:
-						dataType = id.Name(v.IntID())
-					}
-				}
-			}
-		}
 
 		ret = append(ret, ChildrenResult{
 			ReferenceTypeId: ref.ReferenceTypeID.String(),
@@ -494,7 +576,6 @@ func (c *Client) Children(request ChildrenRequest) ([]ChildrenResult, error) {
 			DisplayName:     displayName,
 			NodeClass:       uint32(ref.NodeClass),
 			TypeDefinition:  typeDefStr,
-			DataType:        dataType,
 		})
 	}
 	return ret, nil

--- a/jsh/lib/opcua/opcua.go
+++ b/jsh/lib/opcua/opcua.go
@@ -90,17 +90,17 @@ func Module(ctx context.Context, rt *goja.Runtime, module *goja.Object) {
 	}))
 	// StatusCode
 	o.Set("StatusCode", rt.ToValue(map[string]any{
-		"Good":                   ua.StatusOK,
-		"Uncertain":              ua.StatusUncertain,
-		"BadNodeIdUnknown":       ua.StatusBadNodeIDUnknown,
-		"BadNodeIdInvalid":       ua.StatusBadNodeIDInvalid,
-		"BadAttributeIdInvalid":  ua.StatusBadAttributeIDInvalid,
-		"BadNotReadable":         ua.StatusBadNotReadable,
-		"BadUserAccessDenied":    ua.StatusBadUserAccessDenied,
-		"BadTimeout":             ua.StatusBadTimeout,
-		"BadConnectionRejected":  ua.StatusBadConnectionRejected,
-		"BadSessionIdInvalid":    ua.StatusBadSessionIDInvalid,
-		"BadSecureChannelClosed": ua.StatusBadSecureChannelClosed,
+		"Good":                   uint32(ua.StatusOK),
+		"Uncertain":              uint32(ua.StatusUncertain),
+		"BadNodeIdUnknown":       uint32(ua.StatusBadNodeIDUnknown),
+		"BadNodeIdInvalid":       uint32(ua.StatusBadNodeIDInvalid),
+		"BadAttributeIdInvalid":  uint32(ua.StatusBadAttributeIDInvalid),
+		"BadNotReadable":         uint32(ua.StatusBadNotReadable),
+		"BadUserAccessDenied":    uint32(ua.StatusBadUserAccessDenied),
+		"BadTimeout":             uint32(ua.StatusBadTimeout),
+		"BadConnectionRejected":  uint32(ua.StatusBadConnectionRejected),
+		"BadSessionIdInvalid":    uint32(ua.StatusBadSessionIDInvalid),
+		"BadSecureChannelClosed": uint32(ua.StatusBadSecureChannelClosed),
 	}))
 }
 

--- a/jsh/lib/opcua/opcua.js
+++ b/jsh/lib/opcua/opcua.js
@@ -111,6 +111,11 @@ class Client {
     children(request) {
         return this._client.children(request);
     }
+
+    attributes(request) {
+        return this._client.attributes(request);
+    }
+
 }
 
 /**
@@ -138,6 +143,16 @@ const NodeClass = _opcua.NodeClass;
  */
 const BrowseResultMask = _opcua.BrowseResultMask;
 
+/**
+ * OPC UA attribute ID constants.
+ */
+const AttributeID = _opcua.AttributeID;
+
+/**
+ * OPC UA status code constants.
+ */
+const StatusCode = _opcua.StatusCode;
+
 module.exports = {
     Client,
     MessageSecurityMode,
@@ -145,4 +160,6 @@ module.exports = {
     BrowseDirection,
     NodeClass,
     BrowseResultMask,
+    AttributeID,
+    StatusCode,
 };

--- a/jsh/lib/opcua/opcua_internal_test.go
+++ b/jsh/lib/opcua/opcua_internal_test.go
@@ -8,6 +8,72 @@ import (
 	"github.com/gopcua/opcua/ua"
 )
 
+func TestParseAttributeValue(t *testing.T) {
+	tests := []struct {
+		name   string
+		attrID ua.AttributeID
+		data   *ua.DataValue
+		want   any
+	}{
+		{
+			name:   "DataType NodeID",
+			attrID: ua.AttributeIDDataType,
+			data:   &ua.DataValue{Value: ua.MustVariant(ua.NewNumericNodeID(0, 6))},
+			want:   "Int32",
+		},
+		{
+			name:   "DataType ExpandedNodeID",
+			attrID: ua.AttributeIDDataType,
+			data:   &ua.DataValue{Value: ua.MustVariant(ua.NewNumericExpandedNodeID(0, 1))},
+			want:   "Boolean",
+		},
+		{
+			name:   "DisplayName",
+			attrID: ua.AttributeIDDisplayName,
+			data:   &ua.DataValue{Value: ua.MustVariant(&ua.LocalizedText{Text: "Temperature"})},
+			want:   "Temperature",
+		},
+		{
+			name:   "Description",
+			attrID: ua.AttributeIDDescription,
+			data:   &ua.DataValue{Value: ua.MustVariant(&ua.LocalizedText{Text: "A sensor value"})},
+			want:   "A sensor value",
+		},
+		{
+			name:   "BrowseName",
+			attrID: ua.AttributeIDBrowseName,
+			data:   &ua.DataValue{Value: ua.MustVariant(&ua.QualifiedName{Name: "MyVar"})},
+			want:   "MyVar",
+		},
+		{
+			name:   "NodeClass",
+			attrID: ua.AttributeIDNodeClass,
+			data:   &ua.DataValue{Value: ua.MustVariant(int32(ua.NodeClassVariable))},
+			want:   ua.NodeClassVariable.String(),
+		},
+		{
+			name:   "AccessLevel",
+			attrID: ua.AttributeIDAccessLevel,
+			data:   &ua.DataValue{Value: ua.MustVariant(byte(ua.AccessLevelTypeCurrentRead))},
+			want:   ua.AccessLevelType(ua.AccessLevelTypeCurrentRead).String(),
+		},
+		{
+			name:   "UserAccessLevel",
+			attrID: ua.AttributeIDUserAccessLevel,
+			data:   &ua.DataValue{Value: ua.MustVariant(byte(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite))},
+			want:   ua.AccessLevelType(ua.AccessLevelTypeCurrentRead | ua.AccessLevelTypeCurrentWrite).String(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAttributeValue(tt.attrID, tt.data)
+			if got != tt.want {
+				t.Fatalf("parseAttributeValue(%v) = %v, want %v", tt.attrID, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestToBrowseResultsIncludesContinuationPoint(t *testing.T) {
 	point := []byte{1, 2, 3, 4}
 	results := toBrowseResults([]*ua.BrowseResult{
@@ -33,9 +99,6 @@ func TestToBrowseResultsIncludesContinuationPoint(t *testing.T) {
 	}
 	if got, want := results[0].ContinuationPoint, base64.StdEncoding.EncodeToString(point); got != want {
 		t.Fatalf("unexpected continuation point: got %q want %q", got, want)
-	}
-	if got, want := results[0].StatusText, ua.StatusBadNoContinuationPoints.Error(); got != want {
-		t.Fatalf("unexpected status text: got %q want %q", got, want)
 	}
 	if got := len(results[0].References); got != 1 {
 		t.Fatalf("expected 1 reference, got %d", got)
@@ -66,7 +129,6 @@ func TestDecodeContinuationPoint(t *testing.T) {
 		t.Fatal("expected invalid base64 continuation point to return an error")
 	}
 }
-
 
 func TestCloseNilClient(t *testing.T) {
 	client := &Client{}

--- a/jsh/lib/opcua/opcua_test.go
+++ b/jsh/lib/opcua/opcua_test.go
@@ -57,7 +57,7 @@ func TestScriptOPCUA(t *testing.T) {
 						nodes = nodeList[i];
 						vs = client.read({ nodes: nodes, timestampsToReturn: ua.TimestampsToReturn.Both});
 						vs.forEach((v, idx) => {
-							console.println(nodes[idx], v.status, v.statusCode, v.value, v.type);
+							console.println(nodes[idx], v.status, v.value, v.type);
 						})
 					}
 				} catch (e) {
@@ -68,14 +68,14 @@ func TestScriptOPCUA(t *testing.T) {
 				}
 			`,
 			Output: []string{
-				"ns=1;s=ro_bool 0 StatusGood true Boolean",
-				"ns=1;s=rw_bool 0 StatusGood true Boolean",
-				"ns=1;s=ro_int32 0 StatusGood 5 Int32",
-				"ns=1;s=rw_int32 0 StatusGood 5 Int32",
-				"ns=1;s=NoPermVariable 0 StatusGood 742 Int32",
-				"ns=1;s=ReadWriteVariable 0 StatusGood 12.34 Double",
-				"ns=1;s=ReadOnlyVariable 0 StatusGood 9.87 Double",
-				"ns=1;s=NoAccessVariable 2149515264 StatusBadUserAccessDenied null Null",
+				"ns=1;s=ro_bool 0 true Boolean",
+				"ns=1;s=rw_bool 0 true Boolean",
+				"ns=1;s=ro_int32 0 5 Int32",
+				"ns=1;s=rw_int32 0 5 Int32",
+				"ns=1;s=NoPermVariable 0 742 Int32",
+				"ns=1;s=ReadWriteVariable 0 12.34 Double",
+				"ns=1;s=ReadOnlyVariable 0 9.87 Double",
+				"ns=1;s=NoAccessVariable 2149515264 null Null",
 			},
 		},
 		{
@@ -190,7 +190,7 @@ func TestScriptOPCUA(t *testing.T) {
 						nodeClassMask: ua.NodeClass.Variable,
 					});
 					refs.sort((a,b) => a.browseName < b.browseName ? -1 : 1)
-						.forEach(r => console.println(r.browseName, r.nodeId, r.nodeClass, r.dataType));
+						.forEach(r => console.println(r.browseName, r.nodeId, r.nodeClass));
 				} catch(e) {
 					console.println("Error:", e);
 				} finally {
@@ -198,14 +198,14 @@ func TestScriptOPCUA(t *testing.T) {
 				}
 			`,
 			Output: []string{
-				"NoAccessVariable ns=1;s=NoAccessVariable 2 ",
-				"NoPermVariable ns=1;s=NoPermVariable 2 Int32",
-				"ReadOnlyVariable ns=1;s=ReadOnlyVariable 2 Double",
-				"ReadWriteVariable ns=1;s=ReadWriteVariable 2 Double",
-				"ro_bool ns=1;s=ro_bool 2 Boolean",
-				"ro_int32 ns=1;s=ro_int32 2 Int32",
-				"rw_bool ns=1;s=rw_bool 2 Boolean",
-				"rw_int32 ns=1;s=rw_int32 2 Int32",
+				"NoAccessVariable ns=1;s=NoAccessVariable 2",
+				"NoPermVariable ns=1;s=NoPermVariable 2",
+				"ReadOnlyVariable ns=1;s=ReadOnlyVariable 2",
+				"ReadWriteVariable ns=1;s=ReadWriteVariable 2",
+				"ro_bool ns=1;s=ro_bool 2",
+				"ro_int32 ns=1;s=ro_int32 2",
+				"rw_bool ns=1;s=rw_bool 2",
+				"rw_int32 ns=1;s=rw_int32 2",
 			},
 		},
 		{
@@ -264,7 +264,7 @@ func TestScriptOPCUA(t *testing.T) {
 						includeSubtypes: true,
 						resultMask: ua.BrowseResultMask.All,
 					});
-					console.println("browse custom status:", results[0].statusText);
+					console.println("browse custom status:", results[0].status);
 				} finally {
 					if (client !== undefined) client.close();
 				}
@@ -272,7 +272,7 @@ func TestScriptOPCUA(t *testing.T) {
 			Output: []string{
 				"browse missing nodes: true",
 				"browse invalid node: true",
-				"browse custom status: The operation succeeded. StatusGood (0x0)",
+				"browse custom status: 0",
 			},
 		},
 		{
@@ -337,6 +337,63 @@ func TestScriptOPCUA(t *testing.T) {
 			Output: []string{
 				"browseNext missing continuationPoints: true",
 				"browseNext invalid continuationPoint: true",
+			},
+		},
+		{
+			Name: "opcua-attributes",
+			Script: `
+				ua = require("opcua");
+				try {
+					client = new ua.Client({ endpoint: "opc.tcp://localhost:4840" });
+					results = client.attributes({ requests: [
+						{ node: "ns=1;s=ro_bool",           attributeId: ua.AttributeID.DataType },
+						{ node: "ns=1;s=ro_int32",          attributeId: ua.AttributeID.DataType },
+						{ node: "ns=1;s=ReadWriteVariable", attributeId: ua.AttributeID.DataType },
+						{ node: "ns=1;s=ReadWriteVariable", attributeId: ua.AttributeID.BrowseName },
+						{ node: "ns=1;s=ReadWriteVariable", attributeId: ua.AttributeID.NodeClass },
+					]});
+					results.forEach(r => console.println(r.status, r.value));
+				} catch(e) {
+					console.println("Error:", e);
+				} finally {
+					if (client !== undefined) client.close();
+				}
+			`,
+			Output: []string{
+				"0 Boolean",
+				"0 Int32",
+				"0 Double",
+				"0 ReadWriteVariable",
+				"0 NodeClassVariable",
+			},
+		},
+		{
+			Name: "opcua-attributes-errors",
+			Script: `
+				ua = require("opcua");
+				try {
+					client = new ua.Client({ endpoint: "opc.tcp://localhost:4840" });
+					failed = false;
+					try {
+						client.attributes({ requests: [] });
+					} catch (e) {
+						failed = true;
+					}
+					console.println("attributes empty:", failed);
+					failed = false;
+					try {
+						client.attributes({ requests: [{ node: "ns=x;i=1", attributeId: ua.AttributeID.DataType }] });
+					} catch (e) {
+						failed = true;
+					}
+					console.println("attributes invalid node:", failed);
+				} finally {
+					if (client !== undefined) client.close();
+				}
+			`,
+			Output: []string{
+				"attributes empty: true",
+				"attributes invalid node: true",
 			},
 		},
 		{

--- a/jsh/lib/opcua/opcua_test.go
+++ b/jsh/lib/opcua/opcua_test.go
@@ -57,7 +57,7 @@ func TestScriptOPCUA(t *testing.T) {
 						nodes = nodeList[i];
 						vs = client.read({ nodes: nodes, timestampsToReturn: ua.TimestampsToReturn.Both});
 						vs.forEach((v, idx) => {
-							console.println(nodes[idx], v.status, v.value, v.type);
+							console.println(nodes[idx], v.statusCode, v.value, v.type);
 						})
 					}
 				} catch (e) {
@@ -68,14 +68,14 @@ func TestScriptOPCUA(t *testing.T) {
 				}
 			`,
 			Output: []string{
-				"ns=1;s=ro_bool 0 true Boolean",
-				"ns=1;s=rw_bool 0 true Boolean",
-				"ns=1;s=ro_int32 0 5 Int32",
-				"ns=1;s=rw_int32 0 5 Int32",
-				"ns=1;s=NoPermVariable 0 742 Int32",
-				"ns=1;s=ReadWriteVariable 0 12.34 Double",
-				"ns=1;s=ReadOnlyVariable 0 9.87 Double",
-				"ns=1;s=NoAccessVariable 2149515264 null Null",
+				"ns=1;s=ro_bool StatusGood true Boolean",
+				"ns=1;s=rw_bool StatusGood true Boolean",
+				"ns=1;s=ro_int32 StatusGood 5 Int32",
+				"ns=1;s=rw_int32 StatusGood 5 Int32",
+				"ns=1;s=NoPermVariable StatusGood 742 Int32",
+				"ns=1;s=ReadWriteVariable StatusGood 12.34 Double",
+				"ns=1;s=ReadOnlyVariable StatusGood 9.87 Double",
+				"ns=1;s=NoAccessVariable StatusBadUserAccessDenied null Null",
 			},
 		},
 		{


### PR DESCRIPTION
- Children에서 추가적으로 server로부터 data type attribute를 read해오던 것을 제거
- Attributes() 함수 추가
- StatusCode 상수 추가
- Read와 Browse의 StatusCode, StatusText 등의 필드 제거