### PR TITLE
Add PrecisionFloat64 type for enhanced float64 JSON encoding

### DIFF
--- a/mods/codec/internal/json/json_encode.go
+++ b/mods/codec/internal/json/json_encode.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/machbase/neo-client/api"
@@ -42,6 +43,7 @@ func NewEncoder() *Exporter {
 	return &Exporter{
 		tick:          time.Now(),
 		timeformatter: util.NewTimeFormatter(),
+		precision:     -1,
 	}
 }
 
@@ -157,15 +159,22 @@ func (ex *Exporter) Flush(heading bool) {
 	}
 }
 
-func (ex *Exporter) encodeFloat64(v float64) any {
-	if math.IsNaN(v) {
-		return "NaN"
-	} else if math.IsInf(v, -1) {
-		return "-Inf"
-	} else if math.IsInf(v, 1) {
-		return "+Inf"
+type PrecisionFloat64 float64
+
+func (pf PrecisionFloat64) MarshalJSON() ([]byte, error) {
+	v := float64(pf)
+	switch {
+	case math.IsNaN(v):
+		return []byte(`"NaN"`), nil
+	case math.IsInf(v, -1):
+		return []byte(`"-Inf"`), nil
+	case math.IsInf(v, 1):
+		return []byte(`"+Inf"`), nil
+	case v == 0:
+		// Keep zero formatting stable and avoid "-0".
+		return []byte("0"), nil
 	}
-	return v
+	return strconv.AppendFloat(nil, v, 'f', -1, 64), nil
 }
 
 func (ex *Exporter) AddRow(source []any) error {
@@ -183,13 +192,13 @@ func (ex *Exporter) AddRow(source []any) error {
 		case time.Time:
 			ex.values[i] = ex.timeformatter.FormatEpoch(v)
 		case *float64:
-			ex.values[i] = ex.encodeFloat64(*v)
+			ex.values[i] = PrecisionFloat64(*v)
 		case float64:
-			ex.values[i] = ex.encodeFloat64(v)
+			ex.values[i] = PrecisionFloat64(v)
 		case *float32:
-			ex.values[i] = ex.encodeFloat64(float64(*v))
+			ex.values[i] = PrecisionFloat64(float64(*v))
 		case float32:
-			ex.values[i] = ex.encodeFloat64(float64(v))
+			ex.values[i] = PrecisionFloat64(float64(v))
 		case *net.IP:
 			ex.values[i] = v.String()
 		case net.IP:

--- a/mods/codec/internal/json/json_encode_test.go
+++ b/mods/codec/internal/json/json_encode_test.go
@@ -2,12 +2,30 @@ package json_test
 
 import (
 	"bytes"
+	gojson "encoding/json"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/machbase/neo-server/v8/mods/codec/internal/json"
 	"github.com/stretchr/testify/require"
 )
+
+type flushCloseBuffer struct {
+	bytes.Buffer
+	flushCount int
+	closeCount int
+}
+
+func (b *flushCloseBuffer) Flush() error {
+	b.flushCount++
+	return nil
+}
+
+func (b *flushCloseBuffer) Close() error {
+	b.closeCount++
+	return nil
+}
 
 // previous version of json_encode.go
 // cpu: AMD Ryzen 9 3900X 12-Core Processor
@@ -118,4 +136,151 @@ func TestJsonEncode(t *testing.T) {
 			require.Equal(t, tt.expect, substr)
 		})
 	}
+}
+
+func TestPrecisionFloat64MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  float64
+		expect string
+	}{
+		{
+			name:   "dynamic-significant-digits-trims-trailing-zeros",
+			value:  12.3400,
+			expect: "12.34",
+		},
+		{
+			name:   "integer-like-float-without-fixed-decimals",
+			value:  10.0,
+			expect: "10",
+		},
+		{
+			name:   "normalize-negative-zero",
+			value:  math.Copysign(0, -1),
+			expect: "0",
+		},
+		{
+			name:   "nan-as-string-token",
+			value:  math.NaN(),
+			expect: `"NaN"`,
+		},
+		{
+			name:   "negative-infinity-as-string-token",
+			value:  math.Inf(-1),
+			expect: `"-Inf"`,
+		},
+		{
+			name:   "positive-infinity-as-string-token",
+			value:  math.Inf(1),
+			expect: `"+Inf"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.PrecisionFloat64(tt.value).MarshalJSON()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, string(b))
+		})
+	}
+}
+
+func TestJsonEncodeFlushAndClose(t *testing.T) {
+	out := &flushCloseBuffer{}
+	enc := json.NewEncoder()
+	enc.SetOutputStream(out)
+	enc.SetColumnTypes("string")
+	enc.SetColumns("name")
+	require.NoError(t, enc.Open())
+
+	enc.Flush(false)
+	require.Equal(t, 1, out.flushCount)
+
+	enc.Close()
+	require.Equal(t, 1, out.closeCount)
+}
+
+func TestJsonEncodeRowsArray(t *testing.T) {
+	out := &bytes.Buffer{}
+	enc := json.NewEncoder()
+	enc.SetOutputStream(out)
+	enc.SetColumnTypes("string", "long", "double")
+	enc.SetColumns("name", "seq", "value")
+	enc.SetRowsArray(true)
+	require.NoError(t, enc.Open())
+	require.NoError(t, enc.AddRow([]any{"car-1", int64(7), float64(12.3400)}))
+	enc.Close()
+
+	var payload map[string]any
+	require.NoError(t, gojson.Unmarshal(out.Bytes(), &payload))
+
+	data, ok := payload["data"].(map[string]any)
+	require.True(t, ok)
+	rows, ok := data["rows"].([]any)
+	require.True(t, ok)
+	require.Len(t, rows, 1)
+
+	row, ok := rows[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "car-1", row["name"])
+	require.Equal(t, float64(7), row["seq"])
+	require.Equal(t, float64(12.34), row["value"])
+}
+
+func TestJsonEncodeRowsFlatten(t *testing.T) {
+	out := &bytes.Buffer{}
+	enc := json.NewEncoder()
+	enc.SetOutputStream(out)
+	enc.SetColumnTypes("string", "long", "double")
+	enc.SetColumns("name", "seq", "value")
+	enc.SetRowsFlatten(true)
+	require.NoError(t, enc.Open())
+	require.NoError(t, enc.AddRow([]any{"car-1", int64(1), float64(1.2500)}))
+	require.NoError(t, enc.AddRow([]any{"car-2", int64(2), float64(2.5000)}))
+	enc.Close()
+
+	var payload map[string]any
+	require.NoError(t, gojson.Unmarshal(out.Bytes(), &payload))
+
+	data, ok := payload["data"].(map[string]any)
+	require.True(t, ok)
+	rows, ok := data["rows"].([]any)
+	require.True(t, ok)
+	require.Len(t, rows, 6)
+	require.Equal(t, "car-1", rows[0])
+	require.Equal(t, float64(1), rows[1])
+	require.Equal(t, float64(1.25), rows[2])
+	require.Equal(t, "car-2", rows[3])
+	require.Equal(t, float64(2), rows[4])
+	require.Equal(t, float64(2.5), rows[5])
+}
+
+func TestJsonEncodeTranspose(t *testing.T) {
+	out := &bytes.Buffer{}
+	enc := json.NewEncoder()
+	enc.SetOutputStream(out)
+	enc.SetColumnTypes("string", "double")
+	enc.SetColumns("name", "value")
+	enc.SetTranspose(true)
+	require.NoError(t, enc.Open())
+	require.NoError(t, enc.AddRow([]any{"car-1", float64(1.0)}))
+	require.NoError(t, enc.AddRow([]any{"car-2", float64(2.5000)}))
+	enc.Close()
+
+	var payload map[string]any
+	require.NoError(t, gojson.Unmarshal(out.Bytes(), &payload))
+
+	data, ok := payload["data"].(map[string]any)
+	require.True(t, ok)
+	cols, ok := data["cols"].([]any)
+	require.True(t, ok)
+	require.Len(t, cols, 2)
+
+	col0, ok := cols[0].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{"car-1", "car-2"}, col0)
+
+	col1, ok := cols[1].([]any)
+	require.True(t, ok)
+	require.Equal(t, []any{float64(1), float64(2.5)}, col1)
 }


### PR DESCRIPTION
This pull request refactors the JSON encoding logic for floating-point values in the `mods/codec/internal/json` package to improve precision handling and output formatting. The main change is the introduction of a custom `PrecisionFloat64` type with a dedicated `MarshalJSON` method, ensuring consistent and accurate JSON serialization of special float values (e.g., NaN, infinities, negative zero, and trailing zeros). Comprehensive unit tests are also added to verify the new behavior and edge cases.

**Precision handling improvements:**

* Introduced a `PrecisionFloat64` type with a custom `MarshalJSON` method to serialize float values, ensuring correct handling of special values (NaN, infinities), normalization of negative zero, and trimming of unnecessary trailing zeros. (`json_encode.go`, `json_encode_test.go`) [[1]](diffhunk://#diff-cf7647dd537b215a803f390a6260229ea449c6fe94e76d47a86253777a73ea54L160-R177) [[2]](diffhunk://#diff-cf7647dd537b215a803f390a6260229ea449c6fe94e76d47a86253777a73ea54L186-R201) [[3]](diffhunk://#diff-7441918f6f8cb5acf7c29d80ac675c9694bfb383a66f42961f42c85f5ef7e11eR140-R286)
* Updated the encoder to use `PrecisionFloat64` for all float and pointer-to-float values during row addition, replacing the previous `encodeFloat64` function. (`json_encode.go`)

**Testing enhancements:**

* Added comprehensive tests for `PrecisionFloat64.MarshalJSON`, covering cases like trimming trailing zeros, integer-like floats, negative zero normalization, and special float values. (`json_encode_test.go`)
* Added new tests for encoder behaviors, including flush/close operations, rows as arrays, flattened rows, and transposed output, verifying correct JSON output in each mode. (`json_encode_test.go`)
* Introduced a `flushCloseBuffer` helper for testing flush and close operations. (`json_encode_test.go`)

**Minor internal changes:**

* Added the `strconv` import for float-to-string conversion. (`json_encode.go`)
* Set a default precision value in the encoder struct initialization. (`json_encode.go`)