### PR TITLE
feat: implement server statistics retrieval and visualization

### DIFF
--- a/docs/jsonrpc.gen.md
+++ b/docs/jsonrpc.gen.md
@@ -204,6 +204,53 @@ Implicit runtime parameters such as `context.Context`, `*gin.Context`, and `*Web
 
 </details>
 
+#### server.info.statz
+
+`server.info.statz(names)`
+
+*Params*
+- `names` *array<string>*
+
+*Return*
+
+- `object<ServerStatzResponse>|error`
+
+<details>
+<summary>Request/Response JSON</summary>
+
+*Request*
+
+```json
+{
+    "type": "rpc_req",
+    "session": "client-session-#1",
+    "rpc": {
+        "jsonrpc": "2.0",
+        "id": 20,
+        "method": "server.info.statz",
+        "params": [
+            []
+        ]
+    }
+}
+```
+
+*Response*
+
+```json
+{
+    "type": "rpc_rsp",
+    "session": "client-session-#1",
+    "rpc": {
+        "jsonrpc": "2.0",
+        "id": 20,
+        "result": {}
+    }
+}
+```
+
+</details>
+
 #### server.certificate.get
 
 `server.certificate.get()`
@@ -1215,10 +1262,10 @@ mgmt server implements
 
 #### sshkey.add
 
-`sshkey.add(keyType, key, comment)`
+`sshkey.add(typ, key, comment)`
 
 *Params*
-- `keyType` *string*
+- `typ` *string*
 - `key` *string*
 - `comment` *string*
 
@@ -1266,10 +1313,10 @@ mgmt server implements
 
 #### sshkey.delete
 
-`sshkey.delete(key)`
+`sshkey.delete(fingerprint)`
 
 *Params*
-- `key` *string*
+- `fingerprint` *string*
 
 *Return*
 

--- a/jsh/lib/system/system.go
+++ b/jsh/lib/system/system.go
@@ -3,14 +3,12 @@ package system
 import (
 	"context"
 	_ "embed"
-	"fmt"
 	"runtime"
 	"runtime/debug"
 	"strings"
 	"time"
 
 	"github.com/dop251/goja"
-	"github.com/machbase/neo-server/v8/spi"
 )
 
 //go:embed system.js
@@ -34,8 +32,6 @@ func Module(_ context.Context, rt *goja.Runtime, module *goja.Object) {
 	// m.location("Asia/Shanghai")
 	// m.location("UTC")
 	o.Set("timeLocation", timeLocation)
-	// m.statz("1m", ...keys)
-	o.Set("statz", statz)
 }
 
 func free_os_memory() goja.Value {
@@ -65,35 +61,4 @@ func timeLocation(name string) (*time.Location, error) {
 
 func now() time.Time {
 	return time.Now()
-}
-
-func statz(samplingInterval string, keyFilters ...string) ([]map[string]any, error) {
-	var interval time.Duration
-	if dur, err := time.ParseDuration(samplingInterval); err == nil {
-		interval = dur
-	} else {
-		interval = time.Minute
-	}
-	stat := spi.QueryStatz(interval, spi.QueryStatzFilter(keyFilters))
-	if stat.Err != nil {
-		return nil, stat.Err
-	}
-	ret := []map[string]any{}
-	for _, row := range stat.Rows {
-		m := map[string]any{
-			"time":   row.Timestamp,
-			"values": row.Values,
-			"toString": func() string {
-				return fmt.Sprintf("%s %s", row.Timestamp, row.Values)
-			},
-		}
-		for i, v := range row.Values {
-			if i >= len(keyFilters) {
-				break
-			}
-			m[strings.ReplaceAll(keyFilters[i], ":", "_")] = v
-		}
-		ret = append(ret, m)
-	}
-	return ret, nil
 }

--- a/jsh/lib/system/system.js
+++ b/jsh/lib/system/system.js
@@ -2,10 +2,6 @@
 
 const _system = require('@jsh/system');
 
-function statz(series, ...name) {
-    return _system.statz(series, ...name);
-}
-
 function now() {
     return _system.now();
 }
@@ -28,7 +24,6 @@ function gc() {
 module.exports = {
     free_os_memory,
     gc,
-    statz,
     now,
     timeLocation,
 };

--- a/jsh/lib/system/system_test.go
+++ b/jsh/lib/system/system_test.go
@@ -1,13 +1,11 @@
 package system_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/machbase/neo-server/v8/jsh/test_engine"
-	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,66 +61,6 @@ func TestTimeLocation(t *testing.T) {
 				lines := strings.Split(strings.TrimSpace(result), "\n")
 				require.Equal(t, "UTC", lines[0])
 				require.Equal(t, "Asia/Shanghai", lines[1])
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		test_engine.RunTest(t, tc)
-	}
-}
-
-func TestStatz(t *testing.T) {
-	var out string
-	var cnt int
-	var now time.Time
-
-	seriesID, err := metric.NewSeriesID("METRIC_1M", "1m/1s", time.Second, 60)
-	require.NoError(t, err)
-	c := metric.NewCollector(
-		metric.WithSamplingInterval(time.Second),
-		metric.WithSeries(seriesID),
-	)
-
-	c.AddOutputFunc(func(pd metric.Product) error {
-		out = fmt.Sprintf("%s %s %v %s %s",
-			pd.Name, pd.SeriesTitle, pd.Time.Format(time.TimeOnly), pd.Value.String(), pd.Type)
-		if cnt == 0 {
-			now = pd.Time
-		} else {
-			now = now.Add(time.Second)
-		}
-		cnt++
-		expect := fmt.Sprintf(`m1:f1 1m/1s %s {"samples":1,"value":1} counter`, now.Format(time.TimeOnly))
-		require.Equal(t, expect, out)
-		return nil
-	})
-	c.AddInputFunc(func(g *metric.Gather) error {
-		g.Add("m1:f1", 1.0, metric.CounterType(metric.UnitShort))
-		return nil
-	})
-	c.Start()
-	defer c.Stop()
-
-	time.Sleep(3 * time.Second)
-
-	tests := []test_engine.TestCase{
-		{
-			Name: "statz",
-			Script: `
-				const statz = require("system").statz;
-				const lst = statz('1s', 'm1:f1');
-				for (const item of lst) {
-					if (item.values && item.values.length > 0 && item.values[0] !== null) {
-						console.println(JSON.stringify(item));
-					}
-				}
-			`,
-			ExpectFunc: func(t *testing.T, result string) {
-				lines := strings.Split(result, "\n")
-				require.Contains(t, lines[0], `"time":"`)
-				require.Contains(t, lines[0], `"m1_f1":1`)
-				require.Contains(t, lines[0], `"values":[1]`)
 			},
 		},
 	}

