### PR TITLE
Enhance TQL cache statistics and improve error handling in tests

### DIFF
--- a/jsh/lib/system/system.go
+++ b/jsh/lib/system/system.go
@@ -68,18 +68,11 @@ func now() time.Time {
 }
 
 func statz(samplingInterval string, keyFilters ...string) ([]map[string]any, error) {
-	var interval = spi.MetricShortTerm
-	switch strings.ToLower(samplingInterval) {
-	case "short":
-		interval = spi.MetricShortTerm
-	case "mid":
-		interval = spi.MetricMidTerm
-	case "long":
-		interval = spi.MetricLongTerm
-	default:
-		if dur, err := time.ParseDuration(samplingInterval); err == nil {
-			interval = dur
-		}
+	var interval time.Duration
+	if dur, err := time.ParseDuration(samplingInterval); err == nil {
+		interval = dur
+	} else {
+		interval = time.Minute
 	}
 	stat := spi.QueryStatz(interval, spi.QueryStatzFilter(keyFilters))
 	if stat.Err != nil {

--- a/mods/server/http.go
+++ b/mods/server/http.go
@@ -18,10 +18,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"slices"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -45,8 +43,6 @@ import (
 	"github.com/machbase/neo-server/v8/spi"
 	cmap "github.com/orcaman/concurrent-map/v2"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 )
 
 // Factory
@@ -369,7 +365,7 @@ func (svr *httpd) Router() *gin.Engine {
 	debugGroup.Use(svr.allowDebug)
 	debugGroup.Any("/pprof/*path", gin.WrapF(httpPprof.Index))
 	debugGroup.GET("/dashboard", gin.WrapF(spi.DashboardHandler()))
-	debugGroup.GET("/statz", svr.handleStatz)
+	debugGroup.GET("/statz", gin.WrapF(spi.HandleStatz))
 
 	r.NoRoute(gin.WrapH(http.FileServer(AssetsDir())))
 	return r
@@ -1001,115 +997,6 @@ func (svr *httpd) handleStatzConfig(ctx *gin.Context) {
 		ctx.String(http.StatusMethodNotAllowed, "")
 	}
 }
-func (svr *httpd) handleStatz(ctx *gin.Context) {
-	ret := map[string]any{}
-	includes := ctx.QueryArray("keys")
-	format := ctx.Query("format")
-	interval := ctx.Query("interval")
-	if interval == "" {
-		interval = "1m"
-	}
-	dur, err := time.ParseDuration(interval)
-	if err != nil {
-		dur = time.Minute
-	}
-
-	stat := spi.QueryStatzRows(dur, 1, func(key string) (bool, int) {
-		return strings.HasPrefix(key, "machbase:") ||
-			strings.HasPrefix(key, "go:") ||
-			slices.Contains(includes, key), 0
-	})
-	if stat.Err != nil {
-		ctx.String(http.StatusInternalServerError, stat.Err.Error())
-		return
-	}
-	for idx, col := range stat.Cols {
-		value := stat.Rows[0].Values[idx]
-		valueType := stat.ValueTypes[idx]
-		if format == "html" {
-			if value == nil {
-				ret[col.Name] = "null"
-				continue
-			}
-			printer := message.NewPrinter(language.English)
-			switch col.DataType {
-			case api.DataTypeInt64:
-				ret[col.Name] = printer.Sprintf("%d", value)
-			case api.DataTypeFloat64:
-				switch valueType {
-				case "dur":
-					switch val := value.(type) {
-					case float64:
-						ret[col.Name] = printer.Sprintf("%s", time.Duration(val))
-					case int64:
-						ret[col.Name] = printer.Sprintf("%s", time.Duration(val))
-					default:
-						ret[col.Name] = printer.Sprintf("%v", value)
-					}
-				case "i":
-					switch val := value.(type) {
-					case float64:
-						ret[col.Name] = printer.Sprintf("%d", int64(val))
-					case int64:
-						ret[col.Name] = printer.Sprintf("%d", val)
-					default:
-						ret[col.Name] = printer.Sprintf("%v", value)
-					}
-				default:
-					ret[col.Name] = printer.Sprintf("%f", value)
-				}
-			case api.DataTypeString:
-				ret[col.Name] = value
-			default:
-				ret[col.Name] = printer.Sprintf("%v", value)
-			}
-		} else {
-			ret[col.Name] = value
-		}
-	}
-	if format == "html" {
-		tpl := template.New("statz").Funcs(template.FuncMap{
-			"isMap": func(v any) bool {
-				switch v.(type) {
-				case map[string]any, map[string]float64, map[string]string, map[string]int64:
-					return true
-				default:
-					return false
-				}
-			},
-		})
-		tpl = template.Must(tpl.Parse(tmplStatz))
-		if err := tpl.ExecuteTemplate(ctx.Writer, "statz", ret); err != nil {
-			ctx.String(http.StatusInternalServerError, err.Error())
-		}
-	} else {
-		ctx.JSON(http.StatusOK, ret)
-	}
-}
-
-var tmplStatz = `
-{{- define "statz" }}
-<style>
-  table {
-    border-collapse: collapse;
-  }
-  tr:nth-child(even) {
-    background-color: #f2f2f2;
-  }
-  td {
-    border: 1px solid #ddd;
-    padding: 8px;
-  }
-</style>
-<table>
-{{- range $key, $value := . }}
-<tr>
-  <td>{{ $key }}</td>
-  <td>{{ $value }}</td>
-</tr>
-{{- end }}
-</table>
-{{ end }}`
 
 type LicenseResponse struct {
 	Success bool             `json:"success"`

--- a/mods/server/http_test.go
+++ b/mods/server/http_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
-	"expvar"
 	"fmt"
 	"io"
 	"math/big"
@@ -28,7 +27,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gofrs/uuid/v5"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/websocket"
 	"github.com/machbase/neo-client/api"
@@ -126,35 +124,6 @@ func TestHandleStatzConfig(t *testing.T) {
 		svr.handleStatzConfig(ctx)
 
 		require.Equal(t, http.StatusMethodNotAllowed, writer.Code)
-	})
-}
-
-func TestHandleStatz(t *testing.T) {
-	svr := &httpd{log: logging.GetLog("httpd-fake")}
-	metricKey := "custom:" + uuid.Must(uuid.NewV4()).String()
-	metricValue := expvar.NewInt(metricKey)
-	metricValue.Set(42)
-
-	t.Run("json with invalid interval fallback", func(t *testing.T) {
-		ctx, writer := newTestHTTPContext(http.MethodGet, "/debug/statz?interval=not-a-duration&keys="+url.QueryEscape(metricKey), nil)
-
-		svr.handleStatz(ctx)
-
-		require.Equal(t, http.StatusOK, writer.Code)
-		var payload map[string]any
-		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &payload))
-		require.EqualValues(t, 42, payload[metricKey])
-	})
-
-	t.Run("html renders included metric", func(t *testing.T) {
-		ctx, writer := newTestHTTPContext(http.MethodGet, "/debug/statz?format=html&keys="+url.QueryEscape(metricKey), nil)
-
-		svr.handleStatz(ctx)
-
-		require.Equal(t, http.StatusOK, writer.Code)
-		require.Contains(t, writer.Body.String(), "<table>")
-		require.Contains(t, writer.Body.String(), metricKey)
-		require.Contains(t, writer.Body.String(), "42")
 	})
 }
 

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -1746,7 +1746,7 @@ func (s *Server) statSession(ctx context.Context, reset bool) (*spi.Statz, error
 	if !rsp.Success {
 		return nil, errors.New(rsp.Reason)
 	}
-	return rsp.Statz, nil
+	return &spi.Statz{}, nil
 }
 
 type SessionLimit struct {

--- a/mods/server/svrbackup_test.go
+++ b/mods/server/svrbackup_test.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestBackupdStartSetsCutset(t *testing.T) {
+	s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+	require.NoError(t, s.Start())
+
+	expected := "/"
+	if runtime.GOOS == "windows" {
+		expected = "\\"
+	}
+	require.Equal(t, expected, s.cutset)
+}
+
+func TestBackupdHttpHandler(t *testing.T) {
+	s := NewBackupd()
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/api/backup/ping", nil)
+
+	s.HttpHandler(ctx)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := decodeJSONBody(t, w)
+	require.Equal(t, "pong", body["message"])
+}
+
+func TestBackupdHandleArchiveStatus(t *testing.T) {
+	t.Run("success when idle", func(t *testing.T) {
+		s := NewBackupd()
+		s.backup = backupState{IsRunning: false, Info: BackupArchive{Type: "database"}}
+
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/api/backup/archive/status", nil)
+
+		s.handleArchiveStatus(ctx)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, true, body["success"])
+		require.Equal(t, "success", body["reason"])
+	})
+
+	t.Run("internal server error when backup failed", func(t *testing.T) {
+		s := NewBackupd()
+		s.backup = backupState{IsRunning: false, Message: "backup failed", err: assertErr("failed")}
+
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/api/backup/archive/status", nil)
+
+		s.handleArchiveStatus(ctx)
+
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, false, body["success"])
+		require.Equal(t, "backup failed", body["reason"])
+	})
+}
+
+func TestBackupdHandleArchiveValidation(t *testing.T) {
+	t.Run("reject malformed body", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+		w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", "{}")
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, false, body["success"])
+	})
+
+	t.Run("reject when backup already running", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+		s.backup.IsRunning = true
+		payload := `{"type":"database","duration":{"type":"full"},"path":"backup/a"}`
+
+		w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", payload)
+
+		require.Equal(t, http.StatusInternalServerError, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, "backup is running.", body["reason"])
+	})
+
+	t.Run("reject table backup without table name", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+		payload := `{"type":"table","duration":{"type":"full"},"path":"backup/a"}`
+
+		w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", payload)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, "table name is empty", body["reason"])
+	})
+
+	t.Run("reject invalid backup target type", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+		payload := `{"type":"invalid","duration":{"type":"full"},"path":"backup/a"}`
+
+		w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", payload)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSONBody(t, w)
+		require.True(t, strings.Contains(body["reason"].(string), "invalid backup"))
+	})
+
+	t.Run("reject invalid duration type", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+		payload := `{"type":"database","duration":{"type":"unknown"},"path":"backup/a"}`
+
+		w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", payload)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSONBody(t, w)
+		require.True(t, strings.Contains(body["reason"].(string), "invalid backup type"))
+	})
+}
+
+func TestBackupdHandleArchivesReturnsEmptyWhenBaseDirMissing(t *testing.T) {
+	missingBase := filepath.Join(t.TempDir(), "missing-backup-dir")
+	s := NewBackupd(WithBackupdBaseDir(missingBase))
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/api/backup/archives", nil)
+
+	s.handleArchives(ctx)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := decodeJSONBody(t, w)
+	require.Equal(t, true, body["success"])
+	require.Equal(t, "success", body["reason"])
+	require.Equal(t, []any{}, body["data"])
+}
+
+func TestBackupdHandleMountValidation(t *testing.T) {
+	t.Run("reject empty mount name", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/api/backup/mounts/", strings.NewReader(`{"path":"a"}`))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+
+		s.handleMount(ctx)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, "invalid mount name", body["reason"])
+	})
+
+	t.Run("reject missing path in body", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+
+		w := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(w)
+		ctx.Params = gin.Params{{Key: "name", Value: "test_mount"}}
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/api/backup/mounts/test_mount", strings.NewReader(`{}`))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+
+		s.handleMount(ctx)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, false, body["success"])
+	})
+}
+
+func TestBackupdHandleUnmountRejectsEmptyName(t *testing.T) {
+	s := NewBackupd(WithBackupdBaseDir(t.TempDir()))
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest(http.MethodDelete, "/api/backup/mounts/", nil)
+
+	s.handleUnmount(ctx)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	body := decodeJSONBody(t, w)
+	require.Equal(t, "invalid mount name", body["reason"])
+}
+
+func performBackupRequest(t *testing.T, handler gin.HandlerFunc, method, path, payload string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest(method, path, strings.NewReader(payload))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	handler(ctx)
+	return w
+}
+
+func decodeJSONBody(t *testing.T, w *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	body := map[string]any{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return body
+}
+
+type backupTestErr string
+
+func (e backupTestErr) Error() string { return string(e) }
+
+func assertErr(msg string) error {
+	return backupTestErr(msg)
+}

--- a/mods/server/svrmetric.go
+++ b/mods/server/svrmetric.go
@@ -10,6 +10,7 @@ import (
 	"github.com/machbase/neo-server/v8/mods/tql"
 	"github.com/machbase/neo-server/v8/mods/util"
 	"github.com/machbase/neo-server/v8/mods/util/metric"
+	"github.com/machbase/neo-server/v8/mods/util/metric/input"
 	"github.com/machbase/neo-server/v8/spi"
 )
 
@@ -17,10 +18,12 @@ var statzLog = logging.GetLog("server-statz")
 
 func startServerMetrics(s *Server) {
 	spi.StartMetrics()
-	spi.AddMetricsFunc(collectSysStatz)
-	spi.AddMetricsFunc(collectMachSvrStatz)
-	spi.AddMetricsFunc(collectMqttStatz(s))
-	spi.AddMetricsFunc(collectTqlCacheStatz)
+	spi.AddInput(&input.Runtime{})
+	spi.AddInput(&input.Netstat{})
+	spi.AddInputFunc(collectSysStatz)
+	spi.AddInputFunc(collectMachSvrStatz)
+	spi.AddInputFunc(collectMqttStatz(s))
+	spi.AddInputFunc(collectTqlCacheStatz)
 
 	util.AddShutdownHook(func() { stopServerMetrics() })
 
@@ -40,19 +43,71 @@ func collectSysStatz(g *metric.Gather) error {
 		return err
 	}
 	defer conn.Close()
-	row := conn.QueryRow(ctx, "select sum(usage) from v$sysmem")
-	if err = row.Err(); err != nil {
-		statzLog.Error("failed to query machbase: %v", err)
+	if value, err := queryRowInt64(ctx, conn, "select sum(usage) from v$sysmem"); err != nil {
 		return err
+	} else {
+		g.Add("sys:sysmem", float64(value), metric.GaugeType(metric.UnitBytes))
 	}
-	var usageTotal int64
-	if err = row.Scan(&usageTotal); err != nil {
-		statzLog.Error("failed to scan machbase: %v", err)
+	if value, err := queryRowInt64(ctx, conn, "select value from v$sysstat where name=?", "APPEND_OPEN"); err != nil {
 		return err
+	} else {
+		g.Add("sys:append:open", float64(value), metric.OdometerType(metric.UnitShort))
 	}
-
-	g.Add("sys:sysmem", float64(usageTotal), metric.GaugeType(metric.UnitBytes))
+	if value, err := queryRowInt64(ctx, conn, "select value from v$sysstat where name=?", "APPEND_CLOSE"); err != nil {
+		return err
+	} else {
+		g.Add("sys:append:close", float64(value), metric.OdometerType(metric.UnitShort))
+	}
+	if value, err := queryRowInt64(ctx, conn, "select value from v$sysstat where name=?", "APPEND_DATA_SUCCESS"); err != nil {
+		return err
+	} else {
+		g.Add("sys:append:data:success", float64(value), metric.OdometerType(metric.UnitShort))
+	}
+	if value, err := queryRowInt64(ctx, conn, "select value from v$sysstat where name=?", "APPEND_DATA_FAILURE"); err != nil {
+		return err
+	} else {
+		g.Add("sys:append:data:failure", float64(value), metric.OdometerType(metric.UnitShort))
+	}
+	if value, err := queryRowInt64(ctx, conn, "select count(*) from v$session"); err != nil {
+		return err
+	} else {
+		g.Add("sys:session:count", float64(value), metric.GaugeType(metric.UnitShort))
+	}
+	if value, err := queryRowInt64(ctx, conn, "select count from v$systime where name=?", "EXECUTE"); err != nil {
+		return err
+	} else {
+		g.Add("sys:execute:count", float64(value), metric.OdometerType(metric.UnitShort))
+	}
+	if value, err := queryRowInt64(ctx, conn, "select avg_msec * 1000000 from v$systime where name=?", "EXECUTE"); err != nil {
+		return err
+	} else {
+		g.Add("sys:execute:time:avg", float64(value), metric.GaugeType(metric.UnitDuration))
+	}
+	if value, err := queryRowInt64(ctx, conn, "select min_msec * 1000000 from v$systime where name=?", "EXECUTE"); err != nil {
+		return err
+	} else {
+		g.Add("sys:execute:time:min", float64(value), metric.GaugeType(metric.UnitDuration))
+	}
+	if value, err := queryRowInt64(ctx, conn, "select max_msec * 1000000 from v$systime where name=?", "EXECUTE"); err != nil {
+		return err
+	} else {
+		g.Add("sys:execute:time:max", float64(value), metric.GaugeType(metric.UnitDuration))
+	}
 	return nil
+}
+
+func queryRowInt64(ctx context.Context, conn api.Conn, sqlText string, params ...any) (int64, error) {
+	var result int64
+	row := conn.QueryRow(ctx, sqlText, params...)
+	if err := row.Err(); err != nil {
+		statzLog.Error("failed to query machbase: %v", err)
+		return 0, err
+	}
+	if err := row.Scan(&result); err != nil {
+		statzLog.Error("failed to scan machbase: %v", err)
+		return 0, err
+	}
+	return result, nil
 }
 
 func collectMachSvrStatz(g *metric.Gather) error {

--- a/mods/server/svrmetric.go
+++ b/mods/server/svrmetric.go
@@ -7,6 +7,7 @@ import (
 	"github.com/machbase/neo-client/api"
 	mach "github.com/machbase/neo-engine/v8"
 	"github.com/machbase/neo-server/v8/mods/logging"
+	"github.com/machbase/neo-server/v8/mods/tql"
 	"github.com/machbase/neo-server/v8/mods/util"
 	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/machbase/neo-server/v8/spi"
@@ -19,6 +20,7 @@ func startServerMetrics(s *Server) {
 	spi.AddMetricsFunc(collectSysStatz)
 	spi.AddMetricsFunc(collectMachSvrStatz)
 	spi.AddMetricsFunc(collectMqttStatz(s))
+	spi.AddMetricsFunc(collectTqlCacheStatz)
 
 	util.AddShutdownHook(func() { stopServerMetrics() })
 
@@ -83,4 +85,14 @@ func collectMqttStatz(s *Server) func(g *metric.Gather) error {
 		g.Add("mqtt:inflight_dropped", float64(nfo.InflightDropped), metric.GaugeType(metric.UnitShort))
 		return nil
 	}
+}
+
+func collectTqlCacheStatz(g *metric.Gather) error {
+	stat := tql.StatCache()
+	g.Add("tql:cache:evictions", float64(stat.Evictions), metric.GaugeType(metric.UnitShort))
+	g.Add("tql:cache:insertions", float64(stat.Insertions), metric.GaugeType(metric.UnitShort))
+	g.Add("tql:cache:hits", float64(stat.Hits), metric.GaugeType(metric.UnitShort))
+	g.Add("tql:cache:misses", float64(stat.Misses), metric.GaugeType(metric.UnitShort))
+	g.Add("tql:cache:items", float64(stat.Items), metric.GaugeType(metric.UnitShort))
+	return nil
 }

--- a/mods/server/svrmgmt.go
+++ b/mods/server/svrmgmt.go
@@ -759,7 +759,6 @@ type SessionsResponse struct {
 	Success  bool       `json:"success"`
 	Reason   string     `json:"reason"`
 	Elapse   string     `json:"elapse"`
-	Statz    *spi.Statz `json:"statz"`
 	Sessions []*Session `json:"sessions"`
 }
 
@@ -781,12 +780,6 @@ func (s *Server) Sessions(ctx context.Context, req *SessionsRequest) (*SessionsR
 		rsp.Elapse = time.Since(tick).String()
 	}()
 
-	if req.ResetStatz {
-		spi.ResetQueryStatz()
-	}
-	if req.Statz {
-		rsp.Statz = spi.StatzSnapshot()
-	}
 	if req.Sessions {
 		sessions := []*Session{}
 		if db, ok := spi.Default().(*machsvr.Database); ok {

--- a/mods/tql/fm_fake.go
+++ b/mods/tql/fm_fake.go
@@ -80,18 +80,11 @@ func genStatz(node *Node, gen *statz) {
 }
 
 func (node *Node) fmStatz(samplingInterval string, keyFilters ...string) *statz {
-	var interval = spi.MetricShortTerm
-	switch strings.ToLower(samplingInterval) {
-	case "short":
-		interval = spi.MetricShortTerm
-	case "mid":
-		interval = spi.MetricMidTerm
-	case "long":
-		interval = spi.MetricLongTerm
-	default:
-		if dur, err := time.ParseDuration(samplingInterval); err == nil {
-			interval = dur
-		}
+	var interval time.Duration
+	if dur, err := time.ParseDuration(samplingInterval); err == nil {
+		interval = dur
+	} else {
+		interval = time.Minute
 	}
 
 	ret := &statz{

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -1563,6 +1563,10 @@ func TestWhen(t *testing.T) {
 		for scan.Scan() {
 			notifiedValues = append(notifiedValues, scan.Text())
 		}
+		if err := scan.Err(); err != nil {
+			t.Error("failed to read request body:", err)
+			t.Fail()
+		}
 		fmt.Println(notifiedValues)
 		return &http.Response{
 			StatusCode: http.StatusOK,

--- a/mods/tql/tqlcache.go
+++ b/mods/tql/tqlcache.go
@@ -2,15 +2,12 @@ package tql
 
 import (
 	"crypto/sha1"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/machbase/neo-server/v8/mods/util/metric"
-	"github.com/machbase/neo-server/v8/spi"
 )
 
 var tqlResultCache atomic.Pointer[Cache]
@@ -29,20 +26,6 @@ func StartCache(cap CacheOption) {
 		defer cache.closeWg.Done()
 		cache.cache.Start()
 	}(cache)
-
-	spi.AddMetricsFunc(func(g *metric.Gather) error {
-		cache := tqlResultCache.Load()
-		if cache == nil || cache.cache == nil {
-			return errors.New("tql cache not started")
-		}
-		stat := cache.cache.Metrics()
-		g.Add("tql:cache:evictions", float64(stat.Evictions), metric.GaugeType(metric.UnitShort))
-		g.Add("tql:cache:insertions", float64(stat.Insertions), metric.GaugeType(metric.UnitShort))
-		g.Add("tql:cache:hits", float64(stat.Hits), metric.GaugeType(metric.UnitShort))
-		g.Add("tql:cache:misses", float64(stat.Misses), metric.GaugeType(metric.UnitShort))
-		g.Add("tql:cache:items", float64(cache.cache.Len()), metric.GaugeType(metric.UnitShort))
-		return nil
-	})
 }
 
 func StopCache() {
@@ -50,6 +33,29 @@ func StopCache() {
 		cache.cache.Stop()
 		close(cache.closeCh)
 		cache.closeWg.Wait()
+	}
+}
+
+type CacheStat struct {
+	Evictions  uint64
+	Insertions uint64
+	Hits       uint64
+	Misses     uint64
+	Items      uint64
+}
+
+func StatCache() CacheStat {
+	cache := tqlResultCache.Load()
+	if cache == nil || cache.cache == nil {
+		return CacheStat{}
+	}
+	stat := cache.cache.Metrics()
+	return CacheStat{
+		Evictions:  stat.Evictions,
+		Insertions: stat.Insertions,
+		Hits:       stat.Hits,
+		Misses:     stat.Misses,
+		Items:      uint64(cache.cache.Len()),
 	}
 }
 

--- a/spi/do_query.go
+++ b/spi/do_query.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/machbase/neo-client/api"
@@ -165,7 +163,6 @@ type QueryMeter struct {
 }
 
 func NewQueryMeter() *QueryMeter {
-	metricQueryCount.Add(1)
 	return &QueryMeter{ts: time.Now()}
 }
 
@@ -173,34 +170,12 @@ func (m *QueryMeter) MarkExecute(sqlText string, args []any) {
 	m.SqlText = sqlText
 	m.SqlArgs = args
 	m.Execute = time.Since(m.ts)
-	QueryExecTime(m.Execute)
 }
 
 func (m *QueryMeter) MarkLimitWait() {
 	m.LimitWait = time.Since(m.ts) - m.Execute
-	QueryWaitTime(m.LimitWait)
 }
 
 func (m *QueryMeter) MarkFetch() {
 	m.Fetch = time.Since(m.ts) - m.Execute - m.LimitWait
-	QueryFetchTime(m.Fetch)
-
-	elapse := int64(m.Execute + m.LimitWait + m.Fetch)
-	// update high water mark of query elapse
-	if queryElapseHwm.Load() < elapse {
-		queryElapseHwm.Store(elapse)
-
-		queryElapseHwmLock.Lock()
-		defer queryElapseHwmLock.Unlock()
-
-		metricQueryHwm.Text = m.SqlText
-		metricQueryHwm.Args = m.SqlArgs
-		metricQueryHwm.Elapse = m.Execute + m.LimitWait + m.Fetch
-		metricQueryHwm.Execute = m.Execute
-		metricQueryHwm.Wait = m.LimitWait
-		metricQueryHwm.Fetch = m.Fetch
-	}
 }
-
-var queryElapseHwmLock sync.Mutex
-var queryElapseHwm atomic.Int64

--- a/spi/do_query.go
+++ b/spi/do_query.go
@@ -193,12 +193,12 @@ func (m *QueryMeter) MarkFetch() {
 		queryElapseHwmLock.Lock()
 		defer queryElapseHwmLock.Unlock()
 
-		metricQueryHwmSqlText.Set(m.SqlText)
-		metricQueryHwmSqlArgs.Set(fmt.Sprintf("%v", m.SqlArgs))
-		metricQueryHwmElapse.Set(int64(m.Execute + m.LimitWait + m.Fetch))
-		metricQueryHwmLimitWait.Set(int64(m.LimitWait))
-		metricQueryHwmFetchElapse.Set(int64(m.Fetch))
-		metricQueryHwmExecuteElapse.Set(int64(m.Execute))
+		metricQueryHwm.Text = m.SqlText
+		metricQueryHwm.Args = m.SqlArgs
+		metricQueryHwm.Elapse = m.Execute + m.LimitWait + m.Fetch
+		metricQueryHwm.Execute = m.Execute
+		metricQueryHwm.Wait = m.LimitWait
+		metricQueryHwm.Fetch = m.Fetch
 	}
 }
 

--- a/spi/machsvr/mach_append.go
+++ b/spi/machsvr/mach_append.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/machbase/neo-client/api"
 	mach "github.com/machbase/neo-engine/v8"
-	"github.com/machbase/neo-server/v8/spi"
 )
 
 // Appender creates a new Appender for the given table.
@@ -123,7 +122,6 @@ func (conn *Conn) Appender(ctx context.Context, tableName string, opts ...api.Ap
 		mach.EngFreeStmt(appender.stmt)
 		return nil, err
 	}
-	spi.AllocAppender()
 
 	colCount, err := mach.EngColumnCount(appender.stmt)
 	if err != nil {
@@ -228,7 +226,6 @@ func (ap *Appender) Close() (int64, int64, error) {
 	}
 	ap.closed = true
 	var err error
-	spi.FreeAppender()
 	ap.successCount, ap.failCount, err = mach.EngAppendClose(ap.stmt)
 	if err != nil {
 		return ap.successCount, ap.failCount, err

--- a/spi/machsvr/mach_rows.go
+++ b/spi/machsvr/mach_rows.go
@@ -172,7 +172,6 @@ func (rows *Rows) QueryLimit(ctx context.Context) bool {
 func (rows *Rows) Close() error {
 	var err error
 	if rows.stmt != nil {
-		spi.FreeStmt()
 		if rows.isPrepared {
 			err = mach.EngExecuteClean(rows.stmt)
 		} else {

--- a/spi/machsvr/machsvr.go
+++ b/spi/machsvr/machsvr.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"encoding/pem"
-	"expvar"
 	"fmt"
 	"net"
 	"runtime"
@@ -1203,16 +1202,4 @@ func bind(stmt unsafe.Pointer, idx int, c any) error {
 		return api.ErrDatabaseBindType(idx, c)
 	}
 	return nil
-}
-
-func init() {
-	expvar.Publish("machbase:session:raw_conns", expvar.Func(func() any { return rawConns() }))
-	spi.RawConns = rawConns
-}
-
-func rawConns() int {
-	if _env.handle != nil {
-		return mach.EngConnectionCount(_env.handle)
-	}
-	return 0
 }

--- a/spi/machsvr/machsvr.go
+++ b/spi/machsvr/machsvr.go
@@ -17,7 +17,6 @@ import (
 	"github.com/machbase/neo-client/api"
 	"github.com/machbase/neo-client/machgo"
 	mach "github.com/machbase/neo-engine/v8"
-	"github.com/machbase/neo-server/v8/spi"
 
 	"github.com/machbase/neo-engine/v8/native"
 	cmap "github.com/orcaman/concurrent-map/v2"
@@ -452,12 +451,10 @@ func (db *Database) ConnectTrust(ctx context.Context, username string) (api.Conn
 		returnChan: nil,
 		username:   username,
 	}
-	waitTime := time.Now()
 	if err := mach.EngConnectTrust(db.handle, username, &ret.handle); err != nil {
 		return nil, err
 	}
 	ret.connectTime = time.Now()
-	spi.AllocConn(time.Since(waitTime))
 	return ret, nil
 }
 
@@ -491,7 +488,6 @@ func (db *Database) Connect(ctx context.Context, opts ...api.ConnectOption) (api
 		}
 	}
 
-	waitTime := time.Now()
 	// control max open connections
 	if ret.returnChan != nil {
 		if connTimeout > 0 {
@@ -557,7 +553,6 @@ func (db *Database) Connect(ctx context.Context, opts ...api.ConnectOption) (api
 	}
 	ret.handle = handle
 	ret.connectTime = time.Now()
-	spi.AllocConn(time.Since(waitTime))
 
 	if id, err := mach.EngSessionID(ret.handle); err == nil {
 		ret.id = fmt.Sprintf("%d", id)
@@ -593,7 +588,6 @@ func (conn *Conn) Close() (err error) {
 			}
 		}()
 		conn.closed = true
-		spi.FreeConn(time.Since(conn.connectTime))
 		err = mach.EngDisconnect(conn.handle)
 		if conn.closeCallback != nil {
 			conn.closeCallback()
@@ -633,10 +627,8 @@ func (conn *Conn) Exec(ctx context.Context, sqlText string, params ...any) api.R
 	if result.err = mach.EngAllocStmt(conn.handle, &stmt); result.err != nil {
 		return result
 	}
-	spi.AllocStmt()
 	defer func() {
 		mach.EngFreeStmt(stmt)
-		spi.FreeStmt()
 	}()
 	if len(params) == 0 {
 		if result.err = mach.EngDirectExecute(stmt, sqlText); result.err != nil {
@@ -674,7 +666,6 @@ func (conn *Conn) Prepare(ctx context.Context, sqlText string) (api.Stmt, error)
 	if err := mach.EngAllocStmt(conn.handle, &stmt); err != nil {
 		return nil, err
 	}
-	spi.AllocStmt()
 	if err := mach.EngPrepare(stmt, sqlText); err != nil {
 		mach.EngFreeStmt(stmt)
 		return nil, err
@@ -695,7 +686,6 @@ func (ps *PreparedStmt) Close() error {
 	if err := mach.EngFreeStmt(ps.stmt); err != nil {
 		return err
 	}
-	spi.FreeStmt()
 	return nil
 }
 
@@ -869,7 +859,6 @@ func (conn *Conn) Query(ctx context.Context, sqlText string, params ...any) (api
 	} else {
 		rows.columns = cols
 	}
-	spi.AllocStmt()
 	return rows, nil
 }
 
@@ -981,9 +970,7 @@ func (conn *Conn) QueryRow(ctx context.Context, sqlText string, params ...any) a
 	if row.err = mach.EngAllocStmt(conn.handle, &stmt); row.err != nil {
 		return row
 	}
-	spi.AllocStmt()
 	defer func() {
-		spi.FreeStmt()
 		err := mach.EngFreeStmt(stmt)
 		if err != nil && row.err == nil {
 			row.err = err

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -2,12 +2,14 @@ package spi
 
 import (
 	"context"
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"net/http"
 	"slices"
 	"strings"
 	"sync/atomic"
+	"text/template"
 	"time"
 
 	"github.com/machbase/neo-client/api"
@@ -15,6 +17,8 @@ import (
 	"github.com/machbase/neo-server/v8/mods/util/glob"
 	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/machbase/neo-server/v8/mods/util/metric/input"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 const (
@@ -47,13 +51,41 @@ var (
 	metricQueryCount atomic.Int64
 
 	// longest query
-	metricQueryHwmSqlText       = expvar.NewString("machbase:session:query:hwm:sql_text")
-	metricQueryHwmSqlArgs       = expvar.NewString("machbase:session:query:hwm:sql_args")
-	metricQueryHwmElapse        = expvar.NewInt("machbase:session:query:hwm:elapse")
-	metricQueryHwmExecuteElapse = expvar.NewInt("machbase:session:query:hwm:exec_time")
-	metricQueryHwmLimitWait     = expvar.NewInt("machbase:session:query:hwm:wait_time")
-	metricQueryHwmFetchElapse   = expvar.NewInt("machbase:session:query:hwm:fetch_time")
+	metricQueryHwm = &SqlLaptime{}
 )
+
+func init() {
+	expvar.Publish("machbase:session:query:hwm", metricQueryHwm)
+}
+
+type SqlLaptime struct {
+	Text    string        `json:"text"`
+	Args    []any         `json:"args"`
+	Elapse  time.Duration `json:"elapse"`
+	Execute time.Duration `json:"execute"`
+	Wait    time.Duration `json:"wait"`
+	Fetch   time.Duration `json:"fetch"`
+}
+
+var _ expvar.Var = (*SqlLaptime)(nil)
+
+func (s *SqlLaptime) Reset() {
+	s.Text = ""
+	s.Args = nil
+	s.Elapse = 0
+	s.Execute = 0
+	s.Wait = 0
+	s.Fetch = 0
+}
+
+func (s *SqlLaptime) String() string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		// keep it simple to avoid potential json marshal error again
+		return fmt.Sprintf("{\"text\":%q}", err.Error())
+	}
+	return string(b)
+}
 
 func AllocConn(connWaitTime time.Duration) {
 	metricConnsInUse.Add(1)
@@ -159,12 +191,13 @@ func StatzSnapshot() *Statz {
 	ret.QueryExecAvg, ret.QueryExecHwm, _ = elapseAvgMax("machbase:session:query:exec_time")
 	ret.QueryWaitAvg, ret.QueryWaitHwm, _ = elapseAvgMax("machbase:session:query:wait_time")
 	ret.QueryFetchAvg, ret.QueryFetchHwm, _ = elapseAvgMax("machbase:session:query:fetch_time")
-	ret.QueryHwmSql = metricQueryHwmSqlText.Value()
-	ret.QueryHwmSqlArg = metricQueryHwmSqlArgs.Value()
-	ret.QueryHwm = uint64(metricQueryHwmElapse.Value())
-	ret.QueryHwmExec = uint64(metricQueryHwmExecuteElapse.Value())
-	ret.QueryHwmWait = uint64(metricQueryHwmLimitWait.Value())
-	ret.QueryHwmFetch = uint64(metricQueryHwmFetchElapse.Value())
+	hwm := *metricQueryHwm
+	ret.QueryHwmSql = hwm.Text
+	ret.QueryHwmSqlArg = fmt.Sprintf("%v", hwm.Args)
+	ret.QueryHwm = uint64(hwm.Elapse)
+	ret.QueryHwmExec = uint64(hwm.Execute)
+	ret.QueryHwmWait = uint64(hwm.Wait)
+	ret.QueryHwmFetch = uint64(hwm.Fetch)
 	return ret
 }
 
@@ -209,25 +242,20 @@ func QueryStatzRows(interval time.Duration, rowsCount int, filter func(key strin
 	metricQueryKeys := []MetricQueryKey{}
 	expvar.Do(func(kv expvar.KeyValue) {
 		key := kv.Key
-		if _, ok := kv.Value.(*expvar.Int); ok {
-			if pass, order := filter(key); pass {
+		if pass, order := filter(key); pass {
+			switch kv.Value.(type) {
+			case *expvar.Int:
 				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnInt64(kv.Key), valueType: "i", order: order})
-			}
-		} else if _, ok := kv.Value.(*expvar.String); ok {
-			if pass, order := filter(key); pass {
+			case *expvar.String:
 				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnString(kv.Key), valueType: "s", order: order})
-			}
-		} else if _, ok := kv.Value.(*expvar.Float); ok {
-			if pass, order := filter(key); pass {
+			case *expvar.Float:
 				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnDouble(kv.Key), valueType: "f", order: order})
-			}
-		} else if _, ok := kv.Value.(expvar.Func); ok {
-			if pass, order := filter(key); pass {
+			case expvar.Func:
 				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnString(kv.Key), valueType: "i", order: order})
-			}
-		} else if _, ok := kv.Value.(metric.MultiTimeSeries); ok {
-			if pass, order := filter(key); pass {
+			case metric.MultiTimeSeries:
 				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnString(kv.Key), valueType: "i", order: order})
+			case *SqlLaptime:
+				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnString(kv.Key), valueType: "s", order: order})
 			}
 		}
 	})
@@ -266,27 +294,28 @@ func QueryStatzRows(interval time.Duration, rowsCount int, filter func(key strin
 	colIdxOffset := 0
 	for _, queryKey := range metricQueryKeys {
 		kv := expvar.Get(queryKey.key)
-		if val, ok := kv.(*expvar.Int); ok {
+		switch val := kv.(type) {
+		case *expvar.Int:
 			for r := 0; r < rowsCount; r++ {
 				ret.Rows[r].Values[colIdxOffset] = val.Value()
 			}
 			colIdxOffset++
-		} else if val, ok := kv.(*expvar.String); ok {
+		case *expvar.String:
 			for r := 0; r < rowsCount; r++ {
 				ret.Rows[r].Values[colIdxOffset] = val.Value()
 			}
 			colIdxOffset++
-		} else if val, ok := kv.(*expvar.Float); ok {
+		case *expvar.Float:
 			for r := 0; r < rowsCount; r++ {
 				ret.Rows[r].Values[colIdxOffset] = val.Value()
 			}
 			colIdxOffset++
-		} else if val, ok := kv.(expvar.Func); ok {
+		case expvar.Func:
 			for r := 0; r < rowsCount; r++ {
 				ret.Rows[r].Values[colIdxOffset] = val()
 			}
 			colIdxOffset++
-		} else if val, ok := kv.(metric.MultiTimeSeries); ok {
+		case metric.MultiTimeSeries:
 			tss, prds := val[0].LastN(rowsCount)
 			for i := range tss {
 				ret.Rows[i].Timestamp = tss[i]
@@ -308,6 +337,13 @@ func QueryStatzRows(interval time.Duration, rowsCount int, filter func(key strin
 				}
 			}
 			colIdxOffset++
+		case *SqlLaptime:
+			for r := 0; r < rowsCount; r++ {
+				ret.Rows[r].Values[colIdxOffset] = val.String()
+			}
+			colIdxOffset++
+		default:
+			fmt.Printf("unknown metric type for key:%s, value:%#v\n", queryKey.key, kv)
 		}
 	}
 	return ret
@@ -543,3 +579,114 @@ func DashboardHandler() http.HandlerFunc {
 	dash.AddChart(metric.Chart{Title: "TQL Cache", MetricNames: []string{"tql:cache:*"}, FieldNames: []string{"avg"}})
 	return dash.HandleFunc
 }
+
+func HandleStatz(w http.ResponseWriter, r *http.Request) {
+	ret := map[string]any{}
+	includes := r.URL.Query()["keys"]
+	format := r.URL.Query().Get("format")
+	interval := r.URL.Query().Get("interval")
+	if interval == "" {
+		interval = "1m"
+	}
+	dur, err := time.ParseDuration(interval)
+	if err != nil {
+		dur = time.Minute
+	}
+
+	stat := QueryStatzRows(dur, 1, func(key string) (bool, int) {
+		return strings.HasPrefix(key, "machbase:") || slices.Contains(includes, key), 0
+	})
+	if stat.Err != nil {
+		http.Error(w, stat.Err.Error(), http.StatusInternalServerError)
+		return
+	}
+	for idx, col := range stat.Cols {
+		value := stat.Rows[0].Values[idx]
+		valueType := stat.ValueTypes[idx]
+		if format == "html" {
+			if value == nil {
+				ret[col.Name] = "null"
+				continue
+			}
+			printer := message.NewPrinter(language.English)
+			switch col.DataType {
+			case api.DataTypeInt64:
+				ret[col.Name] = printer.Sprintf("%d", value)
+			case api.DataTypeFloat64:
+				switch valueType {
+				case "dur":
+					switch val := value.(type) {
+					case float64:
+						ret[col.Name] = printer.Sprintf("%s", time.Duration(val))
+					case int64:
+						ret[col.Name] = printer.Sprintf("%s", time.Duration(val))
+					default:
+						ret[col.Name] = printer.Sprintf("%v", value)
+					}
+				case "i":
+					switch val := value.(type) {
+					case float64:
+						ret[col.Name] = printer.Sprintf("%d", int64(val))
+					case int64:
+						ret[col.Name] = printer.Sprintf("%d", val)
+					default:
+						ret[col.Name] = printer.Sprintf("%v", value)
+					}
+				default:
+					ret[col.Name] = printer.Sprintf("%f", value)
+				}
+			case api.DataTypeString:
+				ret[col.Name] = value
+			default:
+				ret[col.Name] = printer.Sprintf("%v", value)
+			}
+		} else {
+			ret[col.Name] = value
+		}
+	}
+	if format == "html" {
+		tpl := template.New("statz").Funcs(template.FuncMap{
+			"isMap": func(v any) bool {
+				switch v.(type) {
+				case map[string]any, map[string]float64, map[string]string, map[string]int64:
+					return true
+				default:
+					return false
+				}
+			},
+		})
+		tpl = template.Must(tpl.Parse(tmplStatz))
+		if err := tpl.ExecuteTemplate(w, "statz", ret); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ret); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+var tmplStatz = `
+{{- define "statz" }}
+<style>
+  table {
+    border-collapse: collapse;
+  }
+  tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+  td {
+    border: 1px solid #ddd;
+    padding: 8px;
+  }
+</style>
+<table>
+{{- range $key, $value := . }}
+<tr>
+  <td>{{ $key }}</td>
+  <td>{{ $value }}</td>
+</tr>
+{{- end }}
+</table>
+{{ end }}`

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -95,8 +95,6 @@ func QueryFetchTime(d time.Duration) {
 	AddMetrics(metric.Measure{Name: "session:query:fetch_time", Value: float64(d), Type: metric.HistogramType(metric.UnitDuration)})
 }
 
-var RawConns func() int
-
 func ResetQueryStatz() {
 	queryElapseHwm.Store(0)
 }
@@ -133,7 +131,6 @@ type Statz struct {
 	ConnsInUse     int32  `json:"connsInUse"`
 	StmtsInUse     int32  `json:"stmtsInUse"`
 	AppendersInUse int32  `json:"appendersInUse"`
-	RawConns       int32  `json:"rawConns"`
 	ConnWaitTime   uint64 `json:"connWaitTime"`
 	ConnUseTime    uint64 `json:"connUseTime"`
 	QueryHwm       uint64 `json:"queryHwm"`
@@ -159,9 +156,6 @@ func StatzSnapshot() *Statz {
 	ret.StmtsInUse = int32(metricStmtsInUse.Load())
 	ret.Appenders = metricAppenders.Load()
 	ret.AppendersInUse = int32(metricAppendersInUse.Load())
-	if RawConns != nil {
-		ret.RawConns = int32(RawConns())
-	}
 	ret.QueryExecAvg, ret.QueryExecHwm, _ = elapseAvgMax("machbase:session:query:exec_time")
 	ret.QueryWaitAvg, ret.QueryWaitHwm, _ = elapseAvgMax("machbase:session:query:wait_time")
 	ret.QueryFetchAvg, ret.QueryFetchHwm, _ = elapseAvgMax("machbase:session:query:fetch_time")

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync/atomic"
 	"text/template"
 	"time"
 
@@ -16,114 +15,13 @@ import (
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/util/glob"
 	"github.com/machbase/neo-server/v8/mods/util/metric"
-	"github.com/machbase/neo-server/v8/mods/util/metric/input"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )
 
-const MetricMeasurePeriod = 500 * time.Millisecond
-
-var MetricTimeFrames = []string{"2h1m", "10h5m", "30h15m"}
-
 const MetricQueryRowsMax = 120
 
 var metricLog = logging.GetLog("statz")
-
-var (
-	// session:conn
-	metricConnsInUse atomic.Int64
-
-	// session:stmt
-	metricStmts      atomic.Int64
-	metricStmtsInUse atomic.Int64
-
-	// session:appender
-	metricAppenders      atomic.Int64
-	metricAppendersInUse atomic.Int64
-
-	// session:query
-	metricQueryCount atomic.Int64
-
-	// longest query
-	metricQueryHwm = &SqlLaptime{}
-)
-
-func init() {
-	expvar.Publish("machbase:session:query:hwm", metricQueryHwm)
-}
-
-type SqlLaptime struct {
-	Text    string        `json:"text"`
-	Args    []any         `json:"args"`
-	Elapse  time.Duration `json:"elapse"`
-	Execute time.Duration `json:"execute"`
-	Wait    time.Duration `json:"wait"`
-	Fetch   time.Duration `json:"fetch"`
-}
-
-var _ expvar.Var = (*SqlLaptime)(nil)
-
-func (s *SqlLaptime) Reset() {
-	s.Text = ""
-	s.Args = nil
-	s.Elapse = 0
-	s.Execute = 0
-	s.Wait = 0
-	s.Fetch = 0
-}
-
-func (s *SqlLaptime) String() string {
-	b, err := json.Marshal(s)
-	if err != nil {
-		// keep it simple to avoid potential json marshal error again
-		return fmt.Sprintf("{\"text\":%q}", err.Error())
-	}
-	return string(b)
-}
-
-func AllocConn(connWaitTime time.Duration) {
-	metricConnsInUse.Add(1)
-	AddMetrics(metric.Measure{Name: "session:conn:wait_time", Value: float64(connWaitTime), Type: metric.HistogramType(metric.UnitDuration)})
-}
-
-func FreeConn(connUseTime time.Duration) {
-	metricConnsInUse.Add(-1)
-	AddMetrics(metric.Measure{Name: "session:conn:use_time", Value: float64(connUseTime), Type: metric.HistogramType(metric.UnitDuration)})
-}
-
-func AllocStmt() {
-	metricStmts.Add(1)
-	metricStmtsInUse.Add(1)
-}
-
-func FreeStmt() {
-	metricStmtsInUse.Add(-1)
-}
-
-func AllocAppender() {
-	metricAppenders.Add(1)
-	metricAppendersInUse.Add(1)
-}
-
-func FreeAppender() {
-	metricAppendersInUse.Add(-1)
-}
-
-func QueryExecTime(d time.Duration) {
-	AddMetrics(metric.Measure{Name: "session:query:exec_time", Value: float64(d), Type: metric.HistogramType(metric.UnitDuration)})
-}
-
-func QueryWaitTime(d time.Duration) {
-	AddMetrics(metric.Measure{Name: "session:query:wait_time", Value: float64(d), Type: metric.HistogramType(metric.UnitDuration)})
-}
-
-func QueryFetchTime(d time.Duration) {
-	AddMetrics(metric.Measure{Name: "session:query:fetch_time", Value: float64(d), Type: metric.HistogramType(metric.UnitDuration)})
-}
-
-func ResetQueryStatz() {
-	queryElapseHwm.Store(0)
-}
 
 type QueryStatzResult struct {
 	Err        error
@@ -137,62 +35,13 @@ type QueryStatzRow struct {
 	Values    []any
 }
 
-func elapseAvgMax(key string) (uint64, uint64, int64) {
-	if value, ok := expvar.Get(key).(metric.MultiTimeSeries); ok && len(value) > 0 {
-		_, val := value[0].Last()
-		prd, ok := val.(*metric.HistogramValue)
-		if !ok {
-			return 0, 0, 0
-		}
-		values := prd.Values
-		return uint64(values[0]), uint64(values[len(values)-1]), int64(prd.Samples)
-	}
-	return 0, 0, 0
-}
-
 type Statz struct {
-	Conns          int64  `json:"conns"`
-	Stmts          int64  `json:"stmts"`
-	Appenders      int64  `json:"appenders"`
-	ConnsInUse     int32  `json:"connsInUse"`
-	StmtsInUse     int32  `json:"stmtsInUse"`
-	AppendersInUse int32  `json:"appendersInUse"`
-	ConnWaitTime   uint64 `json:"connWaitTime"`
-	ConnUseTime    uint64 `json:"connUseTime"`
-	QueryHwm       uint64 `json:"queryHwm"`
-	QueryHwmSql    string `json:"queryHwmSql"`
-	QueryHwmExec   uint64 `json:"queryHwmExec"`
-	QueryHwmWait   uint64 `json:"queryHwmWait"`
-	QueryHwmFetch  uint64 `json:"queryHwmFetch"`
-	QueryHwmSqlArg string `json:"queryHwmSqlArg"`
-	QueryExecHwm   uint64 `json:"queryExecHwm"`
-	QueryExecAvg   uint64 `json:"queryExecAvg"`
-	QueryWaitHwm   uint64 `json:"queryWaitHwm"`
-	QueryWaitAvg   uint64 `json:"queryWaitAvg"`
-	QueryFetchHwm  uint64 `json:"queryFetchHwm"`
-	QueryFetchAvg  uint64 `json:"queryFetchAvg"`
-}
-
-func StatzSnapshot() *Statz {
-	ret := &Statz{}
-	ret.ConnWaitTime, _, _ = elapseAvgMax("machbase:session:conn:wait_time")
-	ret.ConnUseTime, _, ret.Conns = elapseAvgMax("machbase:session:conn:use_time")
-	ret.ConnsInUse = int32(metricConnsInUse.Load())
-	ret.Stmts = metricStmts.Load()
-	ret.StmtsInUse = int32(metricStmtsInUse.Load())
-	ret.Appenders = metricAppenders.Load()
-	ret.AppendersInUse = int32(metricAppendersInUse.Load())
-	ret.QueryExecAvg, ret.QueryExecHwm, _ = elapseAvgMax("machbase:session:query:exec_time")
-	ret.QueryWaitAvg, ret.QueryWaitHwm, _ = elapseAvgMax("machbase:session:query:wait_time")
-	ret.QueryFetchAvg, ret.QueryFetchHwm, _ = elapseAvgMax("machbase:session:query:fetch_time")
-	hwm := *metricQueryHwm
-	ret.QueryHwmSql = hwm.Text
-	ret.QueryHwmSqlArg = fmt.Sprintf("%v", hwm.Args)
-	ret.QueryHwm = uint64(hwm.Elapse)
-	ret.QueryHwmExec = uint64(hwm.Execute)
-	ret.QueryHwmWait = uint64(hwm.Wait)
-	ret.QueryHwmFetch = uint64(hwm.Fetch)
-	return ret
+	QueryExecHwm  uint64 `json:"queryExecHwm"`
+	QueryExecAvg  uint64 `json:"queryExecAvg"`
+	QueryWaitHwm  uint64 `json:"queryWaitHwm"`
+	QueryWaitAvg  uint64 `json:"queryWaitAvg"`
+	QueryFetchHwm uint64 `json:"queryFetchHwm"`
+	QueryFetchAvg uint64 `json:"queryFetchAvg"`
 }
 
 func QueryStatzFilter(filters []string) func(key string) (bool, int) {
@@ -248,8 +97,6 @@ func QueryStatzRows(interval time.Duration, rowsCount int, filter func(key strin
 				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnString(kv.Key), valueType: "i", order: order})
 			case metric.MultiTimeSeries:
 				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnString(kv.Key), valueType: "i", order: order})
-			case *SqlLaptime:
-				metricQueryKeys = append(metricQueryKeys, MetricQueryKey{key: kv.Key, column: api.MakeColumnString(kv.Key), valueType: "s", order: order})
 			}
 		}
 	})
@@ -331,11 +178,6 @@ func QueryStatzRows(interval time.Duration, rowsCount int, filter func(key strin
 				}
 			}
 			colIdxOffset++
-		case *SqlLaptime:
-			for r := 0; r < rowsCount; r++ {
-				ret.Rows[r].Values[colIdxOffset] = val.String()
-			}
-			colIdxOffset++
 		default:
 			fmt.Printf("unknown metric type for key:%s, value:%#v\n", queryKey.key, kv)
 		}
@@ -360,9 +202,6 @@ func StartMetrics() {
 		metric.WithPrefix(prefix),
 		metric.WithInputBuffer(50),
 	)
-	collector.AddInput(&SessionInput{})
-	collector.AddInput(&input.Runtime{})
-	collector.AddInput(&input.Netstat{})
 	collector.AddOutputFunc(onProduct)
 	collector.Start()
 }
@@ -404,7 +243,14 @@ func SetMetricsDestTable(destTable string) error {
 	return nil
 }
 
-func AddMetricsFunc(f func(*metric.Gather) error) {
+func AddInput(mi metric.Input) {
+	if collector == nil {
+		return
+	}
+	collector.AddInput(mi)
+}
+
+func AddInputFunc(f func(*metric.Gather) error) {
 	if collector == nil {
 		return
 	}
@@ -416,24 +262,6 @@ func AddMetrics(m ...metric.Measure) {
 		return
 	}
 	collector.Send(m...)
-}
-
-type SessionInput struct{}
-
-var _ metric.Input = (*SessionInput)(nil)
-
-func (si *SessionInput) Init() error {
-	return nil
-}
-
-func (si *SessionInput) Gather(g *metric.Gather) error {
-	g.Add("session:conn:in_use", float64(metricConnsInUse.Load()), metric.GaugeType(metric.UnitShort))
-	g.Add("session:stmt:in_use", float64(metricStmtsInUse.Load()), metric.GaugeType(metric.UnitShort))
-	g.Add("session:append:in_use", float64(metricAppendersInUse.Load()), metric.GaugeType(metric.UnitShort))
-	g.Add("session:stmt:count", float64(metricStmts.Load()), metric.OdometerType(metric.UnitShort))
-	g.Add("session:query:count", float64(metricQueryCount.Load()), metric.OdometerType(metric.UnitShort))
-	g.Add("session:append:count", float64(metricAppenders.Load()), metric.OdometerType(metric.UnitShort))
-	return nil
 }
 
 type MetricRec struct {
@@ -566,11 +394,11 @@ func DashboardHandler() http.HandlerFunc {
 	dash.AddChart(metric.Chart{Title: "HTTP Payload", MetricNames: []string{"http:recv_bytes", "http:send_bytes"}, Type: metric.ChartTypeLine})
 	dash.AddChart(metric.Chart{Title: "HTTP Status", MetricNames: []string{"http:status_[1-5]xx"}, Type: metric.ChartTypeBarStack})
 	dash.AddChart(metric.Chart{Title: "HTTP Latency", MetricNames: []string{"http:latency"}})
-	dash.AddChart(metric.Chart{Title: "DB Use Count", MetricNames: []string{"session:*:count"}, FieldNames: []string{"non_negative_diff"}, Type: metric.ChartTypeLine})
-	dash.AddChart(metric.Chart{Title: "DB Inuse", MetricNames: []string{"session:*:in_use"}, FieldNames: []string{"avg"}})
-	dash.AddChart(metric.Chart{Title: "DB Native Inuse", MetricNames: []string{"machsvr:*"}, FieldNames: []string{"avg"}})
-	dash.AddChart(metric.Chart{Title: "DB Wait Time", MetricNames: []string{"session:conn:wait_time"}})
-	dash.AddChart(metric.Chart{Title: "DB Use Time", MetricNames: []string{"session:conn:use_time"}})
+	dash.AddChart(metric.Chart{Title: "DB Sessions", MetricNames: []string{"sys:session:count"}, FieldNames: []string{"avg"}, Type: metric.ChartTypeLine})
+	dash.AddChart(metric.Chart{Title: "DB Execute", MetricNames: []string{"sys:execute:count"}, FieldNames: []string{"non_negative_diff"}})
+	dash.AddChart(metric.Chart{Title: "DB Execute Time", MetricNames: []string{"sys:execute:time:*"}, FieldNames: []string{"last"}})
+	dash.AddChart(metric.Chart{Title: "DB Appender", MetricNames: []string{"sys:append:data:*"}, FieldNames: []string{"non_negative_diff"}})
+	dash.AddChart(metric.Chart{Title: "DB Sys Mem", MetricNames: []string{"sys:sysmem"}, FieldNames: []string{"last"}})
 	dash.AddChart(metric.Chart{Title: "TQL Cache", MetricNames: []string{"tql:cache:*"}, FieldNames: []string{"avg"}})
 	return dash.HandleFunc
 }

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -308,7 +308,9 @@ func QueryStatzRows(interval time.Duration, rowsCount int, filter func(key strin
 				case *metric.OdometerValue:
 					ret.Rows[i].Values[colIdxOffset] = prd.Diff()
 				default:
-					fmt.Printf("unknown metric type:%#v\n", prd)
+					if prd != nil {
+						fmt.Printf("unknown metric type:%#v\n", prd)
+					}
 				}
 			}
 			colIdxOffset++
@@ -356,7 +358,7 @@ func SetMetricsDestTable(destTable string) error {
 	destTable = strings.ToUpper(strings.TrimSpace(destTable))
 	if destTable != "" {
 		ctx := context.Background()
-		conn, err := Default().Connect(ctx, api.WithPassword("sys", "manager"))
+		conn, err := Default().Connect(ctx, api.WithAuthKey("sys", DefaultKey()))
 		if err != nil {
 			metricLog.Errorf("metrics connect: %v", err)
 			return nil

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -21,12 +21,6 @@ import (
 	"golang.org/x/text/message"
 )
 
-const (
-	MetricShortTerm = 1 * time.Minute
-	MetricMidTerm   = 5 * time.Minute
-	MetricLongTerm  = 15 * time.Minute
-)
-
 const MetricMeasurePeriod = 500 * time.Millisecond
 
 var MetricTimeFrames = []string{"2h1m", "10h5m", "30h15m"}
@@ -354,10 +348,11 @@ var prefix string = "machbase"
 var metricsDest string
 
 const SERIES_ID_FINEST = "METRIC_2H"
+const SERIES_ID_FINE = "METRIC_2D12H"
 
 func StartMetrics() {
 	m2h, _ := metric.NewSeriesID(SERIES_ID_FINEST, "2h | 1m", 60*time.Second, 120)
-	m2d12h, _ := metric.NewSeriesID("METRIC_2D12H", "2d12h | 30m", 30*time.Minute, 120)
+	m2d12h, _ := metric.NewSeriesID(SERIES_ID_FINE, "2d12h | 30m", 30*time.Minute, 120)
 	collector = metric.NewCollector(
 		metric.WithSamplingInterval(10*time.Second),
 		metric.WithSeries(m2h),

--- a/spi/metrics_test.go
+++ b/spi/metrics_test.go
@@ -1,0 +1,43 @@
+package spi
+
+import (
+	"encoding/json"
+	"expvar"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleStatz(t *testing.T) {
+	metricKey := "custom:" + uuid.Must(uuid.NewV4()).String()
+	metricValue := expvar.NewInt(metricKey)
+	metricValue.Set(42)
+
+	t.Run("json with invalid interval fallback", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/debug/statz?interval=not-a-duration&keys="+url.QueryEscape(metricKey), nil)
+		writer := httptest.NewRecorder()
+
+		HandleStatz(writer, req)
+
+		require.Equal(t, http.StatusOK, writer.Code)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &payload))
+		require.EqualValues(t, 42, payload[metricKey])
+	})
+
+	t.Run("html renders included metric", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/debug/statz?format=html&keys="+url.QueryEscape(metricKey), nil)
+		writer := httptest.NewRecorder()
+
+		HandleStatz(writer, req)
+
+		require.Equal(t, http.StatusOK, writer.Code)
+		require.Contains(t, writer.Body.String(), "<table>")
+		require.Contains(t, writer.Body.String(), metricKey)
+		require.Contains(t, writer.Body.String(), "42")
+	})
+}

--- a/spi/unit_test.go
+++ b/spi/unit_test.go
@@ -293,11 +293,9 @@ func TestInfoValueObjects(t *testing.T) {
 
 func TestMetricsAndWatcherHelpers(t *testing.T) {
 	t.Run("metrics snapshot and filter helpers", func(t *testing.T) {
-		oldRawConns := RawConns
 		oldMetricsDest := metricsDest
 		oldCollector := collector
 		defer func() {
-			RawConns = oldRawConns
 			metricsDest = oldMetricsDest
 			collector = oldCollector
 			metricConnsInUse.Store(0)
@@ -326,7 +324,6 @@ func TestMetricsAndWatcherHelpers(t *testing.T) {
 		metricQueryHwmLimitWait.Set(33)
 		metricQueryHwmFetchElapse.Set(44)
 		queryElapseHwm.Store(999)
-		RawConns = func() int { return 7 }
 
 		ResetQueryStatz()
 		require.Zero(t, queryElapseHwm.Load())
@@ -336,7 +333,6 @@ func TestMetricsAndWatcherHelpers(t *testing.T) {
 		require.Equal(t, int32(2), snapshot.ConnsInUse)
 		require.Equal(t, int32(1), snapshot.StmtsInUse)
 		require.Equal(t, int32(2), snapshot.AppendersInUse)
-		require.Equal(t, int32(7), snapshot.RawConns)
 		require.Equal(t, "select 1", snapshot.QueryHwmSql)
 		require.Equal(t, "[1]", snapshot.QueryHwmSqlArg)
 		require.Equal(t, uint64(111), snapshot.QueryHwm)

--- a/spi/unit_test.go
+++ b/spi/unit_test.go
@@ -298,42 +298,7 @@ func TestMetricsAndWatcherHelpers(t *testing.T) {
 		defer func() {
 			metricsDest = oldMetricsDest
 			collector = oldCollector
-			metricConnsInUse.Store(0)
-			metricStmts.Store(0)
-			metricStmtsInUse.Store(0)
-			metricAppenders.Store(0)
-			metricAppendersInUse.Store(0)
-			metricQueryHwm.Reset()
-			queryElapseHwm.Store(0)
 		}()
-
-		metricConnsInUse.Store(2)
-		metricStmts.Store(3)
-		metricStmtsInUse.Store(1)
-		metricAppenders.Store(4)
-		metricAppendersInUse.Store(2)
-		metricQueryHwm.Text = "select 1"
-		metricQueryHwm.Args = []any{1}
-		metricQueryHwm.Elapse = 111
-		metricQueryHwm.Execute = 22
-		metricQueryHwm.Wait = 33
-		metricQueryHwm.Fetch = 44
-		queryElapseHwm.Store(999)
-
-		ResetQueryStatz()
-		require.Zero(t, queryElapseHwm.Load())
-
-		snapshot := StatzSnapshot()
-		require.Equal(t, int64(3), snapshot.Stmts)
-		require.Equal(t, int32(2), snapshot.ConnsInUse)
-		require.Equal(t, int32(1), snapshot.StmtsInUse)
-		require.Equal(t, int32(2), snapshot.AppendersInUse)
-		require.Equal(t, "select 1", snapshot.QueryHwmSql)
-		require.Equal(t, "[1]", snapshot.QueryHwmSqlArg)
-		require.Equal(t, uint64(111), snapshot.QueryHwm)
-		require.Equal(t, uint64(22), snapshot.QueryHwmExec)
-		require.Equal(t, uint64(33), snapshot.QueryHwmWait)
-		require.Equal(t, uint64(44), snapshot.QueryHwmFetch)
 
 		all := QueryStatzFilter(nil)
 		pass, order := all("any")
@@ -351,13 +316,12 @@ func TestMetricsAndWatcherHelpers(t *testing.T) {
 		require.False(t, pass)
 
 		collector = nil
-		AddMetricsFunc(func(*metricpkg.Gather) error { return nil })
+		AddInputFunc(func(*metricpkg.Gather) error { return nil })
 		AddMetrics(metricpkg.Measure{Name: "noop", Value: 1, Type: metricpkg.GaugeType(metricpkg.UnitShort)})
 		StopMetrics()
 
 		require.NoError(t, SetMetricsDestTable(""))
 		require.Equal(t, "", MetricsDestTable())
-		require.NoError(t, (&SessionInput{}).Init())
 		require.NoError(t, onProduct(metricpkg.Product{Name: "noop", SeriesID: SERIES_ID_FINEST, Value: badMetricValue{}}))
 	})
 

--- a/spi/unit_test.go
+++ b/spi/unit_test.go
@@ -303,12 +303,7 @@ func TestMetricsAndWatcherHelpers(t *testing.T) {
 			metricStmtsInUse.Store(0)
 			metricAppenders.Store(0)
 			metricAppendersInUse.Store(0)
-			metricQueryHwmSqlText.Set("")
-			metricQueryHwmSqlArgs.Set("")
-			metricQueryHwmElapse.Set(0)
-			metricQueryHwmExecuteElapse.Set(0)
-			metricQueryHwmLimitWait.Set(0)
-			metricQueryHwmFetchElapse.Set(0)
+			metricQueryHwm.Reset()
 			queryElapseHwm.Store(0)
 		}()
 
@@ -317,12 +312,12 @@ func TestMetricsAndWatcherHelpers(t *testing.T) {
 		metricStmtsInUse.Store(1)
 		metricAppenders.Store(4)
 		metricAppendersInUse.Store(2)
-		metricQueryHwmSqlText.Set("select 1")
-		metricQueryHwmSqlArgs.Set("[1]")
-		metricQueryHwmElapse.Set(111)
-		metricQueryHwmExecuteElapse.Set(22)
-		metricQueryHwmLimitWait.Set(33)
-		metricQueryHwmFetchElapse.Set(44)
+		metricQueryHwm.Text = "select 1"
+		metricQueryHwm.Args = []any{1}
+		metricQueryHwm.Elapse = 111
+		metricQueryHwm.Execute = 22
+		metricQueryHwm.Wait = 33
+		metricQueryHwm.Fetch = 44
 		queryElapseHwm.Store(999)
 
 		ResetQueryStatz()


### PR DESCRIPTION
This pull request introduces significant improvements and refactoring to the server's metrics collection and statz (statistics) endpoint handling. The changes modernize the metrics system by adopting a new input-based approach, simplify and centralize the statz HTTP handler, and remove legacy or redundant code and dependencies. Additionally, new tests are added for backup functionality, and several code cleanups are performed.

**Metrics system modernization and statz refactor:**

* Migrated the server metrics system to use the new `spi.AddInput` and `spi.AddInputFunc` interfaces, replacing the older `spi.AddMetricsFunc` pattern. This change enables more modular and extensible metric sources, including runtime, network, and TQL cache statistics. (`mods/server/svrmetric.go`) [[1]](diffhunk://#diff-d525fde897d7e0cab825fd599cb4533404f3410097040abb6b120f6450cfdafbR10-R26) [[2]](diffhunk://#diff-d525fde897d7e0cab825fd599cb4533404f3410097040abb6b120f6450cfdafbR144-R153)
* Enhanced the `collectSysStatz` function to gather more detailed system statistics (such as append operations, session counts, and execution times), using a new helper function `queryRowInt64` for concise database queries. (`mods/server/svrmetric.go`)
* Added a new function to collect TQL cache statistics and expose them as metrics. (`mods/server/svrmetric.go`)

**Statz endpoint and HTTP handler simplification:**

* Replaced the custom `handleStatz` HTTP handler with the centralized `spi.HandleStatz` handler, removing the old handler and its associated HTML formatting/template logic. This change also removes related dependencies and tests. (`mods/server/http.go`, `mods/server/http_test.go`) [[1]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL372-R368) [[2]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL1004-L1112) [[3]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL21-L24) [[4]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eL48-L49) [[5]](diffhunk://#diff-b19e214509fd4578d9238c3d67e3007e1ab38a34faf8032652c23887f06f54cbL15) [[6]](diffhunk://#diff-b19e214509fd4578d9238c3d67e3007e1ab38a34faf8032652c23887f06f54cbL31) [[7]](diffhunk://#diff-b19e214509fd4578d9238c3d67e3007e1ab38a34faf8032652c23887f06f54cbL132-L160)
* Updated the statz interval parsing logic to default to a 1-minute duration if the input is invalid, and removed legacy interval keywords ("short", "mid", "long") from both the system and TQL fake statz functions. (`jsh/lib/system/system.go`, `mods/tql/fm_fake.go`) [[1]](diffhunk://#diff-d9e9047a6cffbc16609f12d3564415a43654d002c842b1e7fd8ca5211a31e785L71-R75) [[2]](diffhunk://#diff-362dbdbf801c3111ba4c738362dabbbd22997e9460a5d23b819e16f62029f1c0L83-R87)

**Testing and code quality improvements:**

* Added comprehensive tests for backup-related endpoints, including validation and error scenarios. (`mods/server/svrbackup_test.go`)
* Improved error handling in TQL task tests by checking for scan errors after reading request bodies. (`mods/tql/task_test.go`)

**Code cleanup and dependency removal:**

* Removed unused imports and legacy code, including the statz snapshot from session responses and related code in management and server files. (`mods/server/svrmgmt.go`, `mods/server/server.go`, `mods/tql/tqlcache.go`) [[1]](diffhunk://#diff-7ed17c3c1d52885fcb5de8e5f9b9bf95ea819b1ad5c54a09fd6570a0ee5cabf1L762) [[2]](diffhunk://#diff-7ed17c3c1d52885fcb5de8e5f9b9bf95ea819b1ad5c54a09fd6570a0ee5cabf1L784-L789) [[3]](diffhunk://#diff-bbd5dc679782832979f461e4ced2b2404e3d6ffb81d2acfce65f00123d8bae1dL5-L13) [[4]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL1749-R1749)

These changes collectively modernize the server's metrics infrastructure, simplify the codebase, and improve maintainability and test coverage.