### PR TITLE
implement PrecisionFloat64 type for enhanced float64 JSON encoding

### DIFF
--- a/mods/codec/internal/json/json_encode.go
+++ b/mods/codec/internal/json/json_encode.go
@@ -213,7 +213,7 @@ func (ex *Exporter) AddRow(source []any) error {
 			}
 		case *sql.NullFloat64:
 			if v.Valid {
-				ex.values[i] = v.Float64
+				ex.values[i] = PrecisionFloat64(v.Float64)
 			}
 		case *sql.NullInt16:
 			if v.Valid {
@@ -225,7 +225,7 @@ func (ex *Exporter) AddRow(source []any) error {
 			}
 		case *sql.Null[float32]:
 			if v.Valid {
-				ex.values[i] = v.V
+				ex.values[i] = PrecisionFloat64(float64(v.V))
 			}
 		case *sql.NullInt64:
 			if v.Valid {

--- a/mods/codec/internal/ndjson/encode.go
+++ b/mods/codec/internal/ndjson/encode.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/machbase/neo-client/api"
@@ -99,15 +100,21 @@ func (ex *Exporter) Flush(heading bool) {
 	}
 }
 
-func (ex *Exporter) encodeFloat64(v float64) any {
-	if math.IsNaN(v) {
-		return "NaN"
-	} else if math.IsInf(v, -1) {
-		return "-Inf"
-	} else if math.IsInf(v, 1) {
-		return "+Inf"
+type PrecisionFloat64 float64
+
+func (pf PrecisionFloat64) MarshalJSON() ([]byte, error) {
+	v := float64(pf)
+	switch {
+	case math.IsNaN(v):
+		return []byte(`"NaN"`), nil
+	case math.IsInf(v, -1):
+		return []byte(`"-Inf"`), nil
+	case math.IsInf(v, 1):
+		return []byte(`"+Inf"`), nil
+	case v == 0:
+		return []byte("0"), nil
 	}
-	return v
+	return strconv.AppendFloat(nil, v, 'f', -1, 64), nil
 }
 
 func (ex *Exporter) AddRow(source []any) error {
@@ -121,13 +128,13 @@ func (ex *Exporter) AddRow(source []any) error {
 		case time.Time:
 			values[i] = ex.timeformat.FormatEpoch(v)
 		case *float64:
-			values[i] = ex.encodeFloat64(*v)
+			values[i] = PrecisionFloat64(*v)
 		case float64:
-			values[i] = ex.encodeFloat64(v)
+			values[i] = PrecisionFloat64(v)
 		case *float32:
-			values[i] = ex.encodeFloat64(float64(*v))
+			values[i] = PrecisionFloat64(float64(*v))
 		case float32:
-			values[i] = ex.encodeFloat64(float64(v))
+			values[i] = PrecisionFloat64(float64(v))
 		case *net.IP:
 			values[i] = v.String()
 		case net.IP:
@@ -142,7 +149,7 @@ func (ex *Exporter) AddRow(source []any) error {
 			}
 		case *sql.NullFloat64:
 			if v.Valid {
-				values[i] = v.Float64
+				values[i] = PrecisionFloat64(v.Float64)
 			}
 		case *sql.NullInt16:
 			if v.Valid {
@@ -151,6 +158,10 @@ func (ex *Exporter) AddRow(source []any) error {
 		case *sql.NullInt32:
 			if v.Valid {
 				values[i] = v.Int32
+			}
+		case *sql.Null[float32]:
+			if v.Valid {
+				values[i] = PrecisionFloat64(float64(v.V))
 			}
 		case *sql.NullInt64:
 			if v.Valid {
@@ -163,6 +174,10 @@ func (ex *Exporter) AddRow(source []any) error {
 		case *sql.NullTime:
 			if v.Valid {
 				values[i] = ex.timeformat.Format(v.Time)
+			}
+		case *sql.Null[net.IP]:
+			if v.Valid {
+				values[i] = v.V.String()
 			}
 		default:
 			values[i] = field

--- a/mods/codec/internal/ndjson/encode_test.go
+++ b/mods/codec/internal/ndjson/encode_test.go
@@ -2,6 +2,8 @@ package ndjson_test
 
 import (
 	"bytes"
+	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,5 +71,101 @@ func TestJsonEncode(t *testing.T) {
 		}
 		enc.Close()
 		require.Equal(t, tt.expect, out.String())
+	}
+}
+
+func TestPrecisionFloat64MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  float64
+		expect string
+	}{
+		{
+			name:   "dynamic-significant-digits-trims-trailing-zeros",
+			value:  12.3400,
+			expect: "12.34",
+		},
+		{
+			name:   "integer-like-float-without-fixed-decimals",
+			value:  10.0,
+			expect: "10",
+		},
+		{
+			name:   "normalize-negative-zero",
+			value:  math.Copysign(0, -1),
+			expect: "0",
+		},
+		{
+			name:   "nan-as-string-token",
+			value:  math.NaN(),
+			expect: `"NaN"`,
+		},
+		{
+			name:   "negative-infinity-as-string-token",
+			value:  math.Inf(-1),
+			expect: `"-Inf"`,
+		},
+		{
+			name:   "positive-infinity-as-string-token",
+			value:  math.Inf(1),
+			expect: `"+Inf"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := ndjson.PrecisionFloat64(tt.value).MarshalJSON()
+			require.NoError(t, err)
+			require.Equal(t, tt.expect, string(b))
+		})
+	}
+}
+
+func TestNdjsonEncodeFloatFormatting(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       float64
+		expectField string
+	}{
+		{
+			name:        "trailing-zeros-trimmed",
+			value:       12.3400,
+			expectField: `"value":12.34`,
+		},
+		{
+			name:        "integer-like-float",
+			value:       10.0,
+			expectField: `"value":10`,
+		},
+		{
+			name:        "nan-as-quoted-string",
+			value:       math.NaN(),
+			expectField: `"value":"NaN"`,
+		},
+		{
+			name:        "negative-inf-as-quoted-string",
+			value:       math.Inf(-1),
+			expectField: `"value":"-Inf"`,
+		},
+		{
+			name:        "positive-inf-as-quoted-string",
+			value:       math.Inf(1),
+			expectField: `"value":"+Inf"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			enc := ndjson.NewEncoder()
+			enc.SetOutputStream(out)
+			enc.SetColumnTypes("double")
+			enc.SetColumns("value")
+			enc.Open()
+			require.NoError(t, enc.AddRow([]any{tt.value}))
+			enc.Close()
+			require.True(t, strings.Contains(out.String(), tt.expectField),
+				"output %q does not contain %q", out.String(), tt.expectField)
+		})
 	}
 }


### PR DESCRIPTION
This pull request introduces a new `PrecisionFloat64` type to standardize and improve the JSON encoding of floating-point numbers in both the JSON and NDJSON exporters. The main goal is to ensure that float values are consistently formatted—removing unnecessary trailing zeros, normalizing negative zero, and representing special values like NaN and Infinity as strings. Comprehensive tests are added to verify this new behavior.

**Float formatting improvements:**

* Introduced the `PrecisionFloat64` type with a custom `MarshalJSON` implementation to format floats without trailing zeros, normalize negative zero, and encode special values (`NaN`, `+Inf`, `-Inf`) as strings. (`[mods/codec/internal/ndjson/encode.goL102-R117](diffhunk://#diff-8d9ed2a8c86745a7855d1ad86388611474d5428110566e8cba4c65590088dc2cL102-R117)`)
* Updated both NDJSON and JSON exporters to use `PrecisionFloat64` for all relevant float and nullable float types, ensuring consistent output formatting. (`[[1]](diffhunk://#diff-8d9ed2a8c86745a7855d1ad86388611474d5428110566e8cba4c65590088dc2cL124-R137)`, `[[2]](diffhunk://#diff-8d9ed2a8c86745a7855d1ad86388611474d5428110566e8cba4c65590088dc2cL145-R152)`, `[[3]](diffhunk://#diff-8d9ed2a8c86745a7855d1ad86388611474d5428110566e8cba4c65590088dc2cR162-R165)`, `[[4]](diffhunk://#diff-8d9ed2a8c86745a7855d1ad86388611474d5428110566e8cba4c65590088dc2cR178-R181)`, `[[5]](diffhunk://#diff-cf7647dd537b215a803f390a6260229ea449c6fe94e76d47a86253777a73ea54L216-R216)`, `[[6]](diffhunk://#diff-cf7647dd537b215a803f390a6260229ea449c6fe94e76d47a86253777a73ea54L228-R228)`)

**Testing enhancements:**

* Added unit tests for `PrecisionFloat64.MarshalJSON` to verify correct formatting of regular floats, integer-like floats, negative zero, and special values. (`[mods/codec/internal/ndjson/encode_test.goR76-R171](diffhunk://#diff-4de7dd68d76081b9fe7333660adeed76656a9ed6aa0ec3619c2654dde4d176fbR76-R171)`)
* Added integration tests to confirm that NDJSON encoding produces the expected float formatting in output. (`[mods/codec/internal/ndjson/encode_test.goR76-R171](diffhunk://#diff-4de7dd68d76081b9fe7333660adeed76656a9ed6aa0ec3619c2654dde4d176fbR76-R171)`)

**Other changes:**

* Imported the `strconv` package to support float-to-string conversion in the new `MarshalJSON` method. (`[mods/codec/internal/ndjson/encode.goR10](diffhunk://#diff-8d9ed2a8c86745a7855d1ad86388611474d5428110566e8cba4c65590088dc2cR10)`)
* Added support for encoding nullable `net.IP` types in the NDJSON exporter. (`[mods/codec/internal/ndjson/encode.goR178-R181](diffhunk://#diff-8d9ed2a8c86745a7855d1ad86388611474d5428110566e8cba4c65590088dc2cR178-R181)`)