### PR TITLE
Add comprehensive tests for bridge and TQL modules

### DIFF
--- a/mods/bridge/connector/connector_test.go
+++ b/mods/bridge/connector/connector_test.go
@@ -1,0 +1,104 @@
+package connector
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/machbase/neo-server/v8/mods/bridge/connector/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+func resetDatabasesForTest(t *testing.T) {
+	t.Helper()
+	databasesLock.Lock()
+	prev := databases
+	databases = map[string]*BridgedDatabase{}
+	databasesLock.Unlock()
+	t.Cleanup(func() {
+		databasesLock.Lock()
+		databases = prev
+		databasesLock.Unlock()
+	})
+}
+
+func sqliteDataSource(t *testing.T) string {
+	t.Helper()
+	return "file:" + filepath.Join(t.TempDir(), "connector.db") + "?cache=shared"
+}
+
+func TestNewCachesAndConnectsSqlite(t *testing.T) {
+	resetDatabasesForTest(t)
+
+	ctx := context.Background()
+	name := "sqlite," + sqliteDataSource(t)
+
+	first, err := New(name)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := New(name)
+	require.NoError(t, err)
+	require.Same(t, first, second)
+
+	bridged := first.(*BridgedDatabase)
+	conn, err := bridged.Connect(ctx)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	_, err = bridged.Ping(ctx)
+	require.NoError(t, err)
+
+	ok, reason, err := bridged.UserAuth(ctx, "user", "password")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Empty(t, reason)
+
+	_, err = New("unknown,dsn")
+	require.EqualError(t, err, "unknown database type: unknown,dsn")
+}
+
+func TestNewWithDataSourceAndSetDatabase(t *testing.T) {
+	resetDatabasesForTest(t)
+
+	dataSource := sqliteDataSource(t)
+	db, opts, err := NewWithDataSource("sqlite", dataSource)
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	require.Empty(t, opts)
+
+	_, _, err = NewWithDataSource("postgresql", "postgres://user:pass@127.0.0.1/db")
+	require.NoError(t, err)
+
+	_, _, err = NewWithDataSource("mysql", "user:pass@tcp(127.0.0.1:3306)/db")
+	require.NoError(t, err)
+
+	_, _, err = NewWithDataSource("mssql", "sqlserver://user:pass@127.0.0.1:1433?database=db")
+	require.NoError(t, err)
+
+	_, _, err = NewWithDataSource("unknown", "dsn")
+	require.EqualError(t, err, "unknown database type: unknown")
+
+	sqlDB, err := sqlite.Connect(dataSource)
+	require.NoError(t, err)
+	t.Cleanup(func() { sqlDB.Close() })
+
+	SetDatabase("preloaded", sqlDB, "sqlite", dataSource)
+	preloaded, err := New("preloaded")
+	require.NoError(t, err)
+	require.NotNil(t, preloaded)
+
+	require.PanicsWithValue(t, "db is nil", func() {
+		SetDatabase("panic", nil, "sqlite", dataSource)
+	})
+}
+
+func TestBridgedDatabasePingFailure(t *testing.T) {
+	db, err := sqlite.Connect(sqliteDataSource(t))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	bridged := &BridgedDatabase{db: db}
+	_, err = bridged.Ping(context.Background())
+	require.Error(t, err)
+}

