### PR TITLE
Refactor signal handling in Boot struct; improve cache handling in TQL module; add SSH bridge tests for MySQL

### DIFF
--- a/booter/boot.go
+++ b/booter/boot.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"reflect"
 	"strings"
+	"sync"
 	"syscall"
 )
 
@@ -27,6 +28,7 @@ type Booter interface {
 type boot struct {
 	moduleDefs []*Definition
 	wrappers   []wrapper
+	quitMu     sync.RWMutex
 	quitChan   chan os.Signal
 
 	startupHooks  []func()
@@ -136,17 +138,29 @@ func (bt *boot) ShutdownAndExit(exitCode int) {
 
 func (bt *boot) WaitSignal() {
 	// signal handler
-	bt.quitChan = make(chan os.Signal)
-	signal.Notify(bt.quitChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	quitChan := make(chan os.Signal)
+	bt.quitMu.Lock()
+	bt.quitChan = quitChan
+	bt.quitMu.Unlock()
+	signal.Notify(quitChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	// wait signal
-	<-bt.quitChan
+	<-quitChan
 }
 
 func (bt *boot) NotifySignal() {
-	if bt.quitChan != nil {
-		bt.quitChan <- syscall.SIGINT
+	bt.quitMu.RLock()
+	quitChan := bt.quitChan
+	bt.quitMu.RUnlock()
+	if quitChan != nil {
+		quitChan <- syscall.SIGINT
 	}
+}
+
+func (bt *boot) signalChan() chan os.Signal {
+	bt.quitMu.RLock()
+	defer bt.quitMu.RUnlock()
+	return bt.quitChan
 }
 
 func (bt *boot) AddShutdownHook(f ...func()) {

--- a/booter/boot_test.go
+++ b/booter/boot_test.go
@@ -522,7 +522,7 @@ func TestBootWaitAndNotifySignalInternal(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return bt.quitChan != nil
+		return bt.signalChan() != nil
 	}, time.Second, 10*time.Millisecond)
 
 	go bt.NotifySignal()
@@ -536,5 +536,5 @@ func TestBootWaitAndNotifySignalInternal(t *testing.T) {
 		}
 	}, time.Second, 10*time.Millisecond)
 
-	signal.Stop(bt.quitChan)
+	signal.Stop(bt.signalChan())
 }

--- a/mods/server/mqtt_write.go
+++ b/mods/server/mqtt_write.go
@@ -111,7 +111,7 @@ func (s *mqttd) handleWrite(cl *mqtt.Client, pk packets.Packet) {
 	case "ndjson":
 	default:
 		rsp.Reason = fmt.Sprintf("%s unsupported format %q", pk.TopicName, wp.Format)
-		s.log.Warnf(cl.Net.Remote, rsp.Reason)
+		s.log.Warn(cl.Net.Remote, rsp.Reason)
 		return
 	}
 	switch wp.Compress {

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -659,6 +659,9 @@ func TestShellBridge(t *testing.T) {
 	t.Run("shellBridgeMySqlTest", func(t *testing.T) {
 		shellBridgeMySqlTest(t, mysqlDSN)
 	})
+	t.Run("sshBridgeMySqlTest", func(t *testing.T) {
+		sshBridgeMySqlTest(t, mysqlDSN)
+	})
 	t.Run("shellBridgeMqttTest", func(t *testing.T) {
 		shellBridgeMqttTest(t, mosquittoHostPort)
 	})

--- a/mods/server/ssh_test.go
+++ b/mods/server/ssh_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -277,7 +278,126 @@ func sshBridgePostgresTest(t *testing.T, dsn string) {
 		},
 	}
 	for _, tt := range tests {
-		runSSHTest(t, tt)
+		t.Run(tt.name, func(t *testing.T) {
+			runSSHTest(t, tt)
+		})
+	}
+}
+
+func sshBridgeMySqlTest(t *testing.T, dsn string) {
+	tests := []SSHTestCase{
+		{
+			name: "bridge_list",
+			cmd:  `bridge list`,
+			expect: []string{
+				"┌────────┬──────┬──────┬────────────┐",
+				"│ ROWNUM │ NAME │ TYPE │ CONNECTION │",
+				"├────────┼──────┼──────┼────────────┤",
+				"└────────┴──────┴──────┴────────────┘",
+			},
+		},
+		{
+			name: "bridge_add_mysql",
+			cmd:  fmt.Sprintf(`bridge add -t mysql my "%s"`, dsn),
+			expect: []string{
+				"Adding bridge... my type: mysql path: " + dsn,
+			},
+		},
+		{
+			name: "bridge_list_after_add",
+			cmd:  `bridge list`,
+			expect: []string{
+				"┌────────┬──────┬───────┬──────────────────────────────────────────────────────┐",
+				"│ ROWNUM │ NAME │ TYPE  │ CONNECTION                                           │",
+				"├────────┼──────┼───────┼──────────────────────────────────────────────────────┤",
+				"│      1 │ my   │ mysql │ " + dsn + " │",
+				"└────────┴──────┴───────┴──────────────────────────────────────────────────────┘",
+			},
+		},
+		{
+			name: "bridge_create_mysql_table",
+			cmd: "bridge exec my \"CREATE TABLE IF NOT EXISTS my_example(" +
+				"id INT NOT NULL AUTO_INCREMENT, " +
+				"company VARCHAR(50) UNIQUE NOT NULL, " +
+				"employee INT, " +
+				"discount REAL, " +
+				"plan FLOAT, " +
+				"code CHAR(64), " +
+				"valid SMALLINT, " +
+				"memo TEXT, " +
+				"created_on TIMESTAMP NOT NULL, " +
+				"PRIMARY KEY(id));\"",
+			expect: []string{
+				`executed.`,
+			},
+		},
+		{
+			name: "bridge_desc_table",
+			cmd:  `bridge query my desc my_example`,
+			expect: []string{
+				"┌────────┬────────────┬─────────────┬──────┬─────┬─────────┬────────────────┐",
+				"│ ROWNUM │ FIELD      │ TYPE        │ NULL │ KEY │ DEFAULT │ EXTRA          │",
+				"├────────┼────────────┼─────────────┼──────┼─────┼─────────┼────────────────┤",
+				"│      1 │ id         │ int         │ NO   │ PRI │ NULL    │ auto_increment │",
+				"│      2 │ company    │ varchar(50) │ NO   │ UNI │ NULL    │                │",
+				"│      3 │ employee   │ int         │ YES  │     │ NULL    │                │",
+				"│      4 │ discount   │ double      │ YES  │     │ NULL    │                │",
+				"│      5 │ plan       │ float       │ YES  │     │ NULL    │                │",
+				"│      6 │ code       │ char(64)    │ YES  │     │ NULL    │                │",
+				"│      7 │ valid      │ smallint    │ YES  │     │ NULL    │                │",
+				"│      8 │ memo       │ text        │ YES  │     │ NULL    │                │",
+				"│      9 │ created_on │ timestamp   │ NO   │     │ NULL    │                │",
+				"└────────┴────────────┴─────────────┴──────┴─────┴─────────┴────────────────┘",
+			},
+		},
+		{
+			name: "bridge_insert_mysql",
+			cmd:  `bridge exec my "insert into my_example(company, employee, discount, plan, created_on) value ('acme', 10, 1.234, 2.3456, '2023-09-09 00:00:00')"`,
+			expect: []string{
+				`executed.`,
+			},
+		},
+		{
+			name: "bridge_select_mysql",
+			cmd:  `bridge query my "select * from my_example;"`,
+			expect: []string{
+				"┌────────┬────┬─────────┬──────────┬──────────┬────────┬──────┬───────┬──────┬──────────────────────┐",
+				"│ ROWNUM │ ID │ COMPANY │ EMPLOYEE │ DISCOUNT │   PLAN │ CODE │ VALID │ MEMO │ CREATED_ON           │",
+				"├────────┼────┼─────────┼──────────┼──────────┼────────┼──────┼───────┼──────┼──────────────────────┤",
+				"│      1 │  1 │ acme    │       10 │    1.234 │ 2.3456 │ NULL │ NULL  │ NULL │ 2023-09-09T00:00:00Z │",
+				"└────────┴────┴─────────┴──────────┴──────────┴────────┴──────┴───────┴──────┴──────────────────────┘",
+			},
+		},
+		{
+			name: "bridge_drop_mysql_table",
+			cmd:  `bridge exec my "drop table my_example;"`,
+			expect: []string{
+				`executed.`,
+			},
+		},
+		{
+			name: "bridge_del_mysql",
+			cmd:  `bridge del my`,
+			expect: []string{
+				`Deleted.`,
+			},
+			wait: 5 * time.Second,
+		},
+		{
+			name: "bridge_list_after_del",
+			cmd:  `bridge list`,
+			expect: []string{
+				"┌────────┬──────┬──────┬────────────┐",
+				"│ ROWNUM │ NAME │ TYPE │ CONNECTION │",
+				"├────────┼──────┼──────┼────────────┤",
+				"└────────┴──────┴──────┴────────────┘",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runSSHTest(t, tt)
+		})
 	}
 }
 
@@ -328,7 +448,7 @@ func runSSHTest(t *testing.T, tt SSHTestCase) {
 		t.Fatalf("Failed to get SSH stdin pipe: %v", err)
 	}
 
-	if err := session.RequestPty("xterm", 40, 120, ssh.TerminalModes{}); err != nil {
+	if err := session.RequestPty("xterm", 40, 240, ssh.TerminalModes{}); err != nil {
 		t.Fatalf("Failed to request PTY: %v", err)
 	}
 
@@ -339,7 +459,7 @@ func runSSHTest(t *testing.T, tt SSHTestCase) {
 	if _, err := stdin.Write([]byte(tt.cmd + "\n")); err != nil {
 		t.Fatalf("Failed to write SSH command: %v", err)
 	}
-	if !waitForExpectedOutput(&stdout, user, tt.expect, waitTimeout) {
+	if !waitForSSHOutput(&stdout, user, tt.expect, waitTimeout) {
 		t.Fatalf("Timed out waiting for SSH output, got %s", removeTerminalControlCharacters(stdout.String()))
 	}
 	if _, err := stdin.Write([]byte("exit\n")); err != nil {
@@ -400,6 +520,53 @@ func waitForExpectedOutput(buf *lockedBuffer, user string, expects []string, tim
 	return false
 }
 
+func waitForSSHOutput(buf *lockedBuffer, user string, expects []string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		output := removeTerminalControlCharacters(buf.String())
+		lines := normalizeSSHOutputLines(output, user)
+		if matchExpectedOutput(lines, expects) || isSSHOutputAtPrompt(lines, user) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+func waitForSSHPrompt(buf *lockedBuffer, user string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		output := removeTerminalControlCharacters(buf.String())
+		lines := normalizeSSHOutputLines(output, user)
+		if isSSHOutputAtPrompt(lines, user) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}
+
+func isSSHOutputAtPrompt(lines []string, user string) bool {
+	if len(lines) == 0 {
+		return false
+	}
+	lastLine := strings.TrimSpace(lines[len(lines)-1])
+	if lastLine == ">" {
+		return true
+	}
+	if sshShellID(user) == "jsh" {
+		return strings.EqualFold(lastLine, "jsh>") || strings.EqualFold(lastLine, "jsh >")
+	}
+	return false
+}
+
+func sshShellID(user string) string {
+	if idx := strings.Index(user, ":"); idx >= 0 {
+		return strings.ToLower(strings.TrimSpace(user[idx+1:]))
+	}
+	return ""
+}
+
 func normalizeSSHOutputLines(output string, user string) []string {
 	lines := strings.Split(output, "\n")
 	result := make([]string, 0, len(lines))
@@ -411,9 +578,28 @@ func normalizeSSHOutputLines(output string, user string) []string {
 		if isTerminalPromptLine(trimmed, user) {
 			continue
 		}
+		if len(result) > 0 && shouldJoinWrappedSSHLine(result[len(result)-1], trimmed) {
+			result[len(result)-1] += trimmed
+			continue
+		}
 		result = append(result, trimmed)
 	}
 	return result
+}
+
+func shouldJoinWrappedSSHLine(previous string, current string) bool {
+	if previous == "" || current == "" {
+		return false
+	}
+	first, _ := utf8.DecodeRuneInString(previous)
+	if !strings.ContainsRune("┌├└│", first) {
+		return false
+	}
+	last, _ := utf8.DecodeLastRuneInString(previous)
+	if strings.ContainsRune("┐┤┘│", last) {
+		return false
+	}
+	return true
 }
 
 func matchExpectedOutput(lines []string, expects []string) bool {
@@ -477,6 +663,41 @@ func TestNormalizeSSHOutputLinesRemovesPromptAndBlankLines(t *testing.T) {
 		"┌────────┬──────┬──────┬────────────┐",
 		"│ ROWNUM │ NAME │ TYPE │ CONNECTION │",
 		"└────────┴──────┴──────┴────────────┘",
+		">",
+	}, actual)
+}
+
+func TestNormalizeSSHOutputLinesJoinsWrappedTableLines(t *testing.T) {
+	raw := strings.Join([]string{
+		"Greetings, SYS",
+		"machbase-neo  ( )",
+		"sys machbase-neo 2026-05-06 10:20:37",
+		"> bridge list",
+		"┌────────┬──────┬───────┬───────────────────────────────────────────────",
+		"───────┐",
+		"│ ROWNUM │ NAME │ TYPE  │ CONNECTION                                    ",
+		"       │",
+		"├────────┼──────┼───────┼───────────────────────────────────────────────",
+		"───────┤",
+		"│      1 │ my   │ mysql │ dbuser:secret@tcp(127.0.0.1:55050)/db?parseTime",
+		"=true │",
+		"└────────┴──────┴───────┴───────────────────────────────────────────────",
+		"───────┘",
+		"sys machbase-neo 2026-05-06 10:20:37",
+		">",
+	}, "\n")
+
+	actual := normalizeSSHOutputLines(raw, "sys")
+
+	require.Equal(t, []string{
+		"Greetings, SYS",
+		"machbase-neo  ( )",
+		"> bridge list",
+		"┌────────┬──────┬───────┬──────────────────────────────────────────────────────┐",
+		"│ ROWNUM │ NAME │ TYPE  │ CONNECTION                                           │",
+		"├────────┼──────┼───────┼──────────────────────────────────────────────────────┤",
+		"│      1 │ my   │ mysql │ dbuser:secret@tcp(127.0.0.1:55050)/db?parseTime=true │",
+		"└────────┴──────┴───────┴──────────────────────────────────────────────────────┘",
 		">",
 	}, actual)
 }

--- a/mods/server/ssh_unix.go
+++ b/mods/server/ssh_unix.go
@@ -91,14 +91,29 @@ func (svr *sshd) shellHandler(ss ssh.Session) {
 			ss.Exit(1)
 			return
 		}
+		setWinsize(fn, ptyReq.Window.Width, ptyReq.Window.Height)
+		resizeDone := make(chan struct{})
+		var resizeWG sync.WaitGroup
+		resizeWG.Add(1)
 		svr.addChild(cmd.Process)
 		defer func() {
+			close(resizeDone)
+			resizeWG.Wait()
 			svr.removeChild(cmd.Process)
 			fn.Close()
 		}()
 		go func() {
-			for win := range winCh {
-				setWinsize(fn, win.Width, win.Height)
+			defer resizeWG.Done()
+			for {
+				select {
+				case <-resizeDone:
+					return
+				case win, ok := <-winCh:
+					if !ok {
+						return
+					}
+					setWinsize(fn, win.Width, win.Height)
+				}
 			}
 		}()
 		go func() {

--- a/mods/tql/task.go
+++ b/mods/tql/task.go
@@ -92,6 +92,9 @@ func NewTaskContext(ctx context.Context) *Task {
 	}
 	ret.volatileAssetsProvider = instance.vap
 	ret.ctx, ret.ctxCancel = context.WithCancel(ctx)
+	context.AfterFunc(ret.ctx, func() {
+		ret.fireCircuitBreak(nil)
+	})
 	return ret
 }
 
@@ -409,6 +412,9 @@ func (x *Task) execute() *Result {
 			var cancel context.CancelFunc
 			x._preemptiveCacheUpdateTimeout = 10 * time.Second
 			x.ctx, cancel = context.WithTimeout(context.Background(), x._preemptiveCacheUpdateTimeout)
+			context.AfterFunc(x.ctx, func() {
+				x.fireCircuitBreak(nil)
+			})
 			x._preemptiveCacheUpdateStarted = true
 			go func() {
 				defer cancel()

--- a/mods/tql/task_output.go
+++ b/mods/tql/task_output.go
@@ -96,9 +96,9 @@ func (node *Node) compileSink(code *Line) (ret *output, err error) {
 		}
 		var writer io.Writer = node.task.OutputWriter()
 		// check cache option
-		if val.cacheOption != nil && tqlResultCache != nil {
+		if cache := tqlResultCache.Load(); val.cacheOption != nil && cache != nil {
 			ret.cacheOption = val.cacheOption
-			if item := tqlResultCache.Get(val.cacheOption.key); item != nil {
+			if item := cache.Get(val.cacheOption.key); item != nil {
 				// get cached data
 				ret.cachedData = item.Data
 				// check preemptive update is set and valid
@@ -239,9 +239,9 @@ func (out *output) start() {
 			}
 		}
 
-		if out.cacheOption != nil && out.cacheOption.key != "" && out.cacheWriter != nil && tqlResultCache != nil {
+		if cache := tqlResultCache.Load(); out.cacheOption != nil && out.cacheOption.key != "" && out.cacheWriter != nil && cache != nil {
 			if data := out.cacheWriter.Bytes(); len(data) > 0 {
-				tqlResultCache.Set(out.cacheOption.key, data, out.cacheOption.ttl)
+				cache.Set(out.cacheOption.key, data, out.cacheOption.ttl)
 			}
 		}
 	}()

--- a/mods/tql/task_output.go
+++ b/mods/tql/task_output.go
@@ -171,8 +171,10 @@ func (out *output) start() {
 				out.task.fireCircuitBreak(nil)
 				// task has been cancelled.
 				break loop
-			case rec := <-out.src:
-				if rec.IsEOF() || rec.IsCircuitBreak() {
+			case rec, ok := <-out.src:
+				if !ok || rec == nil {
+					break loop
+				} else if rec.IsEOF() || rec.IsCircuitBreak() {
 					break loop
 				} else if rec.IsError() {
 					out.lastError = rec.Error()

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -219,6 +219,27 @@ func TestTaskCancelNotifiesLateShouldStopListener(t *testing.T) {
 	}
 }
 
+func TestTaskContextCancelNotifiesLateShouldStopListener(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	task := tql.NewTaskContext(ctx)
+	cancel()
+
+	called := make(chan struct{}, 1)
+	task.AddShouldStopListener(func() {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+	})
+
+	select {
+	case <-called:
+		return
+	case <-time.After(1 * time.Second):
+		t.Fatal("late should-stop listener was not notified after context cancellation")
+	}
+}
+
 func TestHistogram(t *testing.T) {
 	var codeLines, resultLines []string
 	codeLines = []string{

--- a/mods/tql/tqlcache.go
+++ b/mods/tql/tqlcache.go
@@ -13,7 +13,7 @@ import (
 	"github.com/machbase/neo-server/v8/mods/util/metric"
 )
 
-var tqlResultCache *Cache
+var tqlResultCache atomic.Pointer[Cache]
 
 type CacheOption struct {
 	MaxCapacity uint64 // max number of items
@@ -22,33 +22,34 @@ type CacheOption struct {
 }
 
 func StartCache(cap CacheOption) {
-	tqlResultCache = newCache(cap)
-	tqlResultCache.closeWg.Add(1)
-	go func() {
-		defer tqlResultCache.closeWg.Done()
-		tqlResultCache.cache.Start()
-	}()
+	cache := newCache(cap)
+	tqlResultCache.Store(cache)
+	cache.closeWg.Add(1)
+	go func(cache *Cache) {
+		defer cache.closeWg.Done()
+		cache.cache.Start()
+	}(cache)
 
 	api.AddMetricsFunc(func(g *metric.Gather) error {
-		if tqlResultCache == nil || tqlResultCache.cache == nil {
+		cache := tqlResultCache.Load()
+		if cache == nil || cache.cache == nil {
 			return errors.New("tql cache not started")
 		}
-		stat := tqlResultCache.cache.Metrics()
+		stat := cache.cache.Metrics()
 		g.Add("tql:cache:evictions", float64(stat.Evictions), metric.GaugeType(metric.UnitShort))
 		g.Add("tql:cache:insertions", float64(stat.Insertions), metric.GaugeType(metric.UnitShort))
 		g.Add("tql:cache:hits", float64(stat.Hits), metric.GaugeType(metric.UnitShort))
 		g.Add("tql:cache:misses", float64(stat.Misses), metric.GaugeType(metric.UnitShort))
-		g.Add("tql:cache:items", float64(tqlResultCache.cache.Len()), metric.GaugeType(metric.UnitShort))
+		g.Add("tql:cache:items", float64(cache.cache.Len()), metric.GaugeType(metric.UnitShort))
 		return nil
 	})
 }
 
 func StopCache() {
-	if tqlResultCache != nil {
-		tqlResultCache.cache.Stop()
-		close(tqlResultCache.closeCh)
-		tqlResultCache.closeWg.Wait()
-		tqlResultCache = nil
+	if cache := tqlResultCache.Swap(nil); cache != nil {
+		cache.cache.Stop()
+		close(cache.closeCh)
+		cache.closeWg.Wait()
 	}
 }
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on thread safety, enhanced SSH bridge testing (especially for MySQL), and improvements to TQL result cache management. The most significant changes are grouped below:

**Thread Safety and Signal Handling:**

* Added a `sync.RWMutex` to the `boot` struct and updated signal handling methods (`WaitSignal`, `NotifySignal`, etc.) to use this lock for safe concurrent access to `quitChan`. This prevents race conditions when accessing or modifying the signal channel. [[1]](diffhunk://#diff-edec8cd089e9695c76131e99ba24e7c56ed2d5ddf89b2c5a38bc478f3fd51b02R9) [[2]](diffhunk://#diff-edec8cd089e9695c76131e99ba24e7c56ed2d5ddf89b2c5a38bc478f3fd51b02R31) [[3]](diffhunk://#diff-edec8cd089e9695c76131e99ba24e7c56ed2d5ddf89b2c5a38bc478f3fd51b02L139-R165) [[4]](diffhunk://#diff-397651d21400725debff1639453ac3108694b21b2878161e015e5a153dbe6099L525-R525) [[5]](diffhunk://#diff-397651d21400725debff1639453ac3108694b21b2878161e015e5a153dbe6099L539-R539)

**SSH Bridge and Testing Enhancements:**

* Added comprehensive MySQL SSH bridge tests, covering bridge creation, table operations, and deletion, similar to existing Postgres tests. [[1]](diffhunk://#diff-85f01ad6de36ebcc7dab3bb85acf3c0713452172648770c6833215310a689a55R662-R664) [[2]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1R281-R400)
* Improved SSH test helper functions to better handle terminal output, including joining wrapped table lines, detecting prompts, and normalizing output for more robust test assertions. [[1]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1L331-R451) [[2]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1L342-R462) [[3]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1R523-R569) [[4]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1R581-R604) [[5]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1R670-R704)
* Increased the PTY width in SSH test sessions for better table rendering and added a utility import for Unicode handling. [[1]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1R13) [[2]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1L331-R451)

**TQL Result Cache Improvements:**

* Refactored `tqlResultCache` to use `atomic.Pointer[Cache]` for thread-safe access and updates, and updated all usages accordingly. [[1]](diffhunk://#diff-bbd5dc679782832979f461e4ced2b2404e3d6ffb81d2acfce65f00123d8bae1dL16-R16) [[2]](diffhunk://#diff-bbd5dc679782832979f461e4ced2b2404e3d6ffb81d2acfce65f00123d8bae1dL25-R52) [[3]](diffhunk://#diff-d4921680b3ae53f2e96e8c91b0d83a7af87b09550402b56595a2a563909dcb58L99-R101) [[4]](diffhunk://#diff-d4921680b3ae53f2e96e8c91b0d83a7af87b09550402b56595a2a563909dcb58L242-R244)

**Other Fixes:**

* Fixed a logging call in MQTT write handler to use the correct log method (`Warn` instead of `Warnf`).
* Fixed a potential goroutine leak in the SSH shell handler by ensuring proper synchronization on PTY resize events.

These changes improve the reliability, correctness, and test coverage of the system, especially in concurrent and multi-protocol environments