### PR TITLE
Implement shell command and path completion functionality

### DIFF
--- a/jsh/lib/shell/completion.go
+++ b/jsh/lib/shell/completion.go
@@ -1,0 +1,645 @@
+package shell
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/hymkor/go-multiline-ny"
+	"github.com/nyaosorg/go-readline-ny"
+)
+
+type candidateKind int
+
+const (
+	candidateCommand candidateKind = iota
+	candidateFile
+	candidateDirectory
+)
+
+type completionCandidate struct {
+	Insert  string
+	Display string
+	Kind    candidateKind
+}
+
+type completionContext struct {
+	fields          []string
+	segment         []string
+	currentWord     string
+	commandName     string
+	commandPosition bool
+	expectingPath   bool
+	onlyDirectory   bool
+	redirection     bool
+}
+
+type shellCompletionCommand struct {
+	shell     *Shell
+	editor    *multiline.Editor
+	delimiter string
+	enclosure string
+}
+
+func newShellCompletionCommand(sh *Shell) *shellCompletionCommand {
+	return &shellCompletionCommand{
+		shell:     sh,
+		delimiter: "&|><;",
+		enclosure: `"'`,
+	}
+}
+
+func (cmd *shellCompletionCommand) String() string {
+	return "SHELL_COMPLETION"
+}
+
+func (cmd *shellCompletionCommand) SetEditor(ed *multiline.Editor) {
+	cmd.editor = ed
+}
+
+func (cmd *shellCompletionCommand) Call(_ context.Context, buffer *readline.Buffer) readline.Result {
+	fieldsBeforeCurrentLine := cmd.fieldsBeforeCurrentLine()
+	fieldsBeforeCursor, lastWordStart := splitBufferFields(buffer, cmd.enclosure, cmd.delimiter)
+	rawCurrentWord := buffer.SubString(lastWordStart, buffer.Cursor)
+	fields := make([]string, 0, len(fieldsBeforeCurrentLine)+len(fieldsBeforeCursor))
+	fields = append(fields, fieldsBeforeCurrentLine...)
+	fields = append(fields, fieldsBeforeCursor...)
+
+	candidates := cmd.shell.completionCandidates(fields)
+	if len(candidates) == 0 {
+		return readline.CONTINUE
+	}
+
+	context := cmd.shell.buildCompletionContext(fields)
+	if len(candidates) == 1 {
+		insert := formatCompletionInsert(rawCurrentWord, candidates[0].Insert, candidates[0].Kind, false)
+		buffer.ReplaceAndRepaint(lastWordStart, insert)
+		return readline.CONTINUE
+	}
+
+	commonPrefix := longestCommonPrefix(candidateInserts(candidates))
+	if len(commonPrefix) > len(context.currentWord) {
+		commonKind := candidateFile
+		allDirectories := true
+		for _, candidate := range candidates {
+			if candidate.Kind != candidateDirectory {
+				allDirectories = false
+				break
+			}
+		}
+		if allDirectories {
+			commonKind = candidateDirectory
+		}
+		buffer.ReplaceAndRepaint(lastWordStart, formatCompletionInsert(rawCurrentWord, commonPrefix, commonKind, true))
+		return readline.CONTINUE
+	}
+
+	fmt.Fprintln(buffer.Out)
+	for _, line := range candidateDisplays(candidates) {
+		fmt.Fprintln(buffer.Out, line)
+	}
+	buffer.RepaintAll()
+	return readline.CONTINUE
+}
+
+func (cmd *shellCompletionCommand) fieldsBeforeCurrentLine() []string {
+	if cmd.editor == nil || cmd.editor.CursorLine() <= 0 {
+		return nil
+	}
+	fields := []string{}
+	for _, line := range cmd.editor.Lines()[:cmd.editor.CursorLine()] {
+		fields = append(fields, lineToFields(line, cmd.enclosure, cmd.delimiter)...)
+	}
+	return fields
+}
+
+func (sh *Shell) getCompletionCandidates(fields []string) (forCompletion []string, forListing []string) {
+	for _, candidate := range sh.completionCandidates(fields) {
+		forCompletion = append(forCompletion, candidate.Insert)
+		forListing = append(forListing, candidate.Display)
+	}
+	return forCompletion, forListing
+}
+
+func (sh *Shell) completionCandidates(fields []string) []completionCandidate {
+	if sh == nil || sh.env == nil {
+		return nil
+	}
+	ctx := sh.buildCompletionContext(fields)
+	if ctx.commandPosition {
+		return sh.completeCommand(ctx.currentWord)
+	}
+	if ctx.expectingPath || ctx.onlyDirectory || shouldCompletePath(ctx.commandName, ctx.currentWord) {
+		return sh.completePath(ctx.currentWord, ctx.onlyDirectory)
+	}
+	return nil
+}
+
+func (sh *Shell) buildCompletionContext(fields []string) completionContext {
+	ctx := completionContext{fields: append([]string{}, fields...)}
+	if len(fields) == 0 {
+		ctx.commandPosition = true
+		return ctx
+	}
+
+	if isCompletionOperator(fields[len(fields)-1]) {
+		ctx.currentWord = ""
+		ctx.segment = currentSegment(fields)
+	} else {
+		ctx.currentWord = fields[len(fields)-1]
+		ctx.segment = currentSegment(fields[:len(fields)-1])
+	}
+
+	ctx.commandName = firstCommandToken(ctx.segment)
+	ctx.commandPosition = ctx.commandName == ""
+	if len(ctx.segment) > 0 {
+		prev := ctx.segment[len(ctx.segment)-1]
+		if isRedirectionOperator(prev) {
+			ctx.redirection = true
+			ctx.expectingPath = true
+		}
+	}
+	if ctx.commandName == "cd" {
+		ctx.expectingPath = true
+		ctx.onlyDirectory = true
+	}
+	return ctx
+}
+
+func currentSegment(fields []string) []string {
+	start := 0
+	for idx, field := range fields {
+		if field == "|" || field == ";" || field == "&&" {
+			start = idx + 1
+		}
+	}
+	return append([]string{}, fields[start:]...)
+}
+
+func firstCommandToken(segment []string) string {
+	skipNext := false
+	for _, field := range segment {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if isRedirectionOperator(field) {
+			skipNext = true
+			continue
+		}
+		if isCompletionOperator(field) || isAssignmentToken(field) || field == "" {
+			continue
+		}
+		return field
+	}
+	return ""
+}
+
+func shouldCompletePath(commandName string, currentWord string) bool {
+	if currentWord == "" {
+		return commandName == "ls" || commandName == "cat"
+	}
+	if strings.HasPrefix(currentWord, "/") || strings.HasPrefix(currentWord, "./") || strings.HasPrefix(currentWord, "../") || strings.HasPrefix(currentWord, "~/") {
+		return true
+	}
+	if strings.HasPrefix(currentWord, "$") || strings.Contains(currentWord, "/") {
+		return true
+	}
+	return commandName == "ls" || commandName == "cat"
+}
+
+func isAssignmentToken(token string) bool {
+	if token == "" {
+		return false
+	}
+	idx := strings.IndexByte(token, '=')
+	if idx <= 0 {
+		return false
+	}
+	name := token[:idx]
+	for i, ch := range name {
+		if i == 0 {
+			if !(ch == '_' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z') {
+				return false
+			}
+			continue
+		}
+		if !(ch == '_' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func isCompletionOperator(token string) bool {
+	return token == "" || token == "|" || token == ";" || token == "&&" || isRedirectionOperator(token)
+}
+
+func isRedirectionOperator(token string) bool {
+	return token == "<" || token == ">" || token == ">>"
+}
+
+func (sh *Shell) completeCommand(prefix string) []completionCandidate {
+	if sh == nil || sh.env == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	results := []completionCandidate{}
+	appendCandidate := func(name string) {
+		if !strings.HasPrefix(name, prefix) {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		results = append(results, completionCandidate{Insert: name, Display: name, Kind: candidateCommand})
+	}
+
+	for _, name := range []string{"alias", "cd", "setenv", "unsetenv", "which", "exit", "quit"} {
+		appendCandidate(name)
+	}
+
+	aliasNames := make([]string, 0, len(sh.env.Aliases()))
+	for name := range sh.env.Aliases() {
+		aliasNames = append(aliasNames, name)
+	}
+	sort.Strings(aliasNames)
+	for _, name := range aliasNames {
+		appendCandidate(name)
+	}
+
+	if sh.env.Filesystem() == nil {
+		return results
+	}
+	if pathValue, ok := sh.env.Get("PATH").(string); ok {
+		for _, dir := range strings.Split(pathValue, ":") {
+			resolvedDir := sh.env.ResolveAbsPath(dir)
+			entries, err := sh.readDir(resolvedDir)
+			if err != nil {
+				continue
+			}
+			for _, entry := range entries {
+				name := entry.Name()
+				if entry.IsDir() {
+					if sh.pathExists(path.Join(resolvedDir, name, "index.js")) {
+						appendCandidate(name)
+					}
+					continue
+				}
+				if strings.HasSuffix(name, ".js") {
+					appendCandidate(strings.TrimSuffix(name, ".js"))
+				}
+			}
+		}
+	}
+	return results
+}
+
+func (sh *Shell) completePath(prefix string, onlyDirectory bool) []completionCandidate {
+	if sh == nil || sh.env == nil {
+		return nil
+	}
+	if sh.env.Filesystem() == nil {
+		return nil
+	}
+	typedDirPrefix, typedBasePrefix := splitTypedPath(prefix)
+	lookupDir := typedDirPrefix
+	if lookupDir == "" {
+		lookupDir = "."
+	}
+	resolvedDir := sh.env.ResolveAbsPath(lookupDir)
+	entries, err := sh.readDir(resolvedDir)
+	if err != nil {
+		return nil
+	}
+
+	results := make([]completionCandidate, 0)
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, typedBasePrefix) {
+			continue
+		}
+		if onlyDirectory && !entry.IsDir() {
+			continue
+		}
+		insert := joinTypedPath(typedDirPrefix, name)
+		display := insert
+		kind := candidateFile
+		if entry.IsDir() {
+			insert += "/"
+			display += "/"
+			kind = candidateDirectory
+		}
+		results = append(results, completionCandidate{Insert: insert, Display: display, Kind: kind})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Kind != results[j].Kind {
+			return results[i].Kind == candidateDirectory
+		}
+		return results[i].Display < results[j].Display
+	})
+	return results
+}
+
+func splitTypedPath(prefix string) (string, string) {
+	idx := strings.LastIndex(prefix, "/")
+	if idx == -1 {
+		return "", prefix
+	}
+	return prefix[:idx+1], prefix[idx+1:]
+}
+
+func joinTypedPath(dirPrefix string, entryName string) string {
+	switch dirPrefix {
+	case "", ".":
+		return entryName
+	default:
+		return dirPrefix + entryName
+	}
+}
+
+func (sh *Shell) pathExists(name string) bool {
+	if sh == nil || sh.env == nil || sh.env.Filesystem() == nil {
+		return false
+	}
+	fd, err := sh.openPath(name)
+	if err != nil {
+		return false
+	}
+	fd.Close()
+	return true
+}
+
+func (sh *Shell) readDir(name string) ([]fs.DirEntry, error) {
+	if sh == nil || sh.env == nil || sh.env.Filesystem() == nil {
+		return nil, fs.ErrInvalid
+	}
+	entries, err := fs.ReadDir(sh.env.Filesystem(), name)
+	if err == nil {
+		return entries, nil
+	}
+	alt := strings.TrimPrefix(name, "/")
+	if alt == "" {
+		alt = "."
+	}
+	if alt == name {
+		return nil, err
+	}
+	return fs.ReadDir(sh.env.Filesystem(), alt)
+}
+
+func (sh *Shell) openPath(name string) (fs.File, error) {
+	if sh == nil || sh.env == nil || sh.env.Filesystem() == nil {
+		return nil, fs.ErrInvalid
+	}
+	fd, err := sh.env.Filesystem().Open(name)
+	if err == nil {
+		return fd, nil
+	}
+	alt := strings.TrimPrefix(name, "/")
+	if alt == "" {
+		alt = "."
+	}
+	if alt == name {
+		return nil, err
+	}
+	return sh.env.Filesystem().Open(alt)
+}
+
+func candidateInserts(candidates []completionCandidate) []string {
+	results := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		results = append(results, candidate.Insert)
+	}
+	return results
+}
+
+func candidateDisplays(candidates []completionCandidate) []string {
+	results := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		results = append(results, candidate.Display)
+	}
+	return results
+}
+
+func formatCompletionInsert(rawWord string, insert string, kind candidateKind, keepEditing bool) string {
+	if kind == candidateCommand {
+		if keepEditing {
+			return insert
+		}
+		return insert + " "
+	}
+
+	needsQuote := needsQuotedCompletion(insert)
+	quoteChar, activeQuote := currentQuoteChar(rawWord)
+	if !activeQuote && !needsQuote {
+		if kind == candidateDirectory || keepEditing {
+			return insert
+		}
+		return insert + " "
+	}
+	if quoteChar == 0 {
+		quoteChar = '"'
+	}
+	if quoteChar == '\'' && strings.ContainsRune(insert, '\'') {
+		quoteChar = '"'
+	}
+	escaped := escapeCompletionText(insert, quoteChar)
+	formatted := string(quoteChar) + escaped
+	if kind == candidateDirectory || keepEditing {
+		return formatted
+	}
+	return formatted + string(quoteChar) + " "
+}
+
+func needsQuotedCompletion(value string) bool {
+	return strings.ContainsAny(value, " \t&|><;\"'")
+}
+
+func currentQuoteChar(rawWord string) (rune, bool) {
+	if rawWord == "" {
+		return 0, false
+	}
+	quote := rune(rawWord[0])
+	if quote != '\'' && quote != '"' {
+		return 0, false
+	}
+	count := 0
+	escaped := false
+	for _, ch := range rawWord {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == quote {
+			count++
+		}
+	}
+	return quote, count%2 == 1
+}
+
+func escapeCompletionText(value string, quoteChar rune) string {
+	if quoteChar == '\'' {
+		return strings.ReplaceAll(value, "\\", "\\\\")
+	}
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, string(quoteChar), "\\"+string(quoteChar))
+	return value
+}
+
+func longestCommonPrefix(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	prefix := values[0]
+	for _, value := range values[1:] {
+		for !strings.HasPrefix(value, prefix) {
+			if prefix == "" {
+				return ""
+			}
+			prefix = prefix[:len(prefix)-1]
+		}
+	}
+	return prefix
+}
+
+func lineToFields(line string, enclosure string, delimiter string) []string {
+	fields, _ := splitTextFields(line, len(line), enclosure, delimiter)
+	return fields
+}
+
+func splitBufferFields(buffer *readline.Buffer, enclosure string, delimiter string) ([]string, int) {
+	fields := []string{}
+	lastWordStart := buffer.Cursor
+	i := 0
+	for i < buffer.Cursor {
+		for i < buffer.Cursor && buffer.Buffer[i].String() == " " {
+			i++
+			lastWordStart = i
+		}
+		if i >= buffer.Cursor {
+			fields = append(fields, "")
+			break
+		}
+		start := i
+		quoteMask := 0
+		for i < buffer.Cursor {
+			cell := buffer.Buffer[i].String()
+			if isQuotedCell(cell, enclosure, &quoteMask) {
+				i++
+				continue
+			}
+			if quoteMask == 0 && cell == " " {
+				fields = append(fields, removeQuotes(buffer.SubString(start, i), enclosure))
+				lastWordStart = i + 1
+				i++
+				break
+			}
+			if quoteMask == 0 && strings.Contains(delimiter, cell) {
+				if start != i {
+					fields = append(fields, removeQuotes(buffer.SubString(start, i), enclosure))
+				}
+				operator := cell
+				if cell == "&" && i+1 < buffer.Cursor && buffer.Buffer[i+1].String() == "&" {
+					operator = "&&"
+					i++
+				} else if cell == ">" && i+1 < buffer.Cursor && buffer.Buffer[i+1].String() == ">" {
+					operator = ">>"
+					i++
+				}
+				fields = append(fields, operator)
+				lastWordStart = i + 1
+				i++
+				break
+			}
+			i++
+		}
+		if i >= buffer.Cursor && start < buffer.Cursor {
+			fields = append(fields, removeQuotes(buffer.SubString(start, i), enclosure))
+			lastWordStart = start
+		}
+	}
+	return fields, lastWordStart
+}
+
+func splitTextFields(text string, cursor int, enclosure string, delimiter string) ([]string, int) {
+	fields := []string{}
+	lastWordStart := cursor
+	i := 0
+	for i < cursor {
+		for i < cursor && text[i] == ' ' {
+			i++
+			lastWordStart = i
+		}
+		if i >= cursor {
+			fields = append(fields, "")
+			break
+		}
+		start := i
+		quoteMask := 0
+		for i < cursor {
+			cell := string(text[i])
+			if isQuotedCell(cell, enclosure, &quoteMask) {
+				i++
+				continue
+			}
+			if quoteMask == 0 && text[i] == ' ' {
+				fields = append(fields, removeQuotes(text[start:i], enclosure))
+				lastWordStart = i + 1
+				i++
+				break
+			}
+			if quoteMask == 0 && strings.Contains(delimiter, cell) {
+				if start != i {
+					fields = append(fields, removeQuotes(text[start:i], enclosure))
+				}
+				operator := cell
+				if text[i] == '&' && i+1 < cursor && text[i+1] == '&' {
+					operator = "&&"
+					i++
+				} else if text[i] == '>' && i+1 < cursor && text[i+1] == '>' {
+					operator = ">>"
+					i++
+				}
+				fields = append(fields, operator)
+				lastWordStart = i + 1
+				i++
+				break
+			}
+			i++
+		}
+		if i >= cursor && start < cursor {
+			fields = append(fields, removeQuotes(text[start:i], enclosure))
+			lastWordStart = start
+		}
+	}
+	return fields, lastWordStart
+}
+
+func isQuotedCell(cell string, enclosure string, mask *int) bool {
+	for idx, quote := range enclosure {
+		if cell != string(quote) {
+			continue
+		}
+		*mask ^= 1 << idx
+		return true
+	}
+	return false
+}
+
+func removeQuotes(text string, enclosure string) string {
+	return strings.Map(func(r rune) rune {
+		if strings.ContainsRune(enclosure, r) {
+			return -1
+		}
+		return r
+	}, text)
+}

