### PR TITLE
add view type

### DIFF
--- a/jsh/lib/machcli/machcli.js
+++ b/jsh/lib/machcli/machcli.js
@@ -178,6 +178,7 @@ const TableType = {
     Lookup: 4,
     KeyValue: 5,
     Tag: 6,
+    View: 7,
 };
 
 function stringTableType(typ) {
@@ -194,6 +195,8 @@ function stringTableType(typ) {
             return "KeyValue";
         case TableType.Tag:
             return "Tag";
+        case TableType.View:
+            return "View";
         default:
             return `UndefinedTable-${typ}`;
     }

--- a/jsh/lib/machcli/machcli_test.go
+++ b/jsh/lib/machcli/machcli_test.go
@@ -46,6 +46,9 @@ func TestDatabase(t *testing.T) {
 					result = conn.exec("CREATE TAG TABLE IF NOT EXISTS TAG (NAME VARCHAR(100) primary key, TIME DATETIME basetime, VALUE DOUBLE)");
 					console.println("Created Table Message:", result.message);
 
+					result = conn.exec("CREATE VIEW TAGVIEW as select * from TAG where name='jsh'");
+					console.println("Created View Message:", result.message);
+
 					result = conn.exec("INSERT INTO TAG values(?, ?, ?)", 'jsh', tick, 123);
 					console.println("Inserted rows:", result.rowsAffected, "Message:", result.message);
 				} catch(err) {
@@ -57,7 +60,29 @@ func TestDatabase(t *testing.T) {
 			`,
 			Output: []string{
 				"Created Table Message: ",
+				"Created View Message: ",
 				"Inserted rows: 1 Message: ",
+			},
+		},
+		{
+			Name: "mach_table_types",
+			Script: `
+				const {Client, stringTableType} = require('machcli');
+				const conf = require("process").env.get("conf");
+				db = new Client(conf);
+				conn = db.connect();
+				rows = conn.query("SELECT NAME, TYPE from M$SYS_TABLES ORDER BY NAME");
+				for (const row of rows) {
+					if (row.NAME.startsWith("_")) continue;
+					console.println("TABLE:", row.NAME, "TYPE:", stringTableType(row.TYPE));
+				}
+				rows.close();
+				conn.close();
+				db.close();
+			`,
+			Output: []string{
+				"TABLE: TAG TYPE: Tag",
+				"TABLE: TAGVIEW TYPE: View",
 			},
 		},
 		{


### PR DESCRIPTION
This pull request adds support for a new "View" table type in the system, updates the string conversion utility to handle this new type, and extends the test suite to verify correct behavior and output for views. The main changes are grouped into enhancements to core logic and improvements to testing.

Enhancements to core logic:

* Added a new `View` type to the `TableType` object in `machcli.js`, allowing the system to recognize and work with database views.
* Updated the `stringTableType` function to return "View" when the new type is encountered, ensuring correct string representation throughout the codebase.

Improvements to testing:

* Modified the `TestDatabase` function in `machcli_test.go` to create a view (`TAGVIEW`) in the test database, and log its creation, ensuring that views are handled correctly in integration tests.
* Added a new test case to verify that both tables and views are listed with the correct type names using the `stringTableType` function, confirming end-to-end support for the new type.