--- a/mods/bridge/connector/connector_test.go
+++ b/mods/bridge/connector/connector_test.go
@@ -9,6 +9,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func closeBridgedDatabase(t *testing.T, db any) {
+	t.Helper()
+	bridged, ok := db.(*BridgedDatabase)
+	if !ok || bridged == nil || bridged.db == nil {
+		return
+	}
+	require.NoError(t, bridged.db.Close())
+}
+
 func resetDatabasesForTest(t *testing.T) {
 	t.Helper()
 	databasesLock.Lock()
@@ -16,6 +25,11 @@ func resetDatabasesForTest(t *testing.T) {
 	databases = map[string]*BridgedDatabase{}
 	databasesLock.Unlock()
 	t.Cleanup(func() {
+		for _, db := range databases {
+			if db != nil && db.db != nil {
+				require.NoError(t, db.db.Close())
+			}
+		}
 		databasesLock.Lock()
 		databases = prev
 		databasesLock.Unlock()
@@ -36,6 +50,7 @@ func TestNewCachesAndConnectsSqlite(t *testing.T) {
 	first, err := New(name)
 	require.NoError(t, err)
 	require.NotNil(t, first)
+	t.Cleanup(func() { closeBridgedDatabase(t, first) })
 
 	second, err := New(name)
 	require.NoError(t, err)
@@ -66,6 +81,7 @@ func TestNewWithDataSourceAndSetDatabase(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, db)
 	require.Empty(t, opts)
+	t.Cleanup(func() { closeBridgedDatabase(t, db) })
 
 	_, _, err = NewWithDataSource("postgresql", "postgres://user:pass@127.0.0.1/db")
 	require.NoError(t, err)

--- a/mods/bridge/internal/base_test.go
+++ b/mods/bridge/internal/base_test.go
@@ -1,0 +1,183 @@
+package internal
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/machbase/neo-client/api"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+func openTestConn(t *testing.T) *sql.Conn {
+	t.Helper()
+	db, err := sql.Open("sqlite3", "file:"+filepath.Join(t.TempDir(), "internal.db")+"?cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+func TestConnAndRows(t *testing.T) {
+	ctx := context.Background()
+	conn := NewConn(openTestConn(t))
+
+	require.Panics(t, func() {
+		conn.Prepare(ctx, "select 1")
+	})
+
+	result := conn.Exec(ctx, `CREATE TABLE example(id INTEGER PRIMARY KEY, name TEXT, created_at DATETIME)`)
+	require.NoError(t, result.Err())
+	require.EqualValues(t, 0, result.RowsAffected())
+	require.Empty(t, result.Message())
+
+	insertedAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	result = conn.Exec(ctx, `INSERT INTO example(id, name, created_at) VALUES(?, ?, ?)`, 1, "alpha", insertedAt)
+	require.NoError(t, result.Err())
+	require.EqualValues(t, 1, result.RowsAffected())
+
+	rows, err := conn.Query(ctx, `SELECT id, name FROM example ORDER BY id`)
+	require.NoError(t, err)
+	defer rows.Close()
+	require.True(t, rows.IsFetchable())
+	require.Equal(t, int64(0), rows.RowsAffected())
+	require.Equal(t, "success", rows.Message())
+
+	cols, err := rows.Columns()
+	require.NoError(t, err)
+	require.Len(t, cols.Names(), 2)
+	require.Equal(t, api.DataTypeInt64, cols[0].DataType)
+	require.Equal(t, api.DataTypeString, cols[1].DataType)
+
+	require.True(t, rows.Next())
+	var id int64
+	var name string
+	require.NoError(t, rows.Scan(&id, &name))
+	require.EqualValues(t, 1, id)
+	require.Equal(t, "alpha", name)
+	require.False(t, rows.Next())
+	require.NoError(t, rows.Err())
+
+	row := conn.QueryRow(ctx, `SELECT id, name, created_at FROM example WHERE id = ?`, 1)
+	require.NoError(t, row.Err())
+	rowCols, err := row.Columns()
+	require.NoError(t, err)
+	require.Len(t, rowCols.Names(), 3)
+
+	var rowID int64
+	var rowName string
+	var rowCreatedAt time.Time
+	require.NoError(t, row.Scan(&rowID, &rowName, &rowCreatedAt))
+	require.EqualValues(t, 1, rowID)
+	require.Equal(t, "alpha", rowName)
+	require.True(t, insertedAt.Equal(rowCreatedAt))
+	require.Equal(t, int64(0), row.RowsAffected())
+	require.Empty(t, row.Message())
+
+	missing := conn.QueryRow(ctx, `SELECT id FROM example WHERE id = ?`, 999)
+	require.EqualError(t, missing.Err(), sql.ErrNoRows.Error())
+
+	row = conn.QueryRow(ctx, `SELECT id FROM example WHERE id = ?`, 1)
+	require.Error(t, row.Scan(&rowID, &rowName))
+
+	_, err = conn.Appender(ctx, "example")
+	require.EqualError(t, err, api.ErrNotImplemented("Appender").Error())
+
+	_, err = conn.Explain(ctx, `SELECT * FROM example`, false)
+	require.EqualError(t, err, api.ErrNotImplemented("Explain").Error())
+
+	require.NoError(t, conn.Close())
+}
+
+func TestResultAndScanTypeHelpers(t *testing.T) {
+	errResult := &Result{err: sql.ErrConnDone}
+	require.EqualError(t, errResult.Err(), sql.ErrConnDone.Error())
+	require.Equal(t, sql.ErrConnDone.Error(), errResult.Message())
+
+	cases := map[string]api.DataType{
+		"bool":            api.DataTypeBoolean,
+		"sql.NullBool":    api.DataTypeBoolean,
+		"int8":            api.DataTypeInt16,
+		"sql.NullByte":    api.DataTypeInt16,
+		"int16":           api.DataTypeInt16,
+		"sql.NullInt16":   api.DataTypeInt16,
+		"int32":           api.DataTypeInt32,
+		"sql.NullInt32":   api.DataTypeInt32,
+		"int64":           api.DataTypeInt64,
+		"sql.NullInt64":   api.DataTypeInt64,
+		"float32":         api.DataTypeFloat32,
+		"float64":         api.DataTypeFloat64,
+		"sql.NullFloat64": api.DataTypeFloat64,
+		"string":          api.DataTypeString,
+		"sql.NullString":  api.DataTypeString,
+		"time.Time":       api.DataTypeDatetime,
+		"sql.NullTime":    api.DataTypeDatetime,
+		"[]byte":          api.DataTypeBinary,
+		"sql.RawBytes":    api.DataTypeBinary,
+		"*interface {}":   api.DataTypeString,
+		"unknown":         api.DataTypeAny,
+	}
+	for input, want := range cases {
+		require.Equal(t, want, scanTypeToDataType(input))
+	}
+
+	base := &SqlBridgeBase{}
+	require.IsType(t, new(bool), base.NewScanType("sql.NullBool", ""))
+	require.IsType(t, new(uint8), base.NewScanType("sql.NullByte", ""))
+	require.IsType(t, new(float64), base.NewScanType("sql.NullFloat64", ""))
+	require.IsType(t, new(int16), base.NewScanType("sql.NullInt16", ""))
+	require.IsType(t, new(int32), base.NewScanType("sql.NullInt32", ""))
+	require.IsType(t, new(int64), base.NewScanType("sql.NullInt64", ""))
+	require.IsType(t, new(string), base.NewScanType("sql.NullString", ""))
+	require.IsType(t, new(sql.NullTime), base.NewScanType("sql.NullTime", ""))
+	require.IsType(t, new([]byte), base.NewScanType("sql.RawBytes", ""))
+	require.IsType(t, new([]byte), base.NewScanType("[]uint8", ""))
+	require.IsType(t, new(bool), base.NewScanType("bool", ""))
+	require.IsType(t, new(int32), base.NewScanType("int32", ""))
+	require.IsType(t, new(int64), base.NewScanType("int64", ""))
+	require.IsType(t, new(string), base.NewScanType("string", ""))
+	require.IsType(t, new(time.Time), base.NewScanType("time.Time", ""))
+	require.Nil(t, base.NewScanType("unknown", ""))
+
+	nullBool := &sql.NullBool{Bool: true, Valid: true}
+	nullByte := &sql.NullByte{Byte: 2, Valid: true}
+	nullFloat := &sql.NullFloat64{Float64: 1.25, Valid: true}
+	nullInt16 := &sql.NullInt16{Int16: 16, Valid: true}
+	nullInt32 := &sql.NullInt32{Int32: 32, Valid: true}
+	nullInt64 := &sql.NullInt64{Int64: 64, Valid: true}
+	nullString := &sql.NullString{String: "text", Valid: true}
+	nullTime := &sql.NullTime{Time: time.Unix(0, 10), Valid: true}
+	raw := sql.RawBytes("bytes")
+
+	normalized := base.NormalizeType([]any{
+		raw,
+		nullBool,
+		nullByte,
+		nullFloat,
+		nullInt16,
+		nullInt32,
+		nullInt64,
+		nullString,
+		nullTime,
+		&sql.NullString{},
+	})
+	require.Equal(t, []byte("bytes"), normalized[0])
+	require.Equal(t, true, normalized[1])
+	require.EqualValues(t, 2, normalized[2])
+	require.Equal(t, 1.25, normalized[3])
+	require.EqualValues(t, 16, normalized[4])
+	require.EqualValues(t, 32, normalized[5])
+	require.EqualValues(t, 64, normalized[6])
+	require.Equal(t, "text", normalized[7])
+	require.Equal(t, nullTime.Time, normalized[8])
+	require.Nil(t, normalized[9])
+
+	wrapped := base.Conn(openTestConn(t))
+	require.IsType(t, &Conn{}, wrapped)
+}

--- a/mods/bridge/service_test.go
+++ b/mods/bridge/service_test.go
@@ -1,0 +1,296 @@
+package bridge_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/machbase/neo-server/v8/mods/bridge"
+	"github.com/machbase/neo-server/v8/mods/model"
+	"github.com/stretchr/testify/require"
+)
+
+type bridgeProviderStub struct {
+	defs        map[string]*model.BridgeDefinition
+	loadAllErr  error
+	loadErr     error
+	saveErr     error
+	removeErr   error
+	lastSaved   *model.BridgeDefinition
+	lastRemoved string
+}
+
+func newBridgeProviderStub(defs ...*model.BridgeDefinition) *bridgeProviderStub {
+	ret := &bridgeProviderStub{defs: map[string]*model.BridgeDefinition{}}
+	for _, def := range defs {
+		cloned := *def
+		ret.defs[def.Name] = &cloned
+	}
+	return ret
+}
+
+func (p *bridgeProviderStub) LoadAllBridges() ([]*model.BridgeDefinition, error) {
+	if p.loadAllErr != nil {
+		return nil, p.loadAllErr
+	}
+	ret := make([]*model.BridgeDefinition, 0, len(p.defs))
+	for _, def := range p.defs {
+		cloned := *def
+		ret = append(ret, &cloned)
+	}
+	return ret, nil
+}
+
+func (p *bridgeProviderStub) LoadBridge(name string) (*model.BridgeDefinition, error) {
+	if p.loadErr != nil {
+		return nil, p.loadErr
+	}
+	def, ok := p.defs[name]
+	if !ok {
+		return nil, fmt.Errorf("bridge '%s' not found", name)
+	}
+	cloned := *def
+	return &cloned, nil
+}
+
+func (p *bridgeProviderStub) SaveBridge(def *model.BridgeDefinition) error {
+	if p.saveErr != nil {
+		return p.saveErr
+	}
+	cloned := *def
+	p.lastSaved = &cloned
+	p.defs[def.Name] = &cloned
+	return nil
+}
+
+func (p *bridgeProviderStub) RemoveBridge(name string) error {
+	if p.removeErr != nil {
+		return p.removeErr
+	}
+	p.lastRemoved = name
+	delete(p.defs, name)
+	return nil
+}
+
+func sqliteBridgePath(t *testing.T) string {
+	t.Helper()
+	return "file:" + filepath.Join(t.TempDir(), "bridge.db") + "?cache=shared"
+}
+
+func TestServiceStartStop(t *testing.T) {
+	bridge.UnregisterAll()
+	t.Cleanup(bridge.UnregisterAll)
+
+	provider := newBridgeProviderStub(&model.BridgeDefinition{
+		Name: "bridge_start_stop",
+		Type: model.BRIDGE_SQLITE,
+		Path: sqliteBridgePath(t),
+	})
+	svc := bridge.NewService(bridge.WithProvider(provider))
+
+	require.NoError(t, svc.Start())
+	registered, err := bridge.GetBridge("bridge_start_stop")
+	require.NoError(t, err)
+	require.Equal(t, "bridge_start_stop", registered.Name())
+
+	svc.Stop()
+	_, err = bridge.GetBridge("bridge_start_stop")
+	require.EqualError(t, err, "undefined bridge name 'bridge_start_stop'")
+}
+
+func TestServiceSqliteLifecycle(t *testing.T) {
+	bridge.UnregisterAll()
+	t.Cleanup(bridge.UnregisterAll)
+
+	provider := newBridgeProviderStub()
+	svc := bridge.NewService(bridge.WithProvider(provider))
+	ctx := context.Background()
+	name := "bridge_service_sqlite"
+
+	addRsp, err := svc.AddBridge(ctx, &bridge.AddBridgeRequest{
+		Name: name,
+		Type: "sqlite",
+		Path: sqliteBridgePath(t),
+	})
+	require.NoError(t, err)
+	require.True(t, addRsp.Success)
+	require.Equal(t, "success", addRsp.Reason)
+	require.NotEmpty(t, addRsp.Elapse)
+	require.NotNil(t, provider.lastSaved)
+	require.Equal(t, name, provider.lastSaved.Name)
+
+	listRsp, err := svc.ListBridge(ctx)
+	require.NoError(t, err)
+	require.True(t, listRsp.Success)
+	require.Equal(t, "success", listRsp.Reason)
+	require.Len(t, listRsp.Bridges, 1)
+	require.Equal(t, name, listRsp.Bridges[0].Name)
+	require.Equal(t, "sqlite", listRsp.Bridges[0].Type)
+
+	getRsp, err := svc.GetBridge(ctx, &bridge.GetBridgeRequest{Name: name})
+	require.NoError(t, err)
+	require.True(t, getRsp.Success)
+	require.Equal(t, name, getRsp.Bridge.Name)
+
+	testRsp, err := svc.TestBridge(ctx, &bridge.TestBridgeRequest{Name: name})
+	require.NoError(t, err)
+	require.True(t, testRsp.Success)
+	require.Equal(t, "success", testRsp.Reason)
+
+	createRsp, err := svc.Exec(ctx, &bridge.ExecRequest{
+		Name: name,
+		Command: bridge.ExecCommand{
+			SqlExec: &bridge.SqlRequest{SqlText: `CREATE TABLE example(id INTEGER PRIMARY KEY, name TEXT)`},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, createRsp.Success)
+	require.EqualValues(t, 0, createRsp.Result.SqlExecResult.RowsAffected)
+	require.EqualValues(t, 0, createRsp.Result.SqlExecResult.LastInsertedId)
+
+	insertRsp, err := svc.Exec(ctx, &bridge.ExecRequest{
+		Name: name,
+		Command: bridge.ExecCommand{
+			SqlExec: &bridge.SqlRequest{SqlText: `INSERT INTO example(id, name) VALUES(?, ?)`, Params: []any{1, "alpha"}},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, insertRsp.Success)
+	require.EqualValues(t, 1, insertRsp.Result.SqlExecResult.RowsAffected)
+	require.EqualValues(t, 1, insertRsp.Result.SqlExecResult.LastInsertedId)
+
+	queryRsp, err := svc.Exec(ctx, &bridge.ExecRequest{
+		Name: name,
+		Command: bridge.ExecCommand{
+			SqlQuery: &bridge.SqlRequest{SqlText: `SELECT id, name FROM example ORDER BY id`},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, queryRsp.Success)
+	require.Equal(t, "success", queryRsp.Reason)
+	require.Len(t, queryRsp.Result.SqlQueryResult.Fields, 2)
+	require.NotEmpty(t, queryRsp.Result.SqlQueryResult.Handle)
+
+	fetchRsp, err := svc.SqlQueryResultFetch(ctx, queryRsp.Result.SqlQueryResult)
+	require.NoError(t, err)
+	require.True(t, fetchRsp.Success)
+	require.False(t, fetchRsp.HasNoRows)
+	require.Equal(t, []any{int64(1), "alpha"}, fetchRsp.Values)
+
+	fetchEndRsp, err := svc.SqlQueryResultFetch(ctx, queryRsp.Result.SqlQueryResult)
+	require.NoError(t, err)
+	require.True(t, fetchEndRsp.Success)
+	require.True(t, fetchEndRsp.HasNoRows)
+	require.Empty(t, fetchEndRsp.Values)
+
+	closeRsp, err := svc.SqlQueryResultClose(ctx, queryRsp.Result.SqlQueryResult)
+	require.NoError(t, err)
+	require.True(t, closeRsp.Success)
+	require.Equal(t, "success", closeRsp.Reason)
+
+	missingHandleRsp, err := svc.SqlQueryResultFetch(ctx, queryRsp.Result.SqlQueryResult)
+	require.NoError(t, err)
+	require.False(t, missingHandleRsp.Success)
+	require.Equal(t, fmt.Sprintf("SqlBridge: handle '%s' not found", queryRsp.Result.SqlQueryResult.Handle), missingHandleRsp.Reason)
+
+	statsRsp, err := svc.StatsBridge(ctx, &bridge.StatsBridgeRequest{Name: name})
+	require.NoError(t, err)
+	require.False(t, statsRsp.Success)
+	require.Equal(t, fmt.Sprintf("bridge '%s' does not support stats", name), statsRsp.Reason)
+
+	delRsp, err := svc.DelBridge(ctx, &bridge.DelBridgeRequest{Name: name})
+	require.NoError(t, err)
+	require.True(t, delRsp.Success)
+	require.Equal(t, name, provider.lastRemoved)
+
+	_, err = bridge.GetBridge(name)
+	require.EqualError(t, err, fmt.Sprintf("undefined bridge name '%s'", name))
+}
+
+func TestServiceErrorPaths(t *testing.T) {
+	bridge.UnregisterAll()
+	t.Cleanup(bridge.UnregisterAll)
+
+	t.Run("list and get failures", func(t *testing.T) {
+		provider := newBridgeProviderStub()
+		provider.loadAllErr = fmt.Errorf("load all failed")
+		provider.loadErr = fmt.Errorf("load failed")
+		svc := bridge.NewService(bridge.WithProvider(provider))
+
+		listRsp, err := svc.ListBridge(context.Background())
+		require.NoError(t, err)
+		require.False(t, listRsp.Success)
+		require.Equal(t, "load all failed", listRsp.Reason)
+
+		getRsp, err := svc.GetBridge(context.Background(), &bridge.GetBridgeRequest{Name: "missing"})
+		require.NoError(t, err)
+		require.False(t, getRsp.Success)
+		require.Equal(t, "load failed", getRsp.Reason)
+	})
+
+	t.Run("add validations and persistence failure", func(t *testing.T) {
+		provider := newBridgeProviderStub()
+		svc := bridge.NewService(bridge.WithProvider(provider))
+		ctx := context.Background()
+
+		tooLongRsp, err := svc.AddBridge(ctx, &bridge.AddBridgeRequest{Name: "01234567890123456789012345678901234567890", Type: "sqlite", Path: sqliteBridgePath(t)})
+		require.NoError(t, err)
+		require.False(t, tooLongRsp.Success)
+		require.Equal(t, "name is too long, should be shorter than 40 characters", tooLongRsp.Reason)
+
+		invalidTypeRsp, err := svc.AddBridge(ctx, &bridge.AddBridgeRequest{Name: "bad_type", Type: "invalid", Path: sqliteBridgePath(t)})
+		require.NoError(t, err)
+		require.False(t, invalidTypeRsp.Success)
+		require.Equal(t, "unsupported bridge type: invalid", invalidTypeRsp.Reason)
+
+		emptyPathRsp, err := svc.AddBridge(ctx, &bridge.AddBridgeRequest{Name: "empty_path", Type: "sqlite"})
+		require.NoError(t, err)
+		require.False(t, emptyPathRsp.Success)
+		require.Equal(t, "path is empty, it should be specified", emptyPathRsp.Reason)
+
+		provider.saveErr = fmt.Errorf("save failed")
+		saveFailRsp, err := svc.AddBridge(ctx, &bridge.AddBridgeRequest{Name: "save_fail", Type: "sqlite", Path: sqliteBridgePath(t)})
+		require.NoError(t, err)
+		require.False(t, saveFailRsp.Success)
+		require.Equal(t, "save failed", saveFailRsp.Reason)
+
+		bridge.Unregister("save_fail")
+	})
+
+	t.Run("exec fetch close and test missing bridge", func(t *testing.T) {
+		svc := bridge.NewService(bridge.WithProvider(newBridgeProviderStub()))
+		ctx := context.Background()
+
+		execRsp, err := svc.Exec(ctx, &bridge.ExecRequest{Name: "missing"})
+		require.NoError(t, err)
+		require.False(t, execRsp.Success)
+		require.Equal(t, "undefined bridge name 'missing'", execRsp.Reason)
+
+		fetchRsp, err := svc.SqlQueryResultFetch(ctx, &bridge.SqlQueryResult{Handle: "missing"})
+		require.NoError(t, err)
+		require.False(t, fetchRsp.Success)
+		require.Equal(t, "SqlBridge: handle 'missing' not found", fetchRsp.Reason)
+
+		closeRsp, err := svc.SqlQueryResultClose(ctx, &bridge.SqlQueryResult{Handle: "missing"})
+		require.NoError(t, err)
+		require.False(t, closeRsp.Success)
+		require.Equal(t, "handle 'missing' not found", closeRsp.Reason)
+
+		testRsp, err := svc.TestBridge(ctx, &bridge.TestBridgeRequest{Name: "missing"})
+		require.NoError(t, err)
+		require.False(t, testRsp.Success)
+		require.Equal(t, "undefined bridge name 'missing'", testRsp.Reason)
+	})
+
+	t.Run("remove failure", func(t *testing.T) {
+		provider := newBridgeProviderStub()
+		provider.removeErr = fmt.Errorf("remove failed")
+		svc := bridge.NewService(bridge.WithProvider(provider))
+
+		delRsp, err := svc.DelBridge(context.Background(), &bridge.DelBridgeRequest{Name: "missing"})
+		require.NoError(t, err)
+		require.False(t, delRsp.Success)
+		require.Equal(t, "remove failed", delRsp.Reason)
+	})
+}

--- a/mods/tql/fm_monad_test.go
+++ b/mods/tql/fm_monad_test.go
@@ -1,0 +1,422 @@
+package tql
+
+import (
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/machbase/neo-server/v8/mods/nums"
+	"github.com/stretchr/testify/require"
+	"gonum.org/v1/gonum/stat"
+)
+
+type capturePredictor struct {
+	fitErr     error
+	fittedX    []float64
+	fittedY    []float64
+	predictArg float64
+	ret        float64
+}
+
+func (p *capturePredictor) Fit(xs, ys []float64) error {
+	p.fittedX = append([]float64(nil), xs...)
+	p.fittedY = append([]float64(nil), ys...)
+	return p.fitErr
+}
+
+func (p *capturePredictor) Predict(x float64) float64 {
+	p.predictArg = x
+	return p.ret
+}
+
+func TestAggregateHelpers(t *testing.T) {
+	node := &Node{}
+
+	t.Run("covariance aggregate", func(t *testing.T) {
+		agg := node.fmCovariance(1.5, 2.5, Weight(3), "cov").(*GroupAggregate)
+		require.Equal(t, "covariance", agg.Type)
+		require.Equal(t, "cov", agg.Name)
+		require.Equal(t, []any{1.5, 2.5, Weight(3)}, agg.Value)
+	})
+
+	t.Run("quantile interpolated aggregate", func(t *testing.T) {
+		agg := node.fmQuantileInterpolated(10, 0.9).(*GroupAggregate)
+		require.Equal(t, "quantile", agg.Type)
+		require.Equal(t, "QUANTILE", agg.Name)
+		require.Equal(t, 10.0, agg.Value)
+		require.Equal(t, 0.9, agg.Percentile)
+		require.Equal(t, stat.LinInterp, agg.Cumulant)
+	})
+}
+
+func TestMapLowPass(t *testing.T) {
+	t.Run("invalid alpha", func(t *testing.T) {
+		node := &Node{}
+		node.SetInflight(NewRecord("k", []any{0.0}))
+
+		ret, err := node.fmMapLowPass(0, 10.0, 1.0)
+		require.Nil(t, ret)
+		require.EqualError(t, err, "MAP_LOWPASS() should have 0 < alpha < 1 ")
+	})
+
+	t.Run("stateful smoothing", func(t *testing.T) {
+		node := &Node{}
+		node.SetInflight(NewRecord("k", []any{0.0}))
+
+		ret, err := node.fmMapLowPass(0, 10.0, 0.25)
+		require.NoError(t, err)
+		require.Equal(t, []any{10.0}, ret.(*Record).Value())
+
+		node.SetInflight(NewRecord("k", []any{0.0}))
+		ret, err = node.fmMapLowPass(0, 14.0, 0.25)
+		require.NoError(t, err)
+		require.Equal(t, []any{11.0}, ret.(*Record).Value())
+	})
+}
+
+func TestGeoDistance(t *testing.T) {
+	node := &Node{}
+	seoul := nums.NewLatLon(37.5665, 126.9780)
+	busan := nums.NewLatLon(35.1796, 129.0756)
+
+	node.SetInflight(NewRecord("k", []any{99.0}))
+	ret, err := node.fmGeoDistance(0, seoul)
+	require.NoError(t, err)
+	values := ret.(*Record).Value().([]any)
+	require.Len(t, values, 1)
+	require.Zero(t, values[0])
+
+	node.SetInflight(NewRecord("k", []any{99.0}))
+	ret, err = node.fmGeoDistance(0, busan)
+	require.NoError(t, err)
+	values = ret.(*Record).Value().([]any)
+	require.Len(t, values, 1)
+	require.InDelta(t, busan.Distance(seoul), values[0].(float64), 0.001)
+
+	node.SetInflight(NewRecord("k", []any{99.0}))
+	ret, err = node.fmGeoDistance(0, "not-a-location")
+	require.NoError(t, err)
+	values = ret.(*Record).Value().([]any)
+	require.Len(t, values, 1)
+	require.Zero(t, values[0])
+}
+
+func TestGroupFillerPredict(t *testing.T) {
+	t.Run("fit keeps latest samples", func(t *testing.T) {
+		predictor := &capturePredictor{}
+		filler := &GroupFillerPredict{predictor: predictor, fallback: "fallback"}
+
+		filler.Fit("bad", 1.0)
+		filler.Fit(1.0, "bad")
+		require.Empty(t, filler.xs)
+		require.Empty(t, filler.ys)
+
+		for i := 0; i < 105; i++ {
+			filler.Fit(i, i*2)
+		}
+		require.Len(t, filler.xs, 100)
+		require.Len(t, filler.ys, 100)
+		require.Equal(t, 5.0, filler.xs[0])
+		require.Equal(t, 10.0, filler.ys[0])
+		require.Equal(t, 104.0, filler.xs[len(filler.xs)-1])
+		require.Equal(t, 208.0, filler.ys[len(filler.ys)-1])
+	})
+
+	t.Run("predict returns fallback when not ready", func(t *testing.T) {
+		plain := &GroupFillerPredict{fallback: "fallback"}
+		require.Equal(t, "fallback", plain.Predict(10.0))
+
+		withPredictor := &GroupFillerPredict{fallback: "fallback", predictor: &capturePredictor{ret: 9}}
+		withPredictor.Fit(1.0, 2.0)
+		require.Equal(t, "fallback", withPredictor.Predict(10.0))
+
+		withPredictor.Fit(2.0, 4.0)
+		require.Equal(t, "fallback", withPredictor.Predict("bad"))
+
+		failedFit := &GroupFillerPredict{fallback: "fallback", predictor: &capturePredictor{fitErr: errors.New("fit failed")}}
+		failedFit.Fit(1.0, 2.0)
+		failedFit.Fit(2.0, 4.0)
+		require.Equal(t, "fallback", failedFit.Predict(3.0))
+	})
+
+	t.Run("predict with linear regression", func(t *testing.T) {
+		filler := &GroupFillerPredict{fallback: -1.0, useLinearRegression: true}
+		filler.Fit(0.0, 1.0)
+		filler.Fit(1.0, 3.0)
+		filler.Fit(2.0, 5.0)
+
+		ret := filler.Predict(3.0)
+		require.InDelta(t, 7.0, ret.(float64), 1e-9)
+	})
+
+	t.Run("predict with external predictor", func(t *testing.T) {
+		base := time.Unix(0, 100)
+		next := base.Add(10 * time.Nanosecond)
+		predictor := &capturePredictor{ret: 123.5}
+		filler := &GroupFillerPredict{fallback: -1.0, predictor: predictor}
+
+		filler.Fit(base, 10)
+		filler.Fit(next, 20)
+
+		ret := filler.Predict(next)
+		require.Equal(t, 123.5, ret)
+		require.Equal(t, []float64{float64(base.UnixNano()), float64(next.UnixNano())}, predictor.fittedX)
+		require.Equal(t, []float64{10, 20}, predictor.fittedY)
+		require.Equal(t, float64(next.UnixNano()), predictor.predictArg)
+	})
+}
+
+func TestGroupFillersAndUnbox(t *testing.T) {
+	t.Run("null value filler", func(t *testing.T) {
+		filler := &GroupFillerNullValue{alt: "fallback"}
+		filler.Fit("ignored", 123)
+		require.Equal(t, "fallback", filler.Predict("anything"))
+	})
+
+	t.Run("time window filler", func(t *testing.T) {
+		filler := &GroupFillerTimeWindow{}
+		tick := time.Unix(0, 42)
+		filler.Fit("ignored", 123)
+		require.Equal(t, tick, filler.Predict(tick))
+	})
+
+	t.Run("unbox scalar types", func(t *testing.T) {
+		filler := &GroupFillerPredict{}
+		floatVal := 1.25
+		intVal := 7
+		int32Val := int32(8)
+		int64Val := int64(9)
+		timeVal := time.Unix(0, 100)
+
+		cases := []struct {
+			name  string
+			input any
+			want  float64
+			ok    bool
+		}{
+			{name: "nil", input: nil, want: 0, ok: false},
+			{name: "float64 pointer", input: &floatVal, want: 1.25, ok: true},
+			{name: "time pointer", input: &timeVal, want: float64(timeVal.UnixNano()), ok: true},
+			{name: "int pointer", input: &intVal, want: 7, ok: true},
+			{name: "int32", input: int32Val, want: 8, ok: true},
+			{name: "int32 pointer", input: &int32Val, want: 8, ok: true},
+			{name: "int64", input: int64Val, want: 9, ok: true},
+			{name: "int64 pointer", input: &int64Val, want: 9, ok: true},
+			{name: "unsupported", input: "bad", want: 0, ok: false},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got, ok := filler.unbox(tc.input)
+				require.Equal(t, tc.ok, ok)
+				require.Equal(t, tc.want, got)
+			})
+		}
+	})
+}
+
+func TestThrottle(t *testing.T) {
+	t.Run("nil inflight still initializes throttle", func(t *testing.T) {
+		node := &Node{}
+		require.Nil(t, node.fmThrottle(1000))
+
+		value, ok := node.GetValue("throttle")
+		require.True(t, ok)
+		throttle := value.(*Throttle)
+		require.Equal(t, time.Millisecond, throttle.minDuration)
+	})
+
+	t.Run("returns inflight without waiting when interval passed", func(t *testing.T) {
+		rec := NewRecord("k", 1)
+		node := &Node{}
+		node.SetInflight(rec)
+		previous := time.Now().Add(-10 * time.Millisecond)
+		node.SetValue("throttle", &Throttle{minDuration: time.Millisecond, last: previous})
+
+		ret := node.fmThrottle(1000)
+		require.Same(t, rec, ret)
+
+		value, _ := node.GetValue("throttle")
+		throttle := value.(*Throttle)
+		require.True(t, throttle.last.After(previous))
+	})
+
+	t.Run("returns inflight after short wait when interval not passed", func(t *testing.T) {
+		rec := NewRecord("k", 1)
+		node := &Node{}
+		node.SetInflight(rec)
+		previous := time.Now()
+		node.SetValue("throttle", &Throttle{minDuration: time.Millisecond, last: previous})
+
+		ret := node.fmThrottle(1000)
+		require.Same(t, rec, ret)
+
+		value, _ := node.GetValue("throttle")
+		throttle := value.(*Throttle)
+		require.True(t, throttle.last.After(previous))
+	})
+}
+
+func TestGroupColumnRelation(t *testing.T) {
+	t.Run("append and result", func(t *testing.T) {
+		covariance := &GroupColumnRelation{name: "covariance"}
+		require.NoError(t, covariance.Append([]any{1.0, 2.0}))
+		require.NoError(t, covariance.Append([]any{2.0, 4.0, Weight(2)}))
+		require.Equal(t, stat.Covariance(covariance.x, covariance.wv.Values(), covariance.wv.Weights()), covariance.Result())
+
+		correlation := &GroupColumnRelation{name: "correlation"}
+		require.NoError(t, correlation.Append([]any{1.0, 2.0}))
+		require.NoError(t, correlation.Append([]any{2.0, 4.0}))
+		require.InDelta(t, 1.0, correlation.Result().(float64), 1e-12)
+
+		lrs := &GroupColumnRelation{name: "lrs"}
+		require.NoError(t, lrs.Append([]any{1.0, 3.0}))
+		require.NoError(t, lrs.Append([]any{2.0, 5.0}))
+		require.NoError(t, lrs.Append([]any{3.0, 7.0}))
+		require.InDelta(t, 2.0, lrs.Result().(float64), 1e-12)
+	})
+
+	t.Run("invalid append leaves no result", func(t *testing.T) {
+		relation := &GroupColumnRelation{name: "covariance"}
+		require.NoError(t, relation.Append("bad"))
+		require.NoError(t, relation.Append([]any{"bad", 1.0}))
+		require.NoError(t, relation.Append([]any{1.0, "bad"}))
+		require.Nil(t, relation.Result())
+
+		relation = &GroupColumnRelation{name: "unknown"}
+		require.NoError(t, relation.Append([]any{1.0, 2.0}))
+		require.Nil(t, relation.Result())
+	})
+}
+
+func TestGroupColumnMoment(t *testing.T) {
+	t.Run("append and result", func(t *testing.T) {
+		moment := &GroupColumnMoment{name: "moment", moment: 2}
+		require.NoError(t, moment.Append(2.0))
+		require.NoError(t, moment.Append([]any{4.0, Weight(2)}))
+		require.Equal(t, stat.Moment(2, moment.wv.Values(), moment.wv.Weights()), moment.Result())
+	})
+
+	t.Run("empty and invalid", func(t *testing.T) {
+		empty := &GroupColumnMoment{name: "moment", moment: 2}
+		require.Nil(t, empty.Result())
+
+		unknown := &GroupColumnMoment{name: "unknown", moment: 2}
+		require.NoError(t, unknown.Append(1.0))
+		require.Nil(t, unknown.Result())
+
+		invalid := &GroupColumnMoment{name: "moment", moment: 2}
+		err := invalid.Append("bad")
+		require.Error(t, err)
+	})
+}
+
+func TestGroupColumnContainer(t *testing.T) {
+	t.Run("calculations and reset", func(t *testing.T) {
+		cdf := &GroupColumnContainer{name: "cdf", quantile: 2.5, cumulant: stat.Empirical}
+		require.NoError(t, cdf.Append(1.0))
+		require.NoError(t, cdf.Append(2.0))
+		require.NoError(t, cdf.Append(4.0))
+		require.Equal(t, stat.CDF(2.5, stat.Empirical, []float64{1, 2, 4}, []float64{1, 1, 1}), cdf.Result())
+		require.Empty(t, cdf.wv)
+
+		quantile := &GroupColumnContainer{name: "quantile", percentile: 0.5, cumulant: stat.Empirical}
+		require.NoError(t, quantile.Append(1.0))
+		require.NoError(t, quantile.Append(2.0))
+		require.NoError(t, quantile.Append(4.0))
+		require.Equal(t, stat.Quantile(0.5, stat.Empirical, []float64{1, 2, 4}, []float64{1, 1, 1}), quantile.Result())
+
+		mean := &GroupColumnContainer{name: "mean"}
+		require.NoError(t, mean.Append(1.0))
+		require.NoError(t, mean.Append([]any{3.0, Weight(2)}))
+		meanWant, _ := stat.MeanStdDev(mean.wv.Values(), mean.wv.Weights())
+		require.Equal(t, meanWant, mean.Result())
+
+		variance := &GroupColumnContainer{name: "variance"}
+		require.NoError(t, variance.Append(1.0))
+		require.NoError(t, variance.Append(3.0))
+		_, varianceWant := stat.MeanVariance(variance.wv.Values(), variance.wv.Weights())
+		require.Equal(t, varianceWant, variance.Result())
+
+		stddev := &GroupColumnContainer{name: "stddev"}
+		require.NoError(t, stddev.Append(1.0))
+		require.NoError(t, stddev.Append(3.0))
+		_, stddevWant := stat.MeanStdDev(stddev.wv.Values(), stddev.wv.Weights())
+		require.Equal(t, stddevWant, stddev.Result())
+
+		stderr := &GroupColumnContainer{name: "stderr"}
+		require.NoError(t, stderr.Append(1.0))
+		require.NoError(t, stderr.Append(3.0))
+		_, stderrStd := stat.MeanStdDev(stderr.wv.Values(), stderr.wv.Weights())
+		require.Equal(t, stat.StdErr(stderrStd, float64(len(stderr.wv))), stderr.Result())
+
+		entropy := &GroupColumnContainer{name: "entropy"}
+		require.NoError(t, entropy.Append(1.0))
+		require.NoError(t, entropy.Append(1.0))
+		require.NoError(t, entropy.Append(2.0))
+		require.Equal(t, stat.Entropy(entropy.wv.Values()), entropy.Result())
+
+		mode := &GroupColumnContainer{name: "mode"}
+		require.NoError(t, mode.Append(1.0))
+		require.NoError(t, mode.Append(2.0))
+		require.NoError(t, mode.Append(2.0))
+		modeWant, _ := stat.Mode(mode.wv.Values(), mode.wv.Weights())
+		require.Equal(t, modeWant, mode.Result())
+	})
+
+	t.Run("empty unknown nan and invalid", func(t *testing.T) {
+		empty := &GroupColumnContainer{name: "mean"}
+		require.Nil(t, empty.Result())
+
+		unknown := &GroupColumnContainer{name: "unknown"}
+		require.NoError(t, unknown.Append(1.0))
+		require.Nil(t, unknown.Result())
+
+		nanValue := &GroupColumnContainer{name: "entropy"}
+		require.NoError(t, nanValue.Append(0.0))
+		require.NoError(t, nanValue.Append(0.0))
+		require.Equal(t, 0.0, nanValue.Result())
+
+		invalid := &GroupColumnContainer{name: "mean"}
+		require.Error(t, invalid.Append("bad"))
+	})
+}
+
+func TestGroupColumnCounter(t *testing.T) {
+	t.Run("count avg rss rms and reset", func(t *testing.T) {
+		count := &GroupColumnCounter{name: "count"}
+		require.NoError(t, count.Append("ignored"))
+		require.NoError(t, count.Append(nil))
+		require.Equal(t, 2.0, count.Result())
+		require.Zero(t, count.count)
+		require.Zero(t, count.value)
+
+		avg := &GroupColumnCounter{name: "avg"}
+		require.NoError(t, avg.Append(2.0))
+		require.NoError(t, avg.Append(4.0))
+		require.Equal(t, 3.0, avg.Result())
+
+		rss := &GroupColumnCounter{name: "rss"}
+		require.NoError(t, rss.Append(3.0))
+		require.NoError(t, rss.Append(4.0))
+		require.Equal(t, 5.0, rss.Result())
+
+		rms := &GroupColumnCounter{name: "rms"}
+		require.NoError(t, rms.Append(3.0))
+		require.NoError(t, rms.Append(4.0))
+		require.Equal(t, math.Sqrt(12.5), rms.Result())
+	})
+
+	t.Run("empty unknown and invalid", func(t *testing.T) {
+		empty := &GroupColumnCounter{name: "avg"}
+		require.Nil(t, empty.Result())
+
+		unknown := &GroupColumnCounter{name: "unknown"}
+		require.NoError(t, unknown.Append(3.0))
+		require.Nil(t, unknown.Result())
+
+		invalid := &GroupColumnCounter{name: "avg"}
+		require.Error(t, invalid.Append("bad"))
+	})
+}

--- a/mods/tql/fm_shell_test.go
+++ b/mods/tql/fm_shell_test.go
@@ -21,3 +21,9 @@ func TestSetServiceControllerAddress(t *testing.T) {
 	SetServiceControllerAddress("unix:///tmp/controller.sock")
 	require.Equal(t, "unix:///tmp/controller.sock", _serviceControllerAddr)
 }
+
+func TestSetServiceWorkspace(t *testing.T) {
+	_serviceWorkspace = ""
+	SetServiceWorkspace("/tmp/service-workspace")
+	require.Equal(t, "/tmp/service-workspace", _serviceWorkspace)
+}

--- a/mods/tql/fm_stat_test.go
+++ b/mods/tql/fm_stat_test.go
@@ -6,6 +6,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStatHelpers(t *testing.T) {
+	node := &Node{}
+
+	require.Equal(t, StatCategoryName("alpha"), node.fmCategory("alpha"))
+	name := "beta"
+	require.Equal(t, StatCategoryName("beta"), node.fmCategory(&name))
+	require.Equal(t, "123", node.fmCategory(123))
+
+	bins, err := node.fmBins(0, 10, 2)
+	require.NoError(t, err)
+	require.Equal(t, "[0.000000-10.000000)/2.000000", bins.(*HistogramStepBins).String())
+
+	maxBins, err := node.fmBins(7)
+	require.NoError(t, err)
+	require.Equal(t, HistogramMaxBins(7), maxBins)
+
+	_, err = node.fmBins()
+	require.EqualError(t, err, "f(bins) invalid number of args; expected 1 or 3, got 0")
+
+	require.Equal(t, BoxplotFormat("chart"), node.fmBoxplotOutputFormat("CHART"))
+	require.Equal(t, BoxplotFormat("standard"), node.fmBoxplotOutputFormat("unexpected"))
+}
+
 func TestHistogramOrder(t *testing.T) {
 	hist := &HistogramPredictedBins{}
 

--- a/mods/tql/task_record_test.go
+++ b/mods/tql/task_record_test.go
@@ -1,0 +1,122 @@
+package tql
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordReceiver struct {
+	name     string
+	received *Record
+}
+
+func (r *recordReceiver) Name() string { return r.name }
+
+func (r *recordReceiver) Receive(rec *Record) {
+	r.received = rec
+}
+
+func TestRecordKindsAndArrayAccessors(t *testing.T) {
+	t.Run("array record", func(t *testing.T) {
+		items := []*Record{NewRecord("k", 1), NewRecord("k2", 2)}
+		rec := ArrayRecord(items)
+
+		require.True(t, rec.IsArray())
+		require.False(t, rec.IsTuple())
+		require.Equal(t, items, rec.Array())
+		require.Equal(t, "ARRAY", rec.String())
+	})
+
+	t.Run("bytes and image records", func(t *testing.T) {
+		bytesRec := NewBytesRecord([]byte("abc"))
+		require.True(t, bytesRec.IsBytes())
+		require.False(t, bytesRec.IsTuple())
+		require.Equal(t, "BYTES", bytesRec.String())
+		require.Nil(t, bytesRec.Array())
+
+		imageRec := NewImageRecord([]byte("img"), "image/png")
+		require.True(t, imageRec.IsImage())
+		require.False(t, imageRec.IsTuple())
+		require.Equal(t, "IMAGE", imageRec.String())
+		require.Equal(t, "image/png", imageRec.contentType)
+	})
+
+	t.Run("special records", func(t *testing.T) {
+		require.Equal(t, "EOF", EofRecord.String())
+		require.Equal(t, "CIRCUITBREAK", BreakRecord.String())
+
+		errRec := ErrorRecord(errors.New("boom"))
+		require.True(t, errRec.IsError())
+		require.EqualError(t, errRec.Error(), "boom")
+		require.Equal(t, "ERROR boom", errRec.String())
+
+		normal := NewRecord("key", 1)
+		require.Nil(t, normal.Error())
+		require.True(t, normal.IsTuple())
+		require.Equal(t, "K:string(key) V:int", normal.String())
+	})
+
+	t.Run("nil record string", func(t *testing.T) {
+		var rec *Record
+		require.Equal(t, "<nil>", rec.String())
+	})
+}
+
+func TestRecordVariableAndTell(t *testing.T) {
+	rec := NewRecord("key", 1)
+	rec.SetVariable("answer", 42)
+
+	v, err := rec.GetVariable("$answer")
+	require.NoError(t, err)
+	require.Equal(t, 42, v)
+
+	v, err = rec.GetVariable("$missing")
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	v, err = rec.GetVariable("answer")
+	require.EqualError(t, err, "undefined variable 'answer'")
+	require.Nil(t, v)
+
+	v, err = NewRecord("other", 2).GetVariable("$answer")
+	require.EqualError(t, err, "undefined variable '$answer'")
+	require.Nil(t, v)
+
+	rec.Tell(nil)
+	rcv := &recordReceiver{name: "capture"}
+	rec.Tell(rcv)
+	require.Same(t, rec, rcv.received)
+}
+
+func TestRecordFlattenAndStringValueTypes(t *testing.T) {
+	t.Run("flatten variants", func(t *testing.T) {
+		require.Equal(t, []any{"k", 1, "two"}, NewRecord("k", []any{1, "two"}).Flatten())
+		require.Equal(t, []any{"k", "value"}, NewRecord("k", "value").Flatten())
+		require.Equal(t, []any{"k"}, NewRecord("k", nil).Flatten())
+	})
+
+	t.Run("string value types", func(t *testing.T) {
+		rec := NewRecord("k", []any{1, "two", []any{true, 3.14, "x", 7}, 9})
+		require.Equal(t, "int, string, []any{bool,float64,string,int,... (len=4)}, int, ... (len=4)", rec.StringValueTypes())
+
+		matrix := NewRecord("k", [][]any{{1, "a"}, {true}, {3.14}, {"tail", 2}})
+		require.Equal(t, "(len=4) [][]any{[0]{int, string},[1]{bool},[2]{float64},[3]{string, int}, ...}", matrix.StringValueTypes())
+	})
+}
+
+func TestRecordEqualKeyAndValue(t *testing.T) {
+	base := time.Date(2024, 1, 2, 3, 4, 5, 6, time.UTC)
+	require.True(t, NewRecord(base, nil).EqualKey(NewRecord(base, nil)))
+	require.False(t, NewRecord(base, nil).EqualKey(NewRecord(base.Add(time.Nanosecond), nil)))
+
+	require.True(t, NewRecord([]int{1, 2}, nil).EqualKey(NewRecord([]int{1, 2}, nil)))
+	require.False(t, NewRecord([]int{1, 2}, nil).EqualKey(NewRecord([]int{1, 3}, nil)))
+	require.False(t, NewRecord("x", nil).EqualKey(nil))
+
+	require.True(t, NewRecord("k", []any{1, "a"}).EqualValue(NewRecord("k", []any{1, "a"})))
+	require.False(t, NewRecord("k", []any{1, "a"}).EqualValue(NewRecord("k", []any{2, "a"})))
+	require.False(t, NewRecord("k", 1).EqualValue(nil))
+}


### PR DESCRIPTION
- Introduced `base_test.go` to validate connection and row handling in the bridge module.
- Created `service_test.go` to test the lifecycle and error handling of the bridge service.
- Added `fm_monad_test.go` for testing various statistical and predictive functionalities in the TQL module.
- Implemented `fm_shell_test.go` to verify service workspace settings.
- Enhanced `fm_stat_test.go` with additional helper tests for statistical functions.
- Added `task_record_test.go` to test record handling, including variable management and flattening.