--- a/jsh/usr/bin/statz.js
+++ b/jsh/usr/bin/statz.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const process = require('process');
+const pretty = require('pretty');
+const parseArgs = require('util/parseArgs');
+const neoapi = require('/usr/lib/neoapi');
+const viz = require('vizspec');
+
+const options = {
+    help: { type: 'boolean', short: 'h', description: 'Show this help message', default: false },
+}
+
+const positionals = [
+    { name: 'names', type: 'string', variadic: true, description: 'metric names to show' }
+];
+
+let showHelp = true;
+let config = {};
+let args = {};
+try {
+    const parsed = parseArgs(process.argv.slice(2), {
+        options,
+        allowPositionals: true,
+        allowNegative: true,
+        positionals: positionals
+    });
+    config = parsed.values;
+    args = parsed.namedPositionals;
+    showHelp = config.help
+}
+catch (err) {
+    console.println(err.message);
+}
+
+if (showHelp || (!args.names) || args.names.length == 0) {
+    console.println(parseArgs.formatHelp({
+        usage: 'Usage: statz [options] <metric_name...>',
+        options,
+        positionals: positionals
+    }));
+    process.exit(showHelp ? 0 : 1);
+}
+
+const client = new neoapi.Client(config);
+client.getServerStatz(...args.names)
+    .then((rsp) => {
+        for (const stat of rsp.statz) {
+            console.println("[" + stat.name + "]");
+            let spec = viz.createSpec(stat.spec);
+            console.println(viz.toTUILines(spec, { width: 80, height: 5, rows: 60 }).join("\n"));
+            console.println();
+        }
+    })
+    .catch((err) => {
+        console.println('Error:', err.message);
+    });

--- a/jsh/usr/lib/neoapi.js
+++ b/jsh/usr/lib/neoapi.js
@@ -187,6 +187,11 @@ class Client extends _Client {
             return this._rpcRequest('server.info.get', []);
         });
     }