--- a/jsh/lib/shell/shell.go
+++ b/jsh/lib/shell/shell.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/hymkor/go-multiline-ny"
-	"github.com/hymkor/go-multiline-ny/completion"
 	"github.com/machbase/neo-server/v8/jsh/engine"
 	"github.com/machbase/neo-server/v8/jsh/log"
 	"github.com/mattn/go-colorable"
@@ -186,12 +185,7 @@ func (sh *Shell) configureEditorSession(ed *multiline.Editor) {
 	ed.DefaultColor = "\x1B[37;49;1m"
 
 	// enable completion
-	ed.BindKey(keys.CtrlI, &completion.CmdCompletionOrList{
-		Delimiter:  "&|><",
-		Enclosure:  `"'`,
-		Postfix:    " ",
-		Candidates: sh.getCompletionCandidates,
-	})
+	ed.BindKey(keys.CtrlI, newShellCompletionCommand(sh))
 	sh.bindPredictionKeys(ed)
 }
 
@@ -256,10 +250,6 @@ func shouldAcceptPrediction(cursor int, bufferLen int, cursorLine int, lineCount
 		return true
 	}
 	return cursorLine >= lineCount-1
-}
-
-func (sh *Shell) getCompletionCandidates(fields []string) (forCompletion []string, forListing []string) {
-	return
 }
 
 // process evaluates shell statements and operators.

