### PR TITLE
Enhance server key handling, OTP formatting, and test coverage

### DIFF
--- a/mods/server/http_query.go
+++ b/mods/server/http_query.go
@@ -885,7 +885,7 @@ func (svr *httpd) handleTqlQuery(ctx *gin.Context) {
 			task.SetConsole(claim.Subject, consoleInfo.consoleId, "")
 		} else {
 			otp := spi.IssueToken()
-			task.SetConsole(claim.Subject, consoleInfo.consoleId, "$otp$:"+otp)
+			task.SetConsole(claim.Subject, consoleInfo.consoleId, "$otp$"+otp)
 		}
 	}
 	task.SetOutputWriterJson(&util.NopCloseWriter{Writer: ctx.Writer}, true)

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -949,6 +949,7 @@ func (s *Server) startHttpServer() error {
 	util.AddShutdownHook(func() { s.httpd.Stop() })
 
 	tql.SetHttpAddresses(s.Http.Listeners)
+	tql.SetServerKeyPath(s.ServerPrivateKeyPath())
 	tql.StartCache(tql.CacheOption{MaxCapacity: 500})
 	util.AddShutdownHook(func() { tql.StopCache() })
 

--- a/mods/tql/fm_shell.go
+++ b/mods/tql/fm_shell.go
@@ -32,6 +32,7 @@ func SetHttpAddresses(addrs []string) {
 
 var _serviceControllerAddr string
 var _serviceWorkspace string
+var _serverKeyPath string
 
 func SetServiceControllerAddress(addr string) {
 	_serviceControllerAddr = addr
@@ -39,6 +40,10 @@ func SetServiceControllerAddress(addr string) {
 
 func SetServiceWorkspace(workspace string) {
 	_serviceWorkspace = workspace
+}
+
+func SetServerKeyPath(path string) {
+	_serverKeyPath = path
 }
 
 func (node *Node) fmShell(cmd0 string, args0 ...string) {
@@ -142,6 +147,7 @@ var ShellExecutable = func(serverAddr string, scriptPath string) ([]string, erro
 		"-v", "/work=" + _serviceWorkspace,
 		"-v", "/tmp=" + filepath.Dir(scriptPath),
 		"-e", "SERVICE_CONTROLLER=" + _serviceControllerAddr,
+		"-e", "NEOSHELL_IDENTITY_FILE=@" + _serverKeyPath,
 		"run",
 		"/tmp/" + filepath.Base(scriptPath),
 	}, nil

--- a/spi/append_worker_test.go
+++ b/spi/append_worker_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	clientapi "github.com/machbase/neo-client/api"
+	"github.com/machbase/neo-client/api"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/stretchr/testify/require"
 )
@@ -20,23 +20,23 @@ func (c *appendWorkerTestConn) Close() error {
 	return nil
 }
 
-func (c *appendWorkerTestConn) Exec(context.Context, string, ...any) clientapi.Result {
+func (c *appendWorkerTestConn) Exec(context.Context, string, ...any) api.Result {
 	return nil
 }
 
-func (c *appendWorkerTestConn) Query(context.Context, string, ...any) (clientapi.Rows, error) {
+func (c *appendWorkerTestConn) Query(context.Context, string, ...any) (api.Rows, error) {
 	return nil, nil
 }
 
-func (c *appendWorkerTestConn) QueryRow(context.Context, string, ...any) clientapi.Row {
+func (c *appendWorkerTestConn) QueryRow(context.Context, string, ...any) api.Row {
 	return nil
 }
 
-func (c *appendWorkerTestConn) Prepare(context.Context, string) (clientapi.Stmt, error) {
+func (c *appendWorkerTestConn) Prepare(context.Context, string) (api.Stmt, error) {
 	return nil, nil
 }
 
-func (c *appendWorkerTestConn) Appender(context.Context, string, ...clientapi.AppenderOption) (clientapi.Appender, error) {
+func (c *appendWorkerTestConn) Appender(context.Context, string, ...api.AppenderOption) (api.Appender, error) {
 	return nil, nil
 }
 
@@ -46,8 +46,8 @@ func (c *appendWorkerTestConn) Explain(context.Context, string, bool) (string, e
 
 type appendWorkerTestAppender struct {
 	tableName  string
-	tableType  clientapi.TableType
-	columns    clientapi.Columns
+	tableType  api.TableType
+	columns    api.Columns
 	appendRows [][]any
 	closed     int32
 }
@@ -72,31 +72,31 @@ func (a *appendWorkerTestAppender) Close() (int64, int64, error) {
 	return int64(len(a.appendRows)), 0, nil
 }
 
-func (a *appendWorkerTestAppender) Columns() (clientapi.Columns, error) {
+func (a *appendWorkerTestAppender) Columns() (api.Columns, error) {
 	return a.columns, nil
 }
 
-func (a *appendWorkerTestAppender) TableType() clientapi.TableType {
+func (a *appendWorkerTestAppender) TableType() api.TableType {
 	return a.tableType
 }
 
-func (a *appendWorkerTestAppender) WithInputColumns(...string) clientapi.Appender {
+func (a *appendWorkerTestAppender) WithInputColumns(...string) api.Appender {
 	return a
 }
 
-func (a *appendWorkerTestAppender) WithInputFormats(...string) clientapi.Appender {
+func (a *appendWorkerTestAppender) WithInputFormats(...string) api.Appender {
 	return a
 }
 
-func (a *appendWorkerTestAppender) WithBatchMaxRows(int) clientapi.Appender {
+func (a *appendWorkerTestAppender) WithBatchMaxRows(int) api.Appender {
 	return a
 }
 
-func (a *appendWorkerTestAppender) WithBatchMaxBytes(int) clientapi.Appender {
+func (a *appendWorkerTestAppender) WithBatchMaxBytes(int) api.Appender {
 	return a
 }
 
-func (a *appendWorkerTestAppender) WithBatchMaxDelay(time.Duration) clientapi.Appender {
+func (a *appendWorkerTestAppender) WithBatchMaxDelay(time.Duration) api.Appender {
 	return a
 }
 
@@ -104,10 +104,10 @@ func newAppendWorkerForTest(tableName string) (*AppendWorker, *appendWorkerTestA
 	ctx, cancel := context.WithCancel(context.Background())
 	appender := &appendWorkerTestAppender{
 		tableName: tableName,
-		tableType: clientapi.TableTypeLog,
-		columns: clientapi.Columns{
-			{Name: "NAME", DataType: clientapi.DataTypeString},
-			{Name: "VALUE", DataType: clientapi.DataTypeFloat64},
+		tableType: api.TableTypeLog,
+		columns: api.Columns{
+			{Name: "NAME", DataType: api.DataTypeString},
+			{Name: "VALUE", DataType: api.DataTypeFloat64},
 		},
 	}
 	conn := &appendWorkerTestConn{}
@@ -116,7 +116,7 @@ func newAppendWorkerForTest(tableName string) (*AppendWorker, *appendWorkerTestA
 		ctxCancel: cancel,
 		conn:      conn,
 		appender:  appender,
-		tableDesc: &clientapi.TableDescription{Name: tableName},
+		tableDesc: &api.TableDescription{Name: tableName},
 		lastTime:  time.Now(),
 		log:       logging.GetLog("append-worker-test"),
 	}, appender, conn
@@ -206,7 +206,47 @@ func TestAppendWorkerAppendLogTimeRequiresLogTable(t *testing.T) {
 	require.NoError(t, worker.AppendLogTime(ts, "temperature", 3.14))
 	require.Equal(t, []interface{}{ts, "temperature", 3.14}, <-worker.appendC)
 
-	appender.tableType = clientapi.TableTypeFixed
+	appender.tableType = api.TableTypeFixed
 	err := worker.AppendLogTime(ts, "temperature", 3.14)
+	require.EqualError(t, err, "sensor is not a log table, use Append() instead")
+}
+
+func TestAppendWorkerAppenderAccessorsAndNoopOptions(t *testing.T) {
+	worker, appender, _ := newAppendWorkerForTest("sensor")
+
+	require.Equal(t, "sensor", worker.TableName())
+	require.Equal(t, api.TableTypeLog, worker.TableType())
+	columns, err := worker.Columns()
+	require.NoError(t, err)
+	require.Equal(t, []string{"NAME", "VALUE"}, columns.Names())
+	require.Same(t, worker, worker.WithInputFormats("json"))
+	require.Same(t, worker, worker.WithBatchMaxRows(100))
+	require.Same(t, worker, worker.WithBatchMaxBytes(1024))
+	require.Same(t, worker, worker.WithBatchMaxDelay(time.Second))
+
+	success, fail, err := worker.Close()
+	require.NoError(t, err)
+	require.Zero(t, success)
+	require.Zero(t, fail)
+	require.Equal(t, int32(-1), atomic.LoadInt32(&worker.refCount))
+	require.Equal(t, int32(0), atomic.LoadInt32(&appender.closed))
+}
+
+func TestAppendWorkerStartAndAppenderWithWorkerAppendLogTime(t *testing.T) {
+	worker, appender, conn := newAppendWorkerForTest("sensor")
+
+	worker.Start()
+	require.NoError(t, worker.Append("temperature", 3.14))
+	worker.Stop()
+	require.NotEmpty(t, appender.appendRows)
+	require.Equal(t, int32(1), atomic.LoadInt32(&appender.closed))
+	require.Equal(t, int32(1), atomic.LoadInt32(&conn.closed))
+
+	worker2, appender2, _ := newAppendWorkerForTest("sensor")
+	worker2.appendC = make(chan []interface{}, 1)
+	wrapped := worker2.WithInputColumns("NAME", "VALUE").(*AppenderWithWorker)
+	sts := time.Unix(10, 0)
+	appender2.tableType = api.TableTypeFixed
+	err := wrapped.AppendLogTime(sts, "tagB", 11.0)
 	require.EqualError(t, err, "sensor is not a log table, use Append() instead")
 }

--- a/spi/do.go
+++ b/spi/do.go
@@ -1,49 +1,10 @@
 package spi
 
 import (
-	"strings"
 	"time"
 
 	"github.com/machbase/neo-client/api"
 )
-
-type TableName string
-
-func (tn TableName) String() string {
-	return strings.ToUpper(string(tn))
-}
-
-// Split splits the full table name that consists of database, user, and table name.
-func (tn TableName) SplitOr(dbName string, userName string) (string, string, string) {
-	tableName := strings.ToUpper(string(tn))
-	parts := strings.SplitN(tableName, ".", 3)
-	if len(parts) == 2 {
-		userName = parts[0]
-		tableName = parts[1]
-	} else if len(parts) == 3 {
-		dbName = parts[0]
-		userName = parts[1]
-		tableName = parts[2]
-	}
-	return dbName, userName, tableName
-}
-
-// Split splits the full table name that consists of database, user, and table name.
-func (tn TableName) Split() (string, string, string) {
-	dbName := "MACHBASEDB"
-	userName := "SYS"
-	tableName := strings.ToUpper(string(tn))
-	parts := strings.SplitN(tableName, ".", 3)
-	if len(parts) == 2 {
-		userName = parts[0]
-		tableName = parts[1]
-	} else if len(parts) == 3 {
-		dbName = parts[0]
-		userName = parts[1]
-		tableName = parts[2]
-	}
-	return dbName, userName, tableName
-}
 
 type InfoType interface {
 	Columns() api.Columns

--- a/spi/do_tables.go
+++ b/spi/do_tables.go
@@ -99,7 +99,7 @@ func ListTables(ctx context.Context, conn api.Conn, showAll bool) (ret []*TableI
 }
 
 func QueryTableType(ctx context.Context, conn api.Conn, fullTableName string) (api.TableType, error) {
-	_, userName, tableName := TableName(fullTableName).Split()
+	_, userName, tableName := api.TableName(fullTableName).Split()
 	sql := "select type from M$SYS_TABLES T, M$SYS_USERS U where U.NAME = ? and U.USER_ID = T.USER_ID AND T.NAME = ?"
 	r := conn.QueryRow(ctx, sql, strings.ToUpper(userName), strings.ToUpper(tableName))
 	if r.Err() != nil {

--- a/spi/do_tags.go
+++ b/spi/do_tags.go
@@ -8,13 +8,13 @@ import (
 )
 
 func ListTagsSql(fullTable string, tagNameColumn string) string {
-	database, user, table := TableName(fullTable).Split()
+	database, user, table := api.TableName(fullTable).Split()
 	return fmt.Sprintf(`SELECT _ID, %s FROM %s.%s._%s_META`, tagNameColumn, database, user, table)
 }
 
 func ListTags(ctx context.Context, conn api.Conn, fullTable string, tagNameColumn string) ([]*TagInfo, error) {
 	var tags []*TagInfo
-	database, user, table := TableName(fullTable).Split()
+	database, user, table := api.TableName(fullTable).Split()
 	rows, err := conn.Query(ctx, ListTagsSql(fullTable, tagNameColumn))
 	if err != nil {
 		return nil, err
@@ -40,7 +40,7 @@ func ListTagsWalk(ctx context.Context, conn api.Conn, table string, tagNameColum
 	}
 	defer rows.Close()
 
-	database, userName, tableName := TableName(table).Split()
+	database, userName, tableName := api.TableName(table).Split()
 	for rows.Next() {
 		nfo := &TagInfo{Database: database, User: userName, Table: tableName}
 		nfo.Err = rows.Scan(&nfo.Id, &nfo.Name)
@@ -51,7 +51,7 @@ func ListTagsWalk(ctx context.Context, conn api.Conn, table string, tagNameColum
 }
 
 func TagStatSql(fullTable string) string {
-	database, user, table := TableName(fullTable).Split()
+	database, user, table := api.TableName(fullTable).Split()
 	return api.SqlTidy(`SELECT`,
 		`NAME, ROW_COUNT,`,
 		`MIN_TIME, MAX_TIME,`,
@@ -63,7 +63,7 @@ func TagStatSql(fullTable string) string {
 }
 
 func TagStat(ctx context.Context, conn api.Conn, table string, tag string) (*TagStatInfo, error) {
-	database, user, table := TableName(table).Split()
+	database, user, table := api.TableName(table).Split()
 	sqlText := TagStatSql(table)
 	nfo := &TagStatInfo{
 		Database: database,

--- a/spi/spi_test.go
+++ b/spi/spi_test.go
@@ -357,11 +357,14 @@ func TestCommands(t *testing.T) {
 		}
 	}()
 	tests := []struct {
-		name       string
-		input      string
-		expect     []string
-		expectErr  string
-		expectFunc func(t *testing.T, actual string)
+		name              string
+		input             string
+		args              []string
+		params            []any
+		stopAfterFirstRow bool
+		expect            []string
+		expectErr         string
+		expectFunc        func(t *testing.T, actual string)
 	}{
 		{
 			name:      "wrong-command",
@@ -381,6 +384,20 @@ func TestCommands(t *testing.T) {
 		{
 			name:  "show_tables_all",
 			input: "show tables --all",
+			expect: []string{
+				"ROWNUM,DATABASE,USER,NAME,ID,TYPE,FLAG",
+				"1,MACHBASEDB,SYS,LOG_DATA,15,Log,",
+				"2,MACHBASEDB,SYS,TAG_DATA,7,Tag,",
+				"3,MACHBASEDB,SYS,TAG_SIMPLE,14,Tag,",
+				"4,MACHBASEDB,SYS,_TAG_DATA_DATA_0,1,KeyValue,Data",
+				"5,MACHBASEDB,SYS,_TAG_DATA_META,2,Lookup,Meta",
+				"6,MACHBASEDB,SYS,_TAG_SIMPLE_DATA_0,8,KeyValue,Data",
+				"7,MACHBASEDB,SYS,_TAG_SIMPLE_META,9,Lookup,Meta",
+			},
+		},
+		{
+			name:  "show_tables_short_all",
+			input: "SHOW tables -a",
 			expect: []string{
 				"ROWNUM,DATABASE,USER,NAME,ID,TYPE,FLAG",
 				"1,MACHBASEDB,SYS,LOG_DATA,15,Log,",
@@ -433,6 +450,25 @@ func TestCommands(t *testing.T) {
 				"TEXT_VALUE text 67108864  ",
 				"BIN_VALUE binary 67108864  ",
 				"_RID long 20  "},
+		},
+		{
+			name:  "desc_table_tag_data",
+			input: "desc tag_data",
+			expect: []string{
+				"NAME varchar 100 tag name ",
+				"TIME datetime 31 basetime ",
+				"VALUE double 17 summarized ",
+				"SHORT_VALUE short 6  ",
+				"USHORT_VALUE ushort 5  ",
+				"INT_VALUE integer 11  ",
+				"UINT_VALUE uinteger 10  ",
+				"LONG_VALUE long 20  ",
+				"ULONG_VALUE ulong 20  ",
+				"STR_VALUE varchar 400  ",
+				"JSON_VALUE json 32767  ",
+				"IPV4_VALUE ipv4 15  ",
+				"IPV6_VALUE ipv6 45  ",
+				"BIN_VALUE binary 32767  "},
 		},
 		{
 			name:  "desc_table_tag_data_all",
@@ -492,6 +528,11 @@ func TestCommands(t *testing.T) {
 			name:   "show_tags_tag_data",
 			input:  "show tags tag_data",
 			expect: []string{"1 1 tag1 MACHBASEDB SYS TAG_DATA 1"},
+		},
+		{
+			name:      "show_tags_not_tag_table",
+			input:     "show tags log_data",
+			expectErr: "table 'LOG_DATA' is not a tag table",
 		},
 		{
 			name:  "show_indexgap",
@@ -580,6 +621,30 @@ func TestCommands(t *testing.T) {
 				"no rows fetched.",
 			},
 		},
+		{
+			name:   "sql-select-row",
+			input:  `sql -- select name as NAME, value as VALUE from tag_data where name = ?`,
+			params: []any{"tag1"},
+			expect: []string{
+				"NAME,VALUE",
+				"1 tag1,123.45",
+				"a row fetched.",
+			},
+		},
+		{
+			name:      "sql_bridge_not_supported",
+			args:      []string{"sql", "--bridge", "sqlite", "select 1"},
+			expectErr: "bridge not supported",
+		},
+		{
+			name:              "sql_callback_stops_after_first_row",
+			input:             `sql -- select name as NAME from tag_data union all select name as NAME from tag_data`,
+			stopAfterFirstRow: true,
+			expectFunc: func(t *testing.T, actual string) {
+				actual = strings.TrimSuffix(actual, "\n")
+				require.Equal(t, "NAME\n1 tag1\na row fetched.", actual)
+			},
+		},
 	}
 
 	h := &spi.CommandHandler{
@@ -606,12 +671,17 @@ func TestCommands(t *testing.T) {
 	h.ShowTableUsage = printShowResult[*spi.TableUsageInfo](t, output)
 	h.ShowLicense = showLicense(t, output)
 	h.Explain = explain(t, output)
-	h.SqlQuery = sqlQuery(t, output)
+	h.SqlQuery = sqlQuery(t, output, false)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer output.Reset()
-			err := h.Exec(t.Context(), spi.ParseCommandLine(tt.input))
+			h.SqlQuery = sqlQuery(t, output, tt.stopAfterFirstRow)
+			args := tt.args
+			if args == nil {
+				args = spi.ParseCommandLine(tt.input)
+			}
+			err := h.Exec(t.Context(), args, tt.params...)
 			if err != nil {
 				if tt.expectErr != "" {
 					require.Contains(t, err.Error(), tt.expectErr)
@@ -719,7 +789,7 @@ func explain(t *testing.T, output io.Writer) func(plan string, err error) {
 	}
 }
 
-func sqlQuery(t *testing.T, output io.Writer) func(q *spi.Query, nrow int64) bool {
+func sqlQuery(t *testing.T, output io.Writer, stopAfterFirstRow bool) func(q *spi.Query, nrow int64) bool {
 	return func(q *spi.Query, nrow int64) bool {
 		if nrow == 0 {
 			columns := q.Columns()
@@ -737,9 +807,12 @@ func sqlQuery(t *testing.T, output io.Writer) func(q *spi.Query, nrow int64) boo
 			q.Scan(buffer...)
 			line := []string{}
 			for _, c := range buffer {
-				line = append(line, fmt.Sprintf("%v", c))
+				line = append(line, fmt.Sprintf("%v", api.Unbox(c)))
 			}
 			fmt.Fprintln(output, nrow, strings.Join(line, ","))
+			if stopAfterFirstRow {
+				return false
+			}
 		} else {
 			fmt.Fprintln(output, q.UserMessage())
 		}

--- a/spi/spi_test.go
+++ b/spi/spi_test.go
@@ -31,23 +31,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestAll(t *testing.T) {
-	if err := testServer.CreateTestTables(); err != nil {
-		t.Fatal(err)
-	}
-	db := testsuite.Database_machsvr(t)
-	testsuite.TestAll(t, db,
-		tcParseCommandLine,
-		tcCommands,
-		tcBridge,
-		tcScan,
-	)
-	if err := testServer.DropTestTables(); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestTableName(t *testing.T) {
+func TestTableNames(t *testing.T) {
 	tests := []struct {
 		input  string
 		expect [3]string
@@ -67,7 +51,7 @@ func TestTableName(t *testing.T) {
 	}
 }
 
-func tcBridge(t *testing.T) {
+func TestBridge(t *testing.T) {
 	tests := []struct {
 		Name        string
 		Bridge      string
@@ -191,7 +175,7 @@ func tcBridge(t *testing.T) {
 	}
 }
 
-func tcScan(t *testing.T) {
+func TestScan(t *testing.T) {
 	t.Parallel()
 
 	now := time.Unix(0, 1729578712564320000).In(time.UTC)
@@ -328,7 +312,7 @@ func tcScan(t *testing.T) {
 	}
 }
 
-func tcParseCommandLine(t *testing.T) {
+func TestParseCommandLine(t *testing.T) {
 	tests := []struct {
 		input  string
 		expect []string
@@ -363,7 +347,15 @@ func tcParseCommandLine(t *testing.T) {
 	}
 }
 
-func tcCommands(t *testing.T) {
+func TestCommands(t *testing.T) {
+	if err := testServer.CreateTestTables(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := testServer.DropTestTables(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	tests := []struct {
 		name       string
 		input      string
@@ -474,17 +466,32 @@ func tcCommands(t *testing.T) {
 			},
 		},
 		{
+			name:  "show_index",
+			input: `show index _TAG_DATA_META_NAME`,
+			expect: []string{
+				"_TAG_DATA_META NAME _TAG_DATA_META_NAME REDBLACK",
+			},
+		},
+		{
 			name:   "show_lsm",
 			input:  "show lsm",
 			expect: []string{},
 		},
 		{
-			name:  "show_tags_tag_data",
-			input: "show tags tag_data",
-			expectFunc: func(t *testing.T, actual string) {
-				lines := strings.Split(actual, "\n")
-				require.Greater(t, len(lines), 100)
-			},
+			name: "sql_insert",
+			input: `sql insert into tag_data (name, time, value, short_value, int_value, long_value, str_value, json_value)
+					values ('tag1', '2024-10-22 06:31:52', 123.45, 123, 12345, 1234567890, 'string value', '{"key": "value"}')`,
+			expect: []string{"", "a row inserted."},
+		},
+		{
+			name:   "sql_exec_table_flush",
+			input:  `sql exec table_flush(tag_data)`,
+			expect: []string{"", "table flushed."},
+		},
+		{
+			name:   "show_tags_tag_data",
+			input:  "show tags tag_data",
+			expect: []string{"1 1 tag1 MACHBASEDB SYS TAG_DATA 1"},
 		},
 		{
 			name:  "show_indexgap",
@@ -555,7 +562,7 @@ func tcCommands(t *testing.T) {
 		{
 			name:   "explain-select-all",
 			input:  `explain -- select * from log_data`,
-			expect: []string{" PROJECT", "  FULL SCAN (LOG_DATA)", ""},
+			expect: []string{" PROJECT", "  FULL SCAN (LOG_DATA)"},
 		},
 		{
 			name:  "explain-full-select-all",
@@ -577,7 +584,7 @@ func tcCommands(t *testing.T) {
 
 	h := &spi.CommandHandler{
 		Database: func(ctx context.Context) (api.Conn, error) {
-			return testServer.DatabaseSVR().Connect(ctx, api.WithPassword("sys", "manager"))
+			return spi.Default().Connect(ctx, api.WithAuthKey("sys", spi.DefaultKey()))
 		},
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/spi/spi_test.go
+++ b/spi/spi_test.go
@@ -347,7 +347,7 @@ func TestParseCommandLine(t *testing.T) {
 	}
 }
 
-func TestCommands(t *testing.T) {
+func TestDatabaseBasedCases(t *testing.T) {
 	if err := testServer.CreateTestTables(); err != nil {
 		t.Fatal(err)
 	}
@@ -356,6 +356,11 @@ func TestCommands(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
+	t.Run("Commands", testCommands)
+	t.Run("Helpers", testDatabaseHelpers)
+}
+
+func testCommands(t *testing.T) {
 	tests := []struct {
 		name              string
 		input             string
@@ -703,6 +708,65 @@ func TestCommands(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommandHandlerHelpers(t *testing.T) {
+	h := spi.NewCommandHandler()
+	require.True(t, h.SilenceUsage)
+	require.True(t, h.SilenceErrors)
+	require.Equal(t, "sql --", h.FallbackVerb)
+	require.Empty(t, h.Verbs())
+	require.False(t, h.IsKnownVerb("sql"))
+
+	h.ShowTables = func(*spi.TableInfo, int64) bool { return true }
+	h.DescribeTable = func(*api.TableDescription) {}
+	h.Explain = func(string, error) {}
+	h.SqlQuery = func(*spi.Query, int64) bool { return true }
+	require.Equal(t, []string{"show", "desc", "explain", "sql"}, h.Verbs())
+	require.True(t, h.IsKnownVerb("SHOW"))
+	require.True(t, h.IsKnownVerb("desc"))
+	require.False(t, h.IsKnownVerb("something"))
+}
+
+func testDatabaseHelpers(t *testing.T) {
+	ctx := t.Context()
+	conn, err := spi.Default().Connect(ctx, api.WithAuthKey("sys", spi.DefaultKey()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	tables, err := spi.ListTables(ctx, conn, false)
+	require.NoError(t, err)
+	require.Len(t, tables, 3)
+
+	tablesAll, err := spi.ListTables(ctx, conn, true)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(tablesAll), len(tables))
+
+	typeTag, err := spi.QueryTableType(ctx, conn, "tag_data")
+	require.NoError(t, err)
+	require.Equal(t, api.TableTypeTag, typeTag)
+
+	_, err = spi.QueryTableType(ctx, conn, "table_not_exists")
+	require.Error(t, err)
+
+	indexes, err := spi.ListIndexes(ctx, conn)
+	require.NoError(t, err)
+	require.NotEmpty(t, indexes)
+
+	tags, err := spi.ListTags(ctx, conn, "tag_data", "NAME")
+	require.NoError(t, err)
+	require.Len(t, tags, 1)
+	require.Equal(t, "tag1", tags[0].Name)
+
+	exists, truncated, err := spi.TruncateTableIfExists(ctx, conn, "table_not_exists", true)
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.False(t, truncated)
+
+	exists, truncated, err = spi.TruncateTableIfExists(ctx, conn, "log_data", false)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.False(t, truncated)
 }
 
 func printShowResult[T spi.InfoType](t *testing.T, output io.Writer) func(nfo T, nrow int64) bool {

--- a/spi/unit_test.go
+++ b/spi/unit_test.go
@@ -217,24 +217,6 @@ func TestSqlBridgeBaseHelpers(t *testing.T) {
 }
 
 func TestInfoValueObjects(t *testing.T) {
-	t.Run("table name helpers", func(t *testing.T) {
-		require.Equal(t, "SYS.EXAMPLE", TableName("sys.example").String())
-		db, user, table := TableName("metrics").SplitOr("db0", "user0")
-		require.Equal(t, "db0", db)
-		require.Equal(t, "user0", user)
-		require.Equal(t, "METRICS", table)
-
-		db, user, table = TableName("user1.metrics").SplitOr("db0", "user0")
-		require.Equal(t, "db0", db)
-		require.Equal(t, "USER1", user)
-		require.Equal(t, "METRICS", table)
-
-		db, user, table = TableName("db1.user1.metrics").SplitOr("db0", "user0")
-		require.Equal(t, "DB1", db)
-		require.Equal(t, "USER1", user)
-		require.Equal(t, "METRICS", table)
-	})
-
 	t.Run("table info kind and values", func(t *testing.T) {
 		tests := []struct {
 			info   TableInfo

--- a/spi/unit_test.go
+++ b/spi/unit_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	clientapi "github.com/machbase/neo-client/api"
+	"github.com/machbase/neo-client/api"
 	metricpkg "github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +19,7 @@ type stubSQLResult struct {
 }
 
 type stubConn struct {
-	execFunc func(ctx context.Context, sqlText string, params ...any) clientapi.Result
+	execFunc func(ctx context.Context, sqlText string, params ...any) api.Result
 	execSQLs []string
 	execArgs [][]any
 }
@@ -42,7 +42,7 @@ func (s *stubConn) Close() error {
 	return nil
 }
 
-func (s *stubConn) Exec(ctx context.Context, sqlText string, params ...any) clientapi.Result {
+func (s *stubConn) Exec(ctx context.Context, sqlText string, params ...any) api.Result {
 	s.execSQLs = append(s.execSQLs, sqlText)
 	s.execArgs = append(s.execArgs, params)
 	if s.execFunc != nil {
@@ -51,19 +51,19 @@ func (s *stubConn) Exec(ctx context.Context, sqlText string, params ...any) clie
 	return &InsertResult{rowsAffected: 1, message: "a row inserted"}
 }
 
-func (s *stubConn) Query(ctx context.Context, sqlText string, params ...any) (clientapi.Rows, error) {
+func (s *stubConn) Query(ctx context.Context, sqlText string, params ...any) (api.Rows, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *stubConn) QueryRow(ctx context.Context, sqlText string, params ...any) clientapi.Row {
+func (s *stubConn) QueryRow(ctx context.Context, sqlText string, params ...any) api.Row {
 	return nil
 }
 
-func (s *stubConn) Prepare(ctx context.Context, query string) (clientapi.Stmt, error) {
+func (s *stubConn) Prepare(ctx context.Context, query string) (api.Stmt, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *stubConn) Appender(ctx context.Context, tableName string, opts ...clientapi.AppenderOption) (clientapi.Appender, error) {
+func (s *stubConn) Appender(ctx context.Context, tableName string, opts ...api.AppenderOption) (api.Appender, error) {
 	return nil, errors.New("not implemented")
 }
 
@@ -74,25 +74,25 @@ func (s *stubConn) Explain(ctx context.Context, sqlText string, full bool) (stri
 func TestWrappedSqlResultMessage(t *testing.T) {
 	tests := []struct {
 		name    string
-		sqlType clientapi.SQLStatementType
+		sqlType api.SQLStatementType
 		rows    int64
 		err     error
 		expect  string
 	}{
-		{name: "insert zero", sqlType: clientapi.SQLStatementTypeInsert, rows: 0, expect: "no rows inserted."},
-		{name: "insert one", sqlType: clientapi.SQLStatementTypeInsert, rows: 1, expect: "a row inserted."},
-		{name: "insert many", sqlType: clientapi.SQLStatementTypeInsert, rows: 3, expect: "3 rows inserted."},
-		{name: "update zero", sqlType: clientapi.SQLStatementTypeUpdate, rows: 0, expect: "no rows updated."},
-		{name: "update one", sqlType: clientapi.SQLStatementTypeUpdate, rows: 1, expect: "a row updated."},
-		{name: "update many", sqlType: clientapi.SQLStatementTypeUpdate, rows: 4, expect: "4 rows updated."},
-		{name: "delete zero", sqlType: clientapi.SQLStatementTypeDelete, rows: 0, expect: "no rows deleted."},
-		{name: "delete one", sqlType: clientapi.SQLStatementTypeDelete, rows: 1, expect: "a row deleted."},
-		{name: "delete many", sqlType: clientapi.SQLStatementTypeDelete, rows: 2, expect: "2 rows deleted."},
-		{name: "create", sqlType: clientapi.SQLStatementTypeCreate, expect: "Created successfully."},
-		{name: "drop", sqlType: clientapi.SQLStatementTypeDrop, expect: "Dropped successfully."},
-		{name: "alter", sqlType: clientapi.SQLStatementTypeAlter, expect: "Altered successfully."},
-		{name: "select", sqlType: clientapi.SQLStatementTypeSelect, expect: "Select successfully."},
-		{name: "default", sqlType: clientapi.SQLStatementType(-1), expect: "executed."},
+		{name: "insert zero", sqlType: api.SQLStatementTypeInsert, rows: 0, expect: "no rows inserted."},
+		{name: "insert one", sqlType: api.SQLStatementTypeInsert, rows: 1, expect: "a row inserted."},
+		{name: "insert many", sqlType: api.SQLStatementTypeInsert, rows: 3, expect: "3 rows inserted."},
+		{name: "update zero", sqlType: api.SQLStatementTypeUpdate, rows: 0, expect: "no rows updated."},
+		{name: "update one", sqlType: api.SQLStatementTypeUpdate, rows: 1, expect: "a row updated."},
+		{name: "update many", sqlType: api.SQLStatementTypeUpdate, rows: 4, expect: "4 rows updated."},
+		{name: "delete zero", sqlType: api.SQLStatementTypeDelete, rows: 0, expect: "no rows deleted."},
+		{name: "delete one", sqlType: api.SQLStatementTypeDelete, rows: 1, expect: "a row deleted."},
+		{name: "delete many", sqlType: api.SQLStatementTypeDelete, rows: 2, expect: "2 rows deleted."},
+		{name: "create", sqlType: api.SQLStatementTypeCreate, expect: "Created successfully."},
+		{name: "drop", sqlType: api.SQLStatementTypeDrop, expect: "Dropped successfully."},
+		{name: "alter", sqlType: api.SQLStatementTypeAlter, expect: "Altered successfully."},
+		{name: "select", sqlType: api.SQLStatementTypeSelect, expect: "Select successfully."},
+		{name: "default", sqlType: api.SQLStatementType(-1), expect: "executed."},
 		{name: "preset error", err: errors.New("boom"), expect: "boom"},
 	}
 
@@ -133,9 +133,9 @@ func TestWrappedSqlRowHelpers(t *testing.T) {
 	t.Run("scan copies values", func(t *testing.T) {
 		row := &WrappedSqlRow{
 			values: []any{int64(7), "neo"},
-			columns: clientapi.Columns{
-				{Name: "ID", DataType: clientapi.DataTypeInt64},
-				{Name: "NAME", DataType: clientapi.DataTypeString},
+			columns: api.Columns{
+				{Name: "ID", DataType: api.DataTypeInt64},
+				{Name: "NAME", DataType: api.DataTypeString},
 			},
 		}
 		var id int64
@@ -222,16 +222,16 @@ func TestInfoValueObjects(t *testing.T) {
 			info   TableInfo
 			expect string
 		}{
-			{info: TableInfo{Type: clientapi.TableTypeLog, Flag: clientapi.TableFlagData}, expect: "Log Table (data)"},
-			{info: TableInfo{Type: clientapi.TableTypeFixed, Flag: clientapi.TableFlagMeta}, expect: "Fixed Table (meta)"},
-			{info: TableInfo{Type: clientapi.TableTypeTag, Flag: clientapi.TableFlagStat}, expect: "Tag Table (stat)"},
-			{info: TableInfo{Type: clientapi.TableType(-1)}, expect: "undef"},
+			{info: TableInfo{Type: api.TableTypeLog, Flag: api.TableFlagData}, expect: "Log Table (data)"},
+			{info: TableInfo{Type: api.TableTypeFixed, Flag: api.TableFlagMeta}, expect: "Fixed Table (meta)"},
+			{info: TableInfo{Type: api.TableTypeTag, Flag: api.TableFlagStat}, expect: "Tag Table (stat)"},
+			{info: TableInfo{Type: api.TableType(-1)}, expect: "undef"},
 		}
 		for _, tc := range tests {
 			require.Equal(t, tc.expect, tc.info.Kind())
 		}
 
-		info := &TableInfo{Database: "DB", User: "SYS", Name: "T", Id: 1, Type: clientapi.TableTypeLookup, Flag: clientapi.TableFlagRollup, err: errors.New("table err")}
+		info := &TableInfo{Database: "DB", User: "SYS", Name: "T", Id: 1, Type: api.TableTypeLookup, Flag: api.TableFlagRollup, err: errors.New("table err")}
 		cols := info.Columns()
 		require.Equal(t, []string{"DATABASE", "USER", "NAME", "ID", "TYPE", "FLAG"}, cols.Names())
 		require.Equal(t, []any{"DB", "SYS", "T", int64(1), info.Type.ShortString(), info.Flag.String()}, info.Values())
@@ -384,12 +384,12 @@ func TestMetricsAndWatcherHelpers(t *testing.T) {
 func TestWriteLineProtocol(t *testing.T) {
 	ctx := context.Background()
 	ts := time.Unix(1700000000, 0).UTC()
-	descColumns := clientapi.Columns{
-		{Name: "NAME", DataType: clientapi.DataTypeString},
-		{Name: "TIME", DataType: clientapi.DataTypeDatetime},
-		{Name: "VALUE", DataType: clientapi.DataTypeFloat64},
-		{Name: "HOST", DataType: clientapi.DataTypeString},
-		{Name: "PORT", DataType: clientapi.DataTypeInt32},
+	descColumns := api.Columns{
+		{Name: "NAME", DataType: api.DataTypeString},
+		{Name: "TIME", DataType: api.DataTypeDatetime},
+		{Name: "VALUE", DataType: api.DataTypeFloat64},
+		{Name: "HOST", DataType: api.DataTypeString},
+		{Name: "PORT", DataType: api.DataTypeInt32},
 	}
 
 	t.Run("insert result helpers", func(t *testing.T) {
@@ -434,7 +434,7 @@ func TestWriteLineProtocol(t *testing.T) {
 	t.Run("abort on exec error", func(t *testing.T) {
 		conn := &stubConn{}
 		callCount := 0
-		conn.execFunc = func(ctx context.Context, sqlText string, params ...any) clientapi.Result {
+		conn.execFunc = func(ctx context.Context, sqlText string, params ...any) api.Result {
 			callCount++
 			if callCount == 2 {
 				return &InsertResult{err: errors.New("exec failed")}
@@ -451,4 +451,4 @@ func TestWriteLineProtocol(t *testing.T) {
 }
 
 var _ driver.Result = stubSQLResult{}
-var _ clientapi.Conn = (*stubConn)(nil)
+var _ api.Conn = (*stubConn)(nil)


### PR DESCRIPTION
This pull request introduces several improvements and refactoring changes across the codebase, with a focus on test coverage, code simplification, and configuration enhancements. The most significant changes include refactoring tests for better structure and coverage, removing the `TableName` type from the `spi` package and using the type from the client API, and adding new configuration options for server key paths.

**Testing and Test Structure Improvements:**

- Refactored and expanded tests in `spi/spi_test.go` (renamed from `spi/do_test.go`):
  - Split monolithic test functions into smaller, focused test cases (`TestTableNames`, `TestBridge`, `TestScan`, `TestParseCommandLine`, `TestDatabaseBasedCases`).
  - Added new test scenarios for command parsing, table descriptions, tag handling, and SQL execution.
  - Improved test coverage for append worker logic, including accessor and no-op option tests, as well as worker start/stop behavior. [[1]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L34-R34) [[2]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L70-R54) [[3]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L194-R178) [[4]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L331-R315) [[5]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L366-R369) [[6]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4R403-R416) [[7]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4R459-R477) [[8]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4R509-R540) [[9]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L558-R611) [[10]](diffhunk://#diff-bd1f25189ba99f0d9ea7a1a52d663832cebba6755839b3c6320999412e439495L209-R252)

**Codebase Simplification and API Consistency:**

- Removed the custom `TableName` type and its methods from `spi/do.go`, replacing its usage throughout the codebase with `api.TableName` from the client API, simplifying table name parsing and reducing code duplication. [[1]](diffhunk://#diff-b648eeb2c802aca96f0602b2da52a002ebe5633cc37dc5a488cc74fe2fe7b8b1L4-L47) [[2]](diffhunk://#diff-e719b3c1b60f9e815fbeb9a171ff1d9a5db9247913cc93df001fc1a15adbb53eL102-R102) [[3]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L11-R17) [[4]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L43-R43) [[5]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L54-R54) [[6]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L66-R66)
- Updated all related code and tests to use the new type, ensuring consistency and reducing maintenance overhead. [[1]](diffhunk://#diff-e719b3c1b60f9e815fbeb9a171ff1d9a5db9247913cc93df001fc1a15adbb53eL102-R102) [[2]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L11-R17) [[3]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L43-R43) [[4]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L54-R54) [[5]](diffhunk://#diff-778430cd2ff9137aa9506e87fc375059b89764f73b13be1053a91ac47193a455L66-R66)

**Configuration and Server Behavior:**

- Added support for setting the server key path in the TQL shell environment:
  - Introduced `SetServerKeyPath` and internal variable `_serverKeyPath` in `mods/tql/fm_shell.go`.
  - Updated the shell executable to pass `NEOSHELL_IDENTITY_FILE` with the server key path.
  - Hooked up the server configuration to set this path during HTTP server startup. [[1]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdR952) [[2]](diffhunk://#diff-abfde1a38b462a96954fdeb01194c6d0cc224da30fd04c062460cdd09bcfcc5bR35) [[3]](diffhunk://#diff-abfde1a38b462a96954fdeb01194c6d0cc224da30fd04c062460cdd09bcfcc5bR45-R48) [[4]](diffhunk://#diff-abfde1a38b462a96954fdeb01194c6d0cc224da30fd04c062460cdd09bcfcc5bR150)

**Minor Bug Fixes and Cleanups:**

- Fixed an OTP string formatting bug by removing an unnecessary colon in `handleTqlQuery`.
- Cleaned up import aliases and type usage in append worker tests for clarity and consistency. [[1]](diffhunk://#diff-bd1f25189ba99f0d9ea7a1a52d663832cebba6755839b3c6320999412e439495L9-R9) [[2]](diffhunk://#diff-bd1f25189ba99f0d9ea7a1a52d663832cebba6755839b3c6320999412e439495L23-R39) [[3]](diffhunk://#diff-bd1f25189ba99f0d9ea7a1a52d663832cebba6755839b3c6320999412e439495L49-R50) [[4]](diffhunk://#diff-bd1f25189ba99f0d9ea7a1a52d663832cebba6755839b3c6320999412e439495L75-R110) [[5]](diffhunk://#diff-bd1f25189ba99f0d9ea7a1a52d663832cebba6755839b3c6320999412e439495L119-R119)

These changes collectively improve code maintainability, test reliability, configuration flexibility, and overall code quality.