+    getServerStatz(...names) {
+        return this._executeWithAuth(() => {
+            return this._rpcRequest('server.info.statz', [names]);
+        });
+    }
     getMachbasePort(callback) {
         this.getServicePorts('mach')
             .then((data) => {

--- a/mods/server/http_rpc_test.go
+++ b/mods/server/http_rpc_test.go
@@ -55,6 +55,15 @@ func TestHttpRpc(t *testing.T) {
 			},
 		},
 		{
+			name:   "getServerStatz",
+			method: "server.info.statz",
+			params: []interface{}{[]string{"http:count"}},
+			expectFunc: func(t *testing.T, rsp gjson.Result) {
+				require.True(t, rsp.Get("result").Exists(), rsp.String())
+				require.Equal(t, "http:count", rsp.Get("result.statz.0.name").String(), rsp.String())
+			},
+		},
+		{
 			name:       "getServicePorts",
 			method:     "service.port.list",
 			params:     []interface{}{"mach"},

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -1080,6 +1080,7 @@ func (s *Server) registerJsonRpcHandlers() {
 	ctl.RegisterJsonRpcHandler("vizspec.render", viz.RPCVizspecRender)
 	ctl.RegisterJsonRpcHandler("vizspec.export", viz.RPCVizspecExport)
 	ctl.RegisterJsonRpcHandler("server.info.get", s.getServerInfo)
+	ctl.RegisterJsonRpcHandler("server.info.statz", s.getServerStatz)
 	ctl.RegisterJsonRpcHandler("service.port.list", s.getServicePorts)
 	ctl.RegisterJsonRpcHandler("proxy.register", s.registerProxy)
 	ctl.RegisterJsonRpcHandler("proxy.unregister", s.unregisterProxy)

--- a/mods/server/svrmetric.go
+++ b/mods/server/svrmetric.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/machbase/neo-client/api"
-	mach "github.com/machbase/neo-engine/v8"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/tql"
 	"github.com/machbase/neo-server/v8/mods/util"
@@ -22,7 +21,6 @@ func startServerMetrics(s *Server) {
 	spi.AddInput(&input.Runtime{})
 	spi.AddInput(&input.Netstat{})
 	spi.AddInputFunc(collectSysStatz)
-	spi.AddInputFunc(collectMachSvrStatz)
 	spi.AddInputFunc(collectMqttStatz(s))
 	spi.AddInputFunc(collectTqlCacheStatz)
 
@@ -161,14 +159,6 @@ func queryRowInt64(ctx context.Context, conn api.Conn, sqlText string, params ..
 		return 0, err
 	}
 	return result, nil
-}
-
-func collectMachSvrStatz(g *metric.Gather) error {
-	nfo := mach.Stat()
-	g.Add("machsvr:conn", float64(nfo.EngConn), metric.GaugeType(metric.UnitShort))
-	g.Add("machsvr:stmt", float64(nfo.EngStmt), metric.GaugeType(metric.UnitShort))
-	g.Add("machsvr:append", float64(nfo.EngAppend), metric.GaugeType(metric.UnitShort))
-	return nil
 }
 
 func collectMqttStatz(s *Server) func(g *metric.Gather) error {

--- a/mods/server/svrmgmt.go
+++ b/mods/server/svrmgmt.go
@@ -26,7 +26,9 @@ import (
 	"github.com/machbase/neo-client/machgo"
 	mach "github.com/machbase/neo-engine/v8"
 	"github.com/machbase/neo-server/v8/booter"
+	"github.com/machbase/neo-server/v8/jsh/viz"
 	"github.com/machbase/neo-server/v8/mods"
+	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/machbase/neo-server/v8/spi"
 	"github.com/machbase/neo-server/v8/spi/machsvr"
 	"golang.org/x/crypto/ssh"
@@ -994,4 +996,43 @@ func (s *Server) getServerInfo() (*ServerInfoResponse, error) {
 		"gc_pause_total_ns": mem.PauseTotalNs,
 	}
 	return rsp, nil
+}
+
+type ServerStatzResponse struct {
+	Statz []ServerStatz `json:"statz"`
+}
+
+type ServerStatz struct {
+	Name string    `json:"name"`
+	Spec *viz.Spec `json:"spec"`
+}
+
+func (s *Server) getServerStatz(names []string) (*ServerStatzResponse, error) {
+	v := spi.Visualizer()
+	ret := &ServerStatzResponse{}
+	for i, name := range names {
+		var metricNames []string
+		var fieldNames []string
+		if strings.Contains(name, "#") {
+			// support metric with tag, e.g. "cpu_usage#host=server1"
+			parts := strings.SplitN(name, "#", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			metricNames = append(metricNames, parts[0])
+			fieldNames = append(fieldNames, parts[1])
+		} else {
+			metricNames = append(metricNames, name)
+		}
+		c := metric.Chart{ID: fmt.Sprintf("chart_%d", i), MetricNames: metricNames, FieldNames: fieldNames}
+		v.AddChart(c)
+	}
+	for i := range names {
+		spec, err := v.Generate(fmt.Sprintf("chart_%d", i), 0)
+		if err != nil {
+			return nil, err
+		}
+		ret.Statz = append(ret.Statz, ServerStatz{Name: names[i], Spec: spec})
+	}
+	return ret, nil
 }

--- a/mods/tql/fm_fake.go
+++ b/mods/tql/fm_fake.go
@@ -14,8 +14,10 @@ import (
 	"time"
 
 	"github.com/machbase/neo-client/api"
+	"github.com/machbase/neo-server/v8/jsh/viz"
 	"github.com/machbase/neo-server/v8/mods/nums"
 	"github.com/machbase/neo-server/v8/mods/nums/opensimplex"
+	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/machbase/neo-server/v8/spi"
 )
 
@@ -45,7 +47,9 @@ func (node *Node) fmFake(origin any) (any, error) {
 	case *rawdata:
 		genRawData(node, gen)
 	case *statz:
-		genStatz(node, gen)
+		if err := genStatz(node, gen); err != nil {
+			ErrorRecord(fmt.Errorf("%s %s", node.Name(), err.Error())).Tell(node.next)
+		}
 	default:
 		return nil, ErrWrongTypeOfArgs("FAKE", 0, "fakeSource", origin)
 	}
@@ -53,43 +57,108 @@ func (node *Node) fmFake(origin any) (any, error) {
 }
 
 type statz struct {
-	interval   time.Duration
-	keyFilters []string
+	names []string
+	g     *spi.VizSpecGenerator
+	txIdx int
 }
 
-func genStatz(node *Node, gen *statz) {
-	statz := spi.QueryStatz(gen.interval, spi.QueryStatzFilter(gen.keyFilters))
-	if statz.Err != nil {
-		ErrorRecord(statz.Err).Tell(node.next)
-		return
+func genStatz(node *Node, gen *statz) error {
+	var specs []*viz.Spec
+	for i := range gen.names {
+		spec, err := gen.g.Generate(fmt.Sprintf("chart_%d", i), gen.txIdx)
+		if err != nil {
+			return err
+		}
+		specs = append(specs, spec)
 	}
+
+	times := make([]int64, 0)
+
+	if len(specs) == 0 {
+		return errors.New("no viz spec generated")
+	}
+	if len(specs[0].Series) == 0 {
+		return errors.New("no series in viz spec")
+	}
+	series := specs[0].Series[0]
+	if len(series.Representation.Fields) == 0 || series.Representation.Fields[0] != "time" {
+		return errors.New("the first field of series should be time")
+	}
+	if len(series.Data) == 0 {
+		return errors.New("no data in series")
+	}
+	if datum, ok := series.Data[0].([]any); !ok || len(datum) < 2 {
+		return errors.New("data item should have at least 2 fields")
+	}
+	for _, datum := range series.Data {
+		item := datum.([]any)
+		if t, ok := item[0].(int64); ok {
+			times = append(times, t)
+		}
+	}
+	if len(times) == 0 {
+		return errors.New("no time data in series")
+	}
+
 	// set columns
 	cols := []*api.Column{
 		api.MakeColumnRownum(),
 		api.MakeColumnDatetime("time"),
 	}
-	cols = append(cols, statz.Cols...)
+
+	for _, spec := range specs {
+		for _, series := range spec.Series {
+			cols = append(cols, api.MakeColumnAny(series.Name))
+		}
+	}
 	node.task.SetResultColumns(cols)
-	if len(statz.Rows) == 0 {
-		return
+
+	for i, ts := range times {
+		values := []any{time.Unix(0, ts)}
+		for _, spec := range specs {
+			if len(spec.Series) == 0 {
+				values = append(values, nil)
+				continue
+			}
+			for _, series := range spec.Series {
+				item, ok := series.Data[i].([]any)
+				if !ok || len(item) < 2 {
+					values = append(values, nil)
+					continue
+				}
+				if t, ok := item[0].(int64); ok && t == ts {
+					values = append(values, item[1])
+				}
+			}
+		}
+		NewRecord(i, values).Tell(node.next)
 	}
-	// yield rows
-	for i, row := range statz.Rows {
-		NewRecord(i, append([]any{row.Timestamp}, row.Values...)).Tell(node.next)
-	}
+	return nil
 }
 
-func (node *Node) fmStatz(samplingInterval string, keyFilters ...string) *statz {
-	var interval time.Duration
-	if dur, err := time.ParseDuration(samplingInterval); err == nil {
-		interval = dur
-	} else {
-		interval = time.Minute
+func (node *Node) fmStatz(tsIdx int, names ...string) *statz {
+	g := spi.Visualizer()
+	for i, name := range names {
+		var metricNames []string
+		var fieldNames []string
+		if strings.Contains(name, "#") {
+			// support metric with tag, e.g. "cpu_usage#host=server1"
+			parts := strings.SplitN(name, "#", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			metricNames = append(metricNames, parts[0])
+			fieldNames = append(fieldNames, parts[1])
+		} else {
+			metricNames = append(metricNames, name)
+		}
+		c := metric.Chart{ID: fmt.Sprintf("chart_%d", i), MetricNames: metricNames, FieldNames: fieldNames}
+		g.AddChart(c)
 	}
-
 	ret := &statz{
-		interval:   interval,
-		keyFilters: keyFilters,
+		names: names,
+		g:     g,
+		txIdx: tsIdx,
 	}
 	return ret
 }

--- a/mods/tql/fx_generate.gen.go
+++ b/mods/tql/fx_generate.gen.go
@@ -2976,12 +2976,12 @@ func (x *Node) gen_csv(args ...any) (any, error) {
 
 // gen_statz
 //
-// syntax: statz(string, ...string)
+// syntax: statz(int, ...string)
 func (x *Node) gen_statz(args ...any) (any, error) {
 	if len(args) < 1 {
 		return nil, ErrInvalidNumOfArgs("statz", 1, len(args))
 	}
-	p0, err := convString(args, 0, "statz", "string")
+	p0, err := convInt(args, 0, "statz", "int")
 	if err != nil {
 		return nil, err
 	}

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/machbase/neo-server/v8/mods/server"
 	"github.com/machbase/neo-server/v8/mods/tql"
 	"github.com/machbase/neo-server/v8/mods/util"
+	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/machbase/neo-server/v8/mods/util/ssfs"
 	"github.com/machbase/neo-server/v8/spi"
 	"github.com/machbase/neo-server/v8/spi/testsuite"
@@ -1742,6 +1744,74 @@ func TestTql(t *testing.T) {
 		return []string{"/bin/bash", path}, nil
 	}
 
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			runTestCase(t, tc)
+		})
+	}
+}
+
+func mustSeriesID(t *testing.T, id, title string, period time.Duration, maxCount int) metric.SeriesID {
+	t.Helper()
+	seriesID, err := metric.NewSeriesID(id, title, period, maxCount)
+	require.NoError(t, err)
+	return seriesID
+}
+
+func TestFakeStatz(t *testing.T) {
+	seriesID := mustSeriesID(t, "CPU_USAGE", "CPU Usage", time.Second, 8)
+	collector := metric.NewCollector(
+		metric.WithSamplingInterval(time.Second),
+		metric.WithSeries(seriesID),
+	)
+	collector.Start()
+	t.Cleanup(collector.Stop)
+
+	collector.Send(metric.Measure{Name: "cpu:usage", Value: 1, Type: metric.CounterType(metric.UnitScalar)})
+	time.Sleep(1100 * time.Millisecond)
+	collector.Send(metric.Measure{Name: "cpu:usage", Value: 2, Type: metric.CounterType(metric.UnitScalar)})
+
+	org := spi.SetCollector(collector)
+	defer spi.SetCollector(org)
+
+	require.Eventually(t, func() bool {
+		mts := collector.Timeseries("cpu:usage")
+		if len(mts) == 0 {
+			return false
+		}
+		_, values := mts[0].All()
+		samples := make([]float64, 0, len(values))
+		for _, raw := range values {
+			v, ok := raw.(*metric.CounterValue)
+			if !ok || v.Samples == 0 {
+				continue
+			}
+			samples = append(samples, v.Value)
+		}
+		if len(samples) < 2 {
+			return false
+		}
+		return samples[len(samples)-2] == 1 && samples[len(samples)-1] == 2
+	}, 3*time.Second, 50*time.Millisecond)
+
+	tests := []TqlTestCase{
+		{
+			Name: "FAKE_statz",
+			Script: `
+				FAKE( statz(0, 'cpu:usage') )
+				FILTER( value(1) != NULL )
+				CSV(timeformat('15:04:05'), heading(true), precision(0))`,
+			ExpectFunc: func(t *testing.T, result string) {
+				lines := strings.Split(result, "\n")
+				require.Equal(t, "time,cpu:usage", lines[0])
+				// 2026-06-12 08:14:22,1
+				require.True(t, regexp.MustCompile(`^[0-9]{2}:[0-9]{2}:[0-9]{2},1$`).MatchString(lines[1]), "line: %q", lines[1])
+				// 2026-06-12 08:14:23,2
+				require.True(t, regexp.MustCompile(`^[0-9]{2}:[0-9]{2}:[0-9]{2},2$`).MatchString(lines[2]), "line: %q", lines[2])
+				require.Equal(t, "", lines[3])
+			},
+		},
+	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			runTestCase(t, tc)

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/machbase/neo-client/api"
+	"github.com/machbase/neo-server/v8/jsh/viz"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/util/glob"
 	"github.com/machbase/neo-server/v8/mods/util/metric"
@@ -512,3 +513,234 @@ var tmplStatz = `
 {{- end }}
 </table>
 {{ end }}`
+
+func Visualizer() *VizSpecGenerator {
+	return NewVizSpecGenerator(collector)
+}
+
+type VizSpecGenerator struct {
+	metric.Dashboard
+	collector *metric.Collector
+}
+
+func NewVizSpecGenerator(c *metric.Collector) *VizSpecGenerator {
+	return &VizSpecGenerator{
+		Dashboard: *metric.NewDashboard(c),
+		collector: c,
+	}
+}
+
+func (g VizSpecGenerator) HandleFunc(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	tsIdxStr := r.URL.Query().Get("tsIdx")
+	var tsIdx int
+	if _, err := fmt.Sscanf(tsIdxStr, "%d", &tsIdx); err != nil {
+		tsIdx = 0
+	}
+
+	spec, err := g.Generate(id, tsIdx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(spec); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (g VizSpecGenerator) Generate(id string, tsIdx int) (*viz.Spec, error) {
+	panelOpt := g.panelByID(id)
+
+	spec := (&viz.Spec{}).Normalize()
+	spec.Domain = viz.Domain{
+		Kind:       viz.DomainKindTime,
+		Timeformat: viz.TimeformatNano,
+		TZ:         "UTC",
+	}
+	spec.Axes.X = viz.Axis{
+		ID:    "time",
+		Type:  viz.AxisTypeTime,
+		Label: "Time",
+	}
+	spec.View = viz.View{PreferredRenderer: "echarts"}
+	spec.Meta = viz.Meta{
+		Producer:    "machbase-neo",
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+
+	axisByID := map[string]struct{}{}
+	var minTime time.Time
+	var maxTime time.Time
+	var found bool
+
+	for _, metricName := range panelOpt.MetricNames {
+		ss, ok := g.getSnapshot(metricName, tsIdx)
+		if !ok || len(ss.Times) == 0 {
+			continue
+		}
+		found = true
+
+		axisID := axisIDForMetric(ss.Meta.MeasureName)
+		axisLabel := ss.Meta.MeasureName
+		if unit := string(ss.Meta.MeasureType.Unit()); unit != "" && unit != string(metric.UnitScalar) {
+			axisLabel = fmt.Sprintf("%s (%s)", ss.Meta.MeasureName, unit)
+		}
+		if _, exists := axisByID[axisID]; !exists {
+			spec.Axes.Y = append(spec.Axes.Y, viz.Axis{
+				ID:    axisID,
+				Type:  viz.AxisTypeLinear,
+				Label: axisLabel,
+				Unit:  string(ss.Meta.MeasureType.Unit()),
+			})
+			axisByID[axisID] = struct{}{}
+		}
+
+		seriesList := ss.Series(panelOpt)
+		for _, series := range seriesList {
+			vizSeries, seriesMin, seriesMax := toVizSeries(series, ss, axisID, panelOpt)
+			if len(vizSeries.Data) == 0 {
+				continue
+			}
+			spec.Series = append(spec.Series, vizSeries)
+			if minTime.IsZero() || seriesMin.Before(minTime) {
+				minTime = seriesMin
+			}
+			if maxTime.IsZero() || seriesMax.After(maxTime) {
+				maxTime = seriesMax
+			}
+		}
+	}
+
+	if !found || len(spec.Series) == 0 {
+		return nil, fmt.Errorf("no metrics found")
+	}
+
+	spec.Domain.From = minTime.UnixNano()
+	spec.Domain.To = maxTime.UnixNano()
+	if err := spec.Validate(); err != nil {
+		return nil, err
+	}
+	return spec, nil
+}
+
+func (g VizSpecGenerator) panelByID(id string) metric.Chart {
+	panels := g.Panels()
+	if len(panels) == 0 {
+		if id == "" {
+			if len(g.Charts) > 0 {
+				return g.Charts[0]
+			}
+			return metric.Chart{ID: "metrics", Title: "Metrics"}
+		}
+		return metric.Chart{ID: id, Title: id, MetricNames: []string{id}}
+	}
+	if id == "" {
+		return panels[0]
+	}
+	for _, panel := range panels {
+		if panel.ID == id {
+			return panel
+		}
+	}
+	for _, chart := range g.Charts {
+		if chart.ID == id {
+			return chart
+		}
+	}
+	return metric.Chart{ID: id, Title: id, MetricNames: []string{id}}
+}
+
+func axisIDForMetric(metricName string) string {
+	var sb strings.Builder
+	for _, r := range metricName {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			sb.WriteRune(r)
+			continue
+		}
+		sb.WriteByte('_')
+	}
+	axisID := strings.Trim(sb.String(), "_")
+	if axisID == "" {
+		return "y"
+	}
+	return axisID
+}
+
+func (g VizSpecGenerator) getSnapshot(metricName string, tsIdx int) (metric.Snapshot, bool) {
+	if g.collector == nil {
+		return metric.Snapshot{}, false
+	}
+	mts := g.collector.Timeseries(metricName)
+	if mts == nil {
+		return metric.Snapshot{}, false
+	}
+	if tsIdx < 0 || tsIdx >= len(mts) {
+		return metric.Snapshot{}, false
+	}
+	ts := mts[tsIdx]
+	times, values := ts.All()
+	if len(times) == 0 {
+		return metric.Snapshot{}, true
+	}
+	meta, _ := ts.Meta().(metric.SeriesInfo)
+	return metric.Snapshot{
+		PublishName: metricName,
+		Times:       times,
+		Values:      values,
+		Interval:    ts.Interval(),
+		MaxCount:    ts.MaxCount(),
+		Meta:        meta,
+	}, true
+}
+
+func toVizSeries(series metric.Series, ss metric.Snapshot, axisID string, chartOpt metric.Chart) (viz.Series, time.Time, time.Time) {
+	data := make([]any, 0, len(series.Data))
+	var minTime time.Time
+	var maxTime time.Time
+	for _, item := range series.Data {
+		if item.Time == 0 {
+			continue
+		}
+		tm := time.UnixMilli(item.Time)
+		data = append(data, []any{tm.UnixNano(), item.Value})
+		if minTime.IsZero() || tm.Before(minTime) {
+			minTime = tm
+		}
+		if maxTime.IsZero() || tm.After(maxTime) {
+			maxTime = tm
+		}
+	}
+
+	vizSeries := viz.Series{
+		ID:   series.Name,
+		Name: series.Name,
+		Axis: axisID,
+		Representation: viz.Representation{
+			Kind:   viz.RepresentationTimeBucketValue,
+			Fields: []string{"time", "value"},
+		},
+		Source: viz.Source{
+			Kind:        viz.SourceKindSampled,
+			Resolution:  ss.Interval.String(),
+			DerivedFrom: ss.PublishName,
+		},
+		Data: data,
+		Quality: viz.Quality{
+			Sampled:         true,
+			RowCount:        len(data),
+			EstimatedPoints: int64(len(data)),
+		},
+		Style: map[string]any{
+			"preferredRenderer": "echarts",
+		},
+		Extra: map[string]any{
+			"chartType":  string(series.Type),
+			"stack":      series.Stack,
+			"smooth":     series.Smooth,
+			"showSymbol": chartOpt.ShowSymbol,
+		},
+	}
+	return vizSeries, minTime, maxTime
+}

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -215,6 +215,13 @@ func StopMetrics() {
 	collector = nil
 }
 
+// collectSysStatz collects system metrics and adds them to the metric gather.
+func SetCollector(c *metric.Collector) *metric.Collector {
+	old := collector
+	collector = c
+	return old
+}
+
 func MetricsDestTable() string {
 	return metricsDest
 }
@@ -426,6 +433,7 @@ func HandleStatz(w http.ResponseWriter, r *http.Request) {
 	for idx, col := range stat.Cols {
 		value := stat.Rows[0].Values[idx]
 		valueType := stat.ValueTypes[idx]
+		col.Name = strings.TrimPrefix(col.Name, "machbase:")
 		if format == "html" {
 			if value == nil {
 				ret[col.Name] = "null"

--- a/spi/metrics_test.go
+++ b/spi/metrics_test.go
@@ -64,8 +64,19 @@ func TestVizSpecGenerator(t *testing.T) {
 		if len(mts) == 0 {
 			return false
 		}
-		times, _ := mts[0].All()
-		return len(times) >= 2
+		_, values := mts[0].All()
+		samples := make([]float64, 0, len(values))
+		for _, raw := range values {
+			v, ok := raw.(*metric.CounterValue)
+			if !ok || v.Samples == 0 {
+				continue
+			}
+			samples = append(samples, v.Value)
+		}
+		if len(samples) < 2 {
+			return false
+		}
+		return samples[len(samples)-2] == 1 && samples[len(samples)-1] == 2
 	}, 3*time.Second, 50*time.Millisecond)
 
 	gen := NewVizSpecGenerator(collector)
@@ -80,9 +91,17 @@ func TestVizSpecGenerator(t *testing.T) {
 	require.Len(t, spec.Series, 1)
 	require.Equal(t, "time-bucket-value", spec.Series[0].Representation.Kind)
 	require.Equal(t, "cpu_usage", spec.Series[0].Axis)
-	require.GreaterOrEqual(t, len(spec.Series[0].Data), 2)
-	require.Equal(t, float64(1), spec.Series[0].Data[len(spec.Series[0].Data)-2].([]any)[1])
-	require.Equal(t, float64(2), spec.Series[0].Data[len(spec.Series[0].Data)-1].([]any)[1])
+	points := make([][]any, 0, len(spec.Series[0].Data))
+	for _, raw := range spec.Series[0].Data {
+		item, ok := raw.([]any)
+		if !ok || len(item) < 2 || item[1] == nil {
+			continue
+		}
+		points = append(points, item)
+	}
+	require.GreaterOrEqual(t, len(points), 2)
+	require.Equal(t, float64(1), points[len(points)-2][1])
+	require.Equal(t, float64(2), points[len(points)-1][1])
 
 	blocks, err := viz.ToTUIBlocks(spec)
 	for _, block := range blocks {
@@ -97,9 +116,17 @@ func TestVizSpecGenerator(t *testing.T) {
 	require.Equal(t, "table", blocks[3].Type)
 	require.Len(t, blocks[2].Lines, 1)
 	require.Equal(t, "▁█", blocks[2].Lines[0])
-	require.GreaterOrEqual(t, len(blocks[3].Rows), 2)
-	firstRow := blocks[3].Rows[len(blocks[3].Rows)-2].([]any)
-	secondRow := blocks[3].Rows[len(blocks[3].Rows)-1].([]any)
+	rows := make([][]any, 0, len(blocks[3].Rows))
+	for _, raw := range blocks[3].Rows {
+		row, ok := raw.([]any)
+		if !ok || len(row) < 2 || row[1] == nil {
+			continue
+		}
+		rows = append(rows, row)
+	}
+	require.GreaterOrEqual(t, len(rows), 2)
+	firstRow := rows[len(rows)-2]
+	secondRow := rows[len(rows)-1]
 	require.Equal(t, float64(1), firstRow[1])
 	require.Equal(t, float64(2), secondRow[1])
 }

--- a/spi/metrics_test.go
+++ b/spi/metrics_test.go
@@ -6,9 +6,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/machbase/neo-server/v8/jsh/viz"
+	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,4 +44,69 @@ func TestHandleStatz(t *testing.T) {
 		require.Contains(t, writer.Body.String(), metricKey)
 		require.Contains(t, writer.Body.String(), "42")
 	})
+}
+
+func TestVizSpecGenerator(t *testing.T) {
+	seriesID := mustSeriesID(t, "CPU_USAGE", "CPU Usage", time.Second, 8)
+	collector := metric.NewCollector(
+		metric.WithSamplingInterval(time.Second),
+		metric.WithSeries(seriesID),
+	)
+	collector.Start()
+	t.Cleanup(collector.Stop)
+
+	collector.Send(metric.Measure{Name: "cpu:usage", Value: 1, Type: metric.CounterType(metric.UnitScalar)})
+	time.Sleep(1100 * time.Millisecond)
+	collector.Send(metric.Measure{Name: "cpu:usage", Value: 2, Type: metric.CounterType(metric.UnitScalar)})
+
+	require.Eventually(t, func() bool {
+		mts := collector.Timeseries("cpu:usage")
+		if len(mts) == 0 {
+			return false
+		}
+		times, _ := mts[0].All()
+		return len(times) >= 2
+	}, 3*time.Second, 50*time.Millisecond)
+
+	gen := NewVizSpecGenerator(collector)
+	require.NoError(t, gen.AddChart(metric.Chart{ID: "cpu", Title: "CPU", MetricNames: []string{"cpu:usage"}}))
+
+	spec, err := gen.Generate("cpu", 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, spec.Version)
+	require.Equal(t, "time", spec.Domain.Kind)
+	require.Equal(t, "ns", spec.Domain.Timeformat)
+	require.Equal(t, "time", spec.Axes.X.Type)
+	require.Len(t, spec.Series, 1)
+	require.Equal(t, "time-bucket-value", spec.Series[0].Representation.Kind)
+	require.Equal(t, "cpu_usage", spec.Series[0].Axis)
+	require.GreaterOrEqual(t, len(spec.Series[0].Data), 2)
+	require.Equal(t, float64(1), spec.Series[0].Data[len(spec.Series[0].Data)-2].([]any)[1])
+	require.Equal(t, float64(2), spec.Series[0].Data[len(spec.Series[0].Data)-1].([]any)[1])
+
+	blocks, err := viz.ToTUIBlocks(spec)
+	for _, block := range blocks {
+		t.Logf("Block Type: %s, Rows: %v", block.Type, block.Rows)
+		t.Log(strings.Join(block.Lines, "\n"))
+	}
+	require.NoError(t, err)
+	require.Len(t, blocks, 4)
+	require.Equal(t, "summary", blocks[0].Type)
+	require.Equal(t, "series-summary", blocks[1].Type)
+	require.Equal(t, "sparkline", blocks[2].Type)
+	require.Equal(t, "table", blocks[3].Type)
+	require.Len(t, blocks[2].Lines, 1)
+	require.Equal(t, "▁█", blocks[2].Lines[0])
+	require.GreaterOrEqual(t, len(blocks[3].Rows), 2)
+	firstRow := blocks[3].Rows[len(blocks[3].Rows)-2].([]any)
+	secondRow := blocks[3].Rows[len(blocks[3].Rows)-1].([]any)
+	require.Equal(t, float64(1), firstRow[1])
+	require.Equal(t, float64(2), secondRow[1])
+}
+
+func mustSeriesID(t *testing.T, id, title string, period time.Duration, maxCount int) metric.SeriesID {
+	t.Helper()
+	seriesID, err := metric.NewSeriesID(id, title, period, maxCount)
+	require.NoError(t, err)
+	return seriesID
 }


### PR DESCRIPTION
This pull request introduces significant changes to the server's metric/statistics ("statz") functionality, focusing on removing the old statz API from the JavaScript system module, and adding a new, more structured server-side API for retrieving server statistics visualizations. It also introduces a visualization specification generator for metrics, exposes a new JSON-RPC endpoint, and updates tests accordingly.

**Server-side Metrics Visualization and API Improvements:**

* Added a new `VizSpecGenerator` in `spi/metrics.go` to generate visualization specifications (`viz.Spec`) for server metrics, enabling more structured and flexible metric visualization. This includes methods for generating specs, handling HTTP requests, and converting metric data into visualization series. (F5aad349L513)
* Exposed a new JSON-RPC endpoint `server.info.statz` by registering `getServerStatz` in `mods/server/server.go`, allowing clients to request structured metric visualizations.
* Implemented the `getServerStatz` method in `mods/server/svrmgmt.go` to process metric/statistics requests, generate visualization specs for requested metrics, and return them in a structured response. (F2c3c5daL997)

**Client and Test Updates:**

* Added a new client method `getServerStatz` in `jsh/usr/lib/neoapi.js` to call the new server-side statz endpoint.
* Updated server-side tests in `mods/server/http_rpc_test.go` to cover the new statz endpoint, verifying the structure and content of the returned stats.
* Added comprehensive tests for the new visualization spec generator in `spi/metrics_test.go`, ensuring correct generation and structure of visualization specs and TUI blocks. (Faac87a1L45)

**Removal of Old statz API and Related Code:**

* Removed the old `statz` function from the JavaScript system module (`jsh/lib/system/system.js` and `jsh/lib/system/system.go`), as well as the corresponding Go implementation and tests, fully deprecating the previous statz API. [[1]](diffhunk://#diff-d9e9047a6cffbc16609f12d3564415a43654d002c842b1e7fd8ca5211a31e785L6-L13) F72a34eaL32, F72a34eaL62, [[2]](diffhunk://#diff-ee1c44d1d06ffa3bcfb8fd0292ddd151c3a57756bb760ec90edc05bef1e622ccL5-L8) F3a92763L24, [[3]](diffhunk://#diff-609a162725ee6b294f32abb5f4da2b8ee2b113aa6ff9b88518d26e7680f41c3eL4-L10) Fb55a532L69)

These changes modernize the server's metric/statistics capabilities, providing a more robust, testable, and extensible foundation for metric visualization and client access.