--- a/jsh/lib/shell/shell_test.go
+++ b/jsh/lib/shell/shell_test.go
@@ -3,7 +3,12 @@ package shell
 import (
 	"bytes"
 	"context"
+	"io"
+	"reflect"
+	"strings"
 	"testing"
+	"testing/fstest"
+	"unsafe"
 
 	"github.com/dop251/goja"
 	"github.com/hymkor/go-multiline-ny"
@@ -194,6 +199,323 @@ func TestPredictHistoryAndCompletionCandidates(t *testing.T) {
 	if forCompletion != nil || forListing != nil {
 		t.Fatalf("getCompletionCandidates() = (%v, %v), want (nil, nil)", forCompletion, forListing)
 	}
+}
+
+func TestCompletePath(t *testing.T) {
+	fileSystem := fstest.MapFS{
+		"work/file.txt":     &fstest.MapFile{Data: []byte("hello")},
+		"work/folder/a.txt": &fstest.MapFile{Data: []byte("a")},
+		"bin/echo.js":       &fstest.MapFile{Data: []byte("echo")},
+	}
+	sh := &Shell{env: engine.NewEnv(engine.WithFilesystem(fileSystem))}
+	sh.env.Set("PWD", "/")
+
+	got := sh.completePath("/wo", false)
+	if len(got) != 1 || got[0].Insert != "/work/" || got[0].Kind != candidateDirectory {
+		t.Fatalf("completePath(/wo) = %+v, want /work/ directory candidate", got)
+	}
+
+	got = sh.completePath("/work/fi", false)
+	if len(got) != 1 || got[0].Insert != "/work/file.txt" || got[0].Kind != candidateFile {
+		t.Fatalf("completePath(/work/fi) = %+v, want /work/file.txt file candidate", got)
+	}
+
+	got = sh.completePath("/work/f", true)
+	if len(got) != 1 || got[0].Insert != "/work/folder/" || got[0].Kind != candidateDirectory {
+		t.Fatalf("completePath(/work/f, dir only) = %+v, want /work/folder/ directory candidate", got)
+	}
+}
+
+func TestCompleteCommand(t *testing.T) {
+	fileSystem := fstest.MapFS{
+		"bin/echo.js":         &fstest.MapFile{Data: []byte("echo")},
+		"bin/env/index.js":    &fstest.MapFile{Data: []byte("env")},
+		"usr/bin/which.js":    &fstest.MapFile{Data: []byte("which")},
+		"work/sample.txt":     &fstest.MapFile{Data: []byte("sample")},
+		"work/node_modules/x": &fstest.MapFile{Data: []byte("x")},
+		"node_modules/.bin/x": &fstest.MapFile{Data: []byte("x")},
+	}
+	env := engine.NewEnv(engine.WithFilesystem(fileSystem))
+	env.Set("PWD", "/")
+	env.Set("PATH", "/bin:/usr/bin")
+	env.SetAlias("ec", []string{"echo"})
+	sh := &Shell{env: env}
+
+	got := sh.completeCommand("e")
+	inserts := candidateInserts(got)
+	if !containsString(inserts, "echo") || !containsString(inserts, "ec") || !containsString(inserts, "env") || !containsString(inserts, "exit") {
+		t.Fatalf("completeCommand(e) = %v, want echo/ec/env/exit candidates", inserts)
+	}
+	if containsString(inserts, "which") {
+		t.Fatalf("completeCommand(e) = %v, did not expect which", inserts)
+	}
+}
+
+func TestBuildCompletionContext(t *testing.T) {
+	sh := &Shell{}
+
+	ctx := sh.buildCompletionContext([]string{"echo", "a", ";", "ls", "/wo"})
+	if ctx.commandName != "ls" || ctx.currentWord != "/wo" || !shouldCompletePath(ctx.commandName, ctx.currentWord) {
+		t.Fatalf("buildCompletionContext(last statement) = %+v, want ls /wo path context", ctx)
+	}
+
+	ctx = sh.buildCompletionContext([]string{"echo", "hi", ">", "/wo"})
+	if !ctx.expectingPath || !ctx.redirection {
+		t.Fatalf("buildCompletionContext(redirection) = %+v, want redirection path context", ctx)
+	}
+
+	ctx = sh.buildCompletionContext([]string{"ec"})
+	if !ctx.commandPosition || ctx.currentWord != "ec" {
+		t.Fatalf("buildCompletionContext(command position) = %+v, want command position for ec", ctx)
+	}
+}
+
+func TestShellCompletionCommandMetadataAndEditorState(t *testing.T) {
+	cmd := newShellCompletionCommand(&Shell{})
+	if got, want := cmd.String(), "SHELL_COMPLETION"; got != want {
+		t.Fatalf("shellCompletionCommand.String() = %q, want %q", got, want)
+	}
+
+	ed := &multiline.Editor{}
+	cmd.SetEditor(ed)
+	if cmd.editor != ed {
+		t.Fatal("shellCompletionCommand.SetEditor() did not store editor")
+	}
+
+	setUnexportedField(t, ed, "lines", []string{"echo hello", "ls /wo"})
+	setUnexportedField(t, ed, "csrline", 1)
+	fields := cmd.fieldsBeforeCurrentLine()
+	if len(fields) != 2 || fields[0] != "echo" || fields[1] != "hello" {
+		t.Fatalf("fieldsBeforeCurrentLine() = %v, want [echo hello]", fields)
+	}
+}
+
+func TestGetCompletionCandidatesAndHelpers(t *testing.T) {
+	fileSystem := fstest.MapFS{
+		"work/demo.txt":    &fstest.MapFile{Data: []byte("hello")},
+		"bin/echo.js":      &fstest.MapFile{Data: []byte("echo")},
+		"bin/env/index.js": &fstest.MapFile{Data: []byte("env")},
+	}
+	env := engine.NewEnv(engine.WithFilesystem(fileSystem))
+	env.Set("PWD", "/")
+	env.Set("PATH", "/bin")
+	env.SetAlias("ec", []string{"echo"})
+	sh := &Shell{env: env}
+
+	forCompletion, forListing := sh.getCompletionCandidates([]string{"e"})
+	if !containsString(forCompletion, "echo") || !containsString(forCompletion, "ec") {
+		t.Fatalf("getCompletionCandidates(command) = %v, want echo/ec", forCompletion)
+	}
+	if !containsString(forListing, "echo") || !containsString(forListing, "ec") {
+		t.Fatalf("getCompletionCandidates(listing) = %v, want echo/ec", forListing)
+	}
+
+	forCompletion, _ = sh.getCompletionCandidates([]string{"cd", "/wo"})
+	if !containsString(forCompletion, "/work/") {
+		t.Fatalf("getCompletionCandidates(path) = %v, want /work/", forCompletion)
+	}
+}
+
+func TestCompletionParsingHelpers(t *testing.T) {
+	if !isAssignmentToken("NAME=value") {
+		t.Fatal("isAssignmentToken(NAME=value) = false, want true")
+	}
+	if isAssignmentToken("1NAME=value") {
+		t.Fatal("isAssignmentToken(1NAME=value) = true, want false")
+	}
+
+	if got := firstCommandToken([]string{"NAME=value", "cat", ">", "out.txt"}); got != "cat" {
+		t.Fatalf("firstCommandToken() = %q, want cat", got)
+	}
+
+	fields := lineToFields(`echo "hello world"; cat /tmp`, `"'`, "&|><;")
+	if len(fields) != 5 || fields[0] != "echo" || fields[1] != "hello world" || fields[2] != ";" || fields[3] != "cat" || fields[4] != "/tmp" {
+		t.Fatalf("lineToFields() = %v, unexpected tokenization", fields)
+	}
+
+	fields, lastWordStart := splitTextFields(`echo hi >> out.txt`, len(`echo hi >> out.txt`), `"'`, "&|><;")
+	if len(fields) != 4 || fields[2] != ">>" || fields[3] != "out.txt" || lastWordStart != len(`echo hi >> `) {
+		t.Fatalf("splitTextFields() = (%v, %d), unexpected result", fields, lastWordStart)
+	}
+
+	buf, _ := newCompletionTestBuffer(t, `echo hi && cat /wo`)
+	fields, lastWordStart = splitBufferFields(buf, `"'`, "&|><;")
+	if len(fields) != 5 || fields[2] != "&&" || fields[4] != "/wo" || lastWordStart != len(`echo hi && cat `) {
+		t.Fatalf("splitBufferFields() = (%v, %d), unexpected result", fields, lastWordStart)
+	}
+
+	if got := currentSegment([]string{"echo", "a", ";", "ls", "/wo"}); len(got) != 2 || got[0] != "ls" || got[1] != "/wo" {
+		t.Fatalf("currentSegment() = %v, want [ls /wo]", got)
+	}
+}
+
+func TestCompletionFormattingHelpers(t *testing.T) {
+	if !shouldCompletePath("ls", "") {
+		t.Fatal("shouldCompletePath(ls, empty) = false, want true")
+	}
+	if shouldCompletePath("echo", "plain") {
+		t.Fatal("shouldCompletePath(echo, plain) = true, want false")
+	}
+	if !shouldCompletePath("echo", "$HOME/file") {
+		t.Fatal("shouldCompletePath(echo, $HOME/file) = false, want true")
+	}
+
+	if !needsQuotedCompletion("my file.txt") {
+		t.Fatal("needsQuotedCompletion(space) = false, want true")
+	}
+	if needsQuotedCompletion("plain.txt") {
+		t.Fatal("needsQuotedCompletion(plain) = true, want false")
+	}
+
+	if quote, active := currentQuoteChar(`"/work/my`); quote != '"' || !active {
+		t.Fatalf("currentQuoteChar(double) = (%q, %v), want (\" , true)", quote, active)
+	}
+	if quote, active := currentQuoteChar(`/work/my`); quote != 0 || active {
+		t.Fatalf("currentQuoteChar(none) = (%q, %v), want (0, false)", quote, active)
+	}
+
+	if got := escapeCompletionText(`my"file`, '"'); got != `my\"file` {
+		t.Fatalf("escapeCompletionText(double) = %q, want %q", got, `my\"file`)
+	}
+	if got := escapeCompletionText(`my\file`, '\''); got != `my\\file` {
+		t.Fatalf("escapeCompletionText(single) = %q, want %q", got, `my\\file`)
+	}
+
+	if got := formatCompletionInsert(`/work/my`, `/work/my dir/`, candidateDirectory, false); got != `"/work/my dir/` {
+		t.Fatalf("formatCompletionInsert(directory) = %q, want open quoted dir", got)
+	}
+	if got := formatCompletionInsert(`/work/my`, `/work/my file.txt`, candidateFile, false); got != `"/work/my file.txt" ` {
+		t.Fatalf("formatCompletionInsert(file) = %q, want closed quoted file", got)
+	}
+	if got := formatCompletionInsert(`plain`, `echo`, candidateCommand, false); got != `echo ` {
+		t.Fatalf("formatCompletionInsert(command) = %q, want command with space", got)
+	}
+
+	if got := longestCommonPrefix([]string{"alpha", "alpine", "alps"}); got != "alp" {
+		t.Fatalf("longestCommonPrefix() = %q, want alp", got)
+	}
+}
+
+func TestShellCompletionCommandCallQuotesSingleFilePath(t *testing.T) {
+	fileSystem := fstest.MapFS{
+		"work/my file.txt": &fstest.MapFile{Data: []byte("hello")},
+	}
+	env := engine.NewEnv(engine.WithFilesystem(fileSystem))
+	env.Set("PWD", "/")
+	sh := &Shell{env: env}
+	cmd := newShellCompletionCommand(sh)
+	buf, _ := newCompletionTestBuffer(t, `cat /work/my`)
+
+	cmd.Call(context.Background(), buf)
+
+	if got, want := buf.String(), `cat "/work/my file.txt" `; got != want {
+		t.Fatalf("shellCompletionCommand.Call(file with space) = %q, want %q", got, want)
+	}
+}
+
+func TestShellCompletionCommandCallKeepsDirectoryQuoteOpen(t *testing.T) {
+	fileSystem := fstest.MapFS{
+		"work/my dir/file.txt": &fstest.MapFile{Data: []byte("hello")},
+	}
+	env := engine.NewEnv(engine.WithFilesystem(fileSystem))
+	env.Set("PWD", "/")
+	sh := &Shell{env: env}
+	cmd := newShellCompletionCommand(sh)
+	buf, _ := newCompletionTestBuffer(t, `cd /work/my`)
+
+	cmd.Call(context.Background(), buf)
+
+	if got, want := buf.String(), `cd "/work/my dir/`; got != want {
+		t.Fatalf("shellCompletionCommand.Call(directory with space) = %q, want %q", got, want)
+	}
+}
+
+func TestShellCompletionCommandCallExtendsCommonPrefix(t *testing.T) {
+	fileSystem := fstest.MapFS{
+		"work/alpha.txt":  &fstest.MapFile{Data: []byte("a")},
+		"work/alpine.txt": &fstest.MapFile{Data: []byte("b")},
+	}
+	env := engine.NewEnv(engine.WithFilesystem(fileSystem))
+	env.Set("PWD", "/")
+	sh := &Shell{env: env}
+	cmd := newShellCompletionCommand(sh)
+	buf, out := newCompletionTestBuffer(t, `cat /work/al`)
+
+	cmd.Call(context.Background(), buf)
+
+	if got, want := buf.String(), `cat /work/alp`; got != want {
+		t.Fatalf("shellCompletionCommand.Call(common prefix) buffer = %q, want %q", got, want)
+	}
+	if printed := out.String(); containsSubstring(printed, "alpha.txt") || containsSubstring(printed, "alpine.txt") {
+		t.Fatalf("shellCompletionCommand.Call(common prefix) output = %q, did not expect candidate list", printed)
+	}
+}
+
+func TestShellCompletionCommandCallListsAmbiguousCandidates(t *testing.T) {
+	fileSystem := fstest.MapFS{
+		"work/alpha.txt": &fstest.MapFile{Data: []byte("a")},
+		"work/amber.txt": &fstest.MapFile{Data: []byte("b")},
+	}
+	env := engine.NewEnv(engine.WithFilesystem(fileSystem))
+	env.Set("PWD", "/")
+	sh := &Shell{env: env}
+	cmd := newShellCompletionCommand(sh)
+	buf, out := newCompletionTestBuffer(t, `cat /work/a`)
+
+	cmd.Call(context.Background(), buf)
+
+	if got, want := buf.String(), `cat /work/a`; got != want {
+		t.Fatalf("shellCompletionCommand.Call(ambiguous list) buffer = %q, want %q", got, want)
+	}
+	if printed := out.String(); !containsSubstring(printed, "alpha.txt") || !containsSubstring(printed, "amber.txt") {
+		t.Fatalf("shellCompletionCommand.Call(ambiguous list) output = %q, want listed candidates", printed)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubstring(value string, target string) bool {
+	return strings.Contains(value, target)
+}
+
+func newCompletionTestBuffer(tb testing.TB, text string) (*readline.Buffer, *bytes.Buffer) {
+	tb.Helper()
+	out := &bytes.Buffer{}
+	ed := &readline.Editor{
+		Writer: out,
+		PromptWriter: func(io.Writer) (int, error) {
+			return 0, nil
+		},
+	}
+	ed.Init()
+
+	buf := &readline.Buffer{
+		Editor: ed,
+		Buffer: make([]readline.Cell, 0, len(text)),
+	}
+	setUnexportedInt(tb, buf, "termWidth", 80+int(readline.ScrollMargin))
+	buf.InsertString(0, text)
+	buf.Cursor = len(buf.Buffer)
+	return buf, out
+}
+
+func setUnexportedInt(tb testing.TB, target any, fieldName string, value int) {
+	tb.Helper()
+	field := reflect.ValueOf(target).Elem().FieldByName(fieldName)
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().SetInt(int64(value))
+}
+
+func setUnexportedField(tb testing.TB, target any, fieldName string, value any) {
+	tb.Helper()
+	field := reflect.ValueOf(target).Elem().FieldByName(fieldName)
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
 }
 
 func TestExecReturnsExceptionValue(t *testing.T) {


### PR DESCRIPTION
This pull request refactors and enhances the shell's completion system, replacing the previous completion logic with a new, more robust implementation and introducing comprehensive tests for completion features. The changes improve maintainability and test coverage for path and command completion, context parsing, and formatting.

**Shell completion system refactor:**

* Replaces the previous dependency on `go-multiline-ny/completion` with a custom `shellCompletionCommand` implementation, updating how the Ctrl-I key is bound for completion in the editor (`shell.go`). [[1]](diffhunk://#diff-6c1f8807ad18a6d5b94351daa56ca42de9512e86879afd850f1145f79443c26aL12) [[2]](diffhunk://#diff-6c1f8807ad18a6d5b94351daa56ca42de9512e86879afd850f1145f79443c26aL189-R188)
* Removes the unused `getCompletionCandidates` method stub from the `Shell` struct (`shell.go`).

**Test coverage and helpers:**

* Adds extensive unit tests for path and command completion, completion context building, formatting, and shell completion command behavior, ensuring correct handling of various edge cases and scenarios (`shell_test.go`).
* Introduces helper functions for test buffer creation, field manipulation, and string matching to support the new tests (`shell_test.go`).
* Updates imports to include necessary testing and reflection packages (`shell_test.go`).