### PR TITLE
Refactor server metrics and add Prometheus integration

### DIFF
--- a/mods/server/http.go
+++ b/mods/server/http.go
@@ -105,6 +105,7 @@ type httpd struct {
 	pathMap map[string]string
 
 	statzAllowed []string
+	statzToken   string
 	cypherAlg    string
 	cypherKey    string
 	cypherPad    string
@@ -132,6 +133,10 @@ func (svr *httpd) Start() error {
 		gin.SetMode(gin.DebugMode)
 	} else {
 		gin.SetMode(gin.ReleaseMode)
+	}
+
+	if svr.statzToken == "" {
+		spi.SetPrometheusBearerToken(svr.statzToken)
 	}
 
 	var connContext func(context.Context, net.Conn) context.Context
@@ -366,6 +371,7 @@ func (svr *httpd) Router() *gin.Engine {
 	debugGroup.Any("/pprof/*path", gin.WrapF(httpPprof.Index))
 	debugGroup.GET("/dashboard", gin.WrapF(spi.DashboardHandler()))
 	debugGroup.GET("/statz", gin.WrapF(spi.HandleStatz))
+	debugGroup.GET("/metrics", gin.WrapF(spi.HandlePrometheusMetrics))
 
 	r.NoRoute(gin.WrapH(http.FileServer(AssetsDir())))
 	return r

--- a/mods/server/http_opts.go
+++ b/mods/server/http_opts.go
@@ -156,6 +156,12 @@ func WithHttpStatzAllow(remotes ...string) HttpOption {
 	}
 }
 
+func WithHttpStatzToken(token string) HttpOption {
+	return func(s *httpd) {
+		s.statzToken = token
+	}
+}
+
 func WithHttpQueryCypher(algAndKey string) HttpOption {
 	alg := ""
 	pad := "PCKCS7"

--- a/mods/server/http_test.go
+++ b/mods/server/http_test.go
@@ -63,6 +63,83 @@ func TestStatz(t *testing.T) {
 	require.GreaterOrEqual(t, len(result), 2)
 }
 
+func TestDebugMetrics(t *testing.T) {
+	prevToken := spi.PrometheusBearerToken()
+	t.Cleanup(func() {
+		spi.SetPrometheusBearerToken(prevToken)
+	})
+
+	t.Run("without fixed token", func(t *testing.T) {
+		spi.SetPrometheusBearerToken("")
+
+		req, _ := http.NewRequest(http.MethodGet, httpServerAddress+"/debug/metrics", nil)
+		rsp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer rsp.Body.Close()
+
+		require.Equal(t, http.StatusOK, rsp.StatusCode)
+		require.Contains(t, rsp.Header.Get("Content-Type"), "text/plain")
+	})
+
+	t.Run("with fixed token", func(t *testing.T) {
+		spi.SetPrometheusBearerToken("prom-fixed-token")
+
+		t.Run("rejects missing token", func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, httpServerAddress+"/debug/metrics", nil)
+			rsp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer rsp.Body.Close()
+
+			require.Equal(t, http.StatusUnauthorized, rsp.StatusCode)
+		})
+
+		t.Run("accepts matching token", func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, httpServerAddress+"/debug/metrics", nil)
+			req.Header.Set("Authorization", "Bearer prom-fixed-token")
+			rsp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer rsp.Body.Close()
+
+			require.Equal(t, http.StatusOK, rsp.StatusCode)
+		})
+	})
+}
+
+func TestAllowDebug(t *testing.T) {
+	svr := &httpd{log: logging.GetLog("httpd-fake")}
+
+	t.Run("allows loopback", func(t *testing.T) {
+		ctx, writer := newTestHTTPContext(http.MethodGet, "/debug/metrics", nil)
+		ctx.Request.RemoteAddr = "127.0.0.1:12345"
+
+		svr.allowDebug(ctx)
+
+		require.False(t, ctx.IsAborted())
+		require.Equal(t, http.StatusOK, writer.Code)
+	})
+
+	t.Run("rejects non allowed remote", func(t *testing.T) {
+		ctx, writer := newTestHTTPContext(http.MethodGet, "/debug/metrics", nil)
+		ctx.Request.RemoteAddr = "192.0.2.10:12345"
+
+		svr.allowDebug(ctx)
+
+		require.True(t, ctx.IsAborted())
+		require.Equal(t, http.StatusForbidden, writer.Code)
+	})
+
+	t.Run("allows configured remote", func(t *testing.T) {
+		svr.statzAllowed = []string{"192.0.2.10"}
+		ctx, writer := newTestHTTPContext(http.MethodGet, "/debug/metrics", nil)
+		ctx.Request.RemoteAddr = "192.0.2.10:12345"
+
+		svr.allowDebug(ctx)
+
+		require.False(t, ctx.IsAborted())
+		require.Equal(t, http.StatusOK, writer.Code)
+	})
+}
+
 func TestHandleStatzConfig(t *testing.T) {
 	prevDest := spi.MetricsDestTable()
 	t.Cleanup(func() {

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -918,6 +918,7 @@ func (s *Server) startHttpServer() error {
 		WithHttpReadBufSize(s.Http.ReadBufSize),
 		WithHttpKeepAlive(s.Http.KeepAlive),
 		WithHttpStatzAllow(s.Http.AllowStatz...),
+		WithHttpStatzToken(s.Http.StatzToken),
 		WithHttpQueryCypher(s.Http.QueryCypher),
 	}
 	if s.mqttd != nil {

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -861,7 +861,20 @@ func TestPrometheusScrapeWithDocker(t *testing.T) {
 
 	pool := dockertest.NewPoolT(t, "")
 
-	target := strings.TrimPrefix(httpServerAddress, "http://")
+	// On Linux, use --network=host so Prometheus can reach services bound to 127.0.0.1.
+	// Docker containers on Linux cannot reach the host loopback via host-gateway;
+	// they can only access services bound to 0.0.0.0 through the bridge.
+	// With host network mode, the container shares the host network namespace,
+	// so 127.0.0.1 resolves directly, and incoming requests appear as 127.0.0.1
+	// which is always allowed by the allowDebug middleware.
+	httpHostPort := strings.TrimPrefix(httpServerAddress, "http://")
+	var promTargetAddr string
+	if runtime.GOOS == "linux" {
+		promTargetAddr = httpHostPort // e.g. 127.0.0.1:15654 — reachable via host network
+	} else {
+		promTargetAddr = "host.docker.internal:" + strings.Split(httpHostPort, ":")[1]
+	}
+
 	config := fmt.Sprintf(`global:
   scrape_interval: 1s
   scrape_timeout: 1s
@@ -870,11 +883,11 @@ scrape_configs:
   - job_name: machbase-neo
     metrics_path: /debug/metrics
     static_configs:
-      - targets: ["host.docker.internal:%s"]
+      - targets: ["%s"]
     authorization:
       type: Bearer
       credentials: "%s"
-`, strings.Split(target, ":")[1], token)
+`, promTargetAddr, token)
 
 	configPath := filepath.Join(t.TempDir(), "prometheus.yml")
 	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
@@ -885,19 +898,33 @@ scrape_configs:
 		dockertest.WithMounts([]string{configPath + ":/etc/prometheus/prometheus.yml:ro"}),
 		dockertest.WithHostConfig(func(cfg *container.HostConfig) {
 			if runtime.GOOS == "linux" {
-				cfg.ExtraHosts = append(cfg.ExtraHosts, "host.docker.internal:host-gateway")
+				// Host network mode: shares host network namespace.
+				// ExtraHosts is not supported (and not needed) in this mode.
+				cfg.NetworkMode = "host"
 			}
 		}),
 	)
 
-	for _, nw := range prom.Container.NetworkSettings.Networks {
-		if nw != nil && nw.IPAddress.IsValid() {
-			httpServer.statzAllowed = append(httpServer.statzAllowed, nw.IPAddress.String())
-			break
+	// On non-Linux, Prometheus runs in its own network and we must whitelist its IP
+	// in statzAllowed so the allowDebug middleware permits scrape requests.
+	// On Linux with host network mode, source IP is 127.0.0.1 and always allowed.
+	if runtime.GOOS != "linux" {
+		for _, nw := range prom.Container.NetworkSettings.Networks {
+			if nw != nil && nw.IPAddress.IsValid() {
+				httpServer.statzAllowed = append(httpServer.statzAllowed, nw.IPAddress.String())
+				break
+			}
 		}
 	}
 
-	promURL := "http://" + prom.GetHostPort("9090/tcp")
+	// With host network mode on Linux, Prometheus binds directly to the host's port 9090.
+	// There is no Docker port mapping, so GetHostPort returns empty; use localhost directly.
+	var promURL string
+	if runtime.GOOS == "linux" {
+		promURL = "http://127.0.0.1:9090"
+	} else {
+		promURL = "http://" + prom.GetHostPort("9090/tcp")
+	}
 
 	err := pool.Retry(t.Context(), 45*time.Second, func() error {
 		rsp, err := http.Get(promURL + "/-/ready")

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -899,7 +899,7 @@ scrape_configs:
 
 	promURL := "http://" + prom.GetHostPort("9090/tcp")
 
-	err := pool.Retry(t.Context(), 90*time.Second, func() error {
+	err := pool.Retry(t.Context(), 45*time.Second, func() error {
 		rsp, err := http.Get(promURL + "/-/ready")
 		if err != nil {
 			return err
@@ -912,7 +912,7 @@ scrape_configs:
 	})
 	require.NoError(t, err)
 
-	err = pool.Retry(t.Context(), 90*time.Second, func() error {
+	err = pool.Retry(t.Context(), 45*time.Second, func() error {
 		rsp, err := http.Get(promURL + "/api/v1/targets")
 		if err != nil {
 			return err
@@ -953,7 +953,7 @@ scrape_configs:
 	})
 	require.NoError(t, err)
 
-	err = pool.Retry(t.Context(), 90*time.Second, func() error {
+	err = pool.Retry(t.Context(), 45*time.Second, func() error {
 		rsp, err := http.Get(promURL + "/api/v1/query?query=up%7Bjob%3D%22machbase-neo%22%7D")
 		if err != nil {
 			return err

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/machbase/neo-server/v8/mods/util"
 	"github.com/machbase/neo-server/v8/spi"
 	"github.com/machbase/neo-server/v8/test"
+	"github.com/moby/moby/api/types/container"
 	"github.com/ory/dockertest/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -841,6 +842,155 @@ func TestShellBridge(t *testing.T) {
 		shellBridgeNatsTest(t, natsHostPort)
 	})
 
+}
+
+func TestPrometheusScrapeWithDocker(t *testing.T) {
+	if !test.SupportDockerTest() {
+		t.Skip("dockertest does not work in this environment")
+	}
+
+	prevToken := spi.PrometheusBearerToken()
+	prevAllowed := append([]string(nil), httpServer.statzAllowed...)
+	t.Cleanup(func() {
+		spi.SetPrometheusBearerToken(prevToken)
+		httpServer.statzAllowed = prevAllowed
+	})
+
+	token := "prom-scrape-token"
+	spi.SetPrometheusBearerToken(token)
+
+	pool := dockertest.NewPoolT(t, "")
+
+	target := strings.TrimPrefix(httpServerAddress, "http://")
+	config := fmt.Sprintf(`global:
+  scrape_interval: 1s
+  scrape_timeout: 1s
+
+scrape_configs:
+  - job_name: machbase-neo
+    metrics_path: /debug/metrics
+    static_configs:
+      - targets: ["host.docker.internal:%s"]
+    authorization:
+      type: Bearer
+      credentials: "%s"
+`, strings.Split(target, ":")[1], token)
+
+	configPath := filepath.Join(t.TempDir(), "prometheus.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o644))
+
+	repo, tag := test.PrometheusDockerImage.Resolve()
+	prom := pool.RunT(t, repo,
+		dockertest.WithTag(tag),
+		dockertest.WithMounts([]string{configPath + ":/etc/prometheus/prometheus.yml:ro"}),
+		dockertest.WithHostConfig(func(cfg *container.HostConfig) {
+			if runtime.GOOS == "linux" {
+				cfg.ExtraHosts = append(cfg.ExtraHosts, "host.docker.internal:host-gateway")
+			}
+		}),
+	)
+
+	for _, nw := range prom.Container.NetworkSettings.Networks {
+		if nw != nil && nw.IPAddress.IsValid() {
+			httpServer.statzAllowed = append(httpServer.statzAllowed, nw.IPAddress.String())
+			break
+		}
+	}
+
+	promURL := "http://" + prom.GetHostPort("9090/tcp")
+
+	err := pool.Retry(t.Context(), 90*time.Second, func() error {
+		rsp, err := http.Get(promURL + "/-/ready")
+		if err != nil {
+			return err
+		}
+		defer rsp.Body.Close()
+		if rsp.StatusCode != http.StatusOK {
+			return fmt.Errorf("prometheus not ready: %d", rsp.StatusCode)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = pool.Retry(t.Context(), 90*time.Second, func() error {
+		rsp, err := http.Get(promURL + "/api/v1/targets")
+		if err != nil {
+			return err
+		}
+		defer rsp.Body.Close()
+		body, err := io.ReadAll(rsp.Body)
+		if err != nil {
+			return err
+		}
+		var payload struct {
+			Status string `json:"status"`
+			Data   struct {
+				ActiveTargets []struct {
+					Health string `json:"health"`
+					Labels struct {
+						Job string `json:"job"`
+					} `json:"labels"`
+				} `json:"activeTargets"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return err
+		}
+		if payload.Status != "success" {
+			return fmt.Errorf("targets api failed: %s", string(body))
+		}
+		up := false
+		for _, target := range payload.Data.ActiveTargets {
+			if target.Labels.Job == "machbase-neo" && strings.EqualFold(target.Health, "up") {
+				up = true
+				break
+			}
+		}
+		if !up {
+			return fmt.Errorf("target is not up yet: %s", string(body))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = pool.Retry(t.Context(), 90*time.Second, func() error {
+		rsp, err := http.Get(promURL + "/api/v1/query?query=up%7Bjob%3D%22machbase-neo%22%7D")
+		if err != nil {
+			return err
+		}
+		defer rsp.Body.Close()
+		body, err := io.ReadAll(rsp.Body)
+		if err != nil {
+			return err
+		}
+		var payload struct {
+			Status string `json:"status"`
+			Data   struct {
+				Result []struct {
+					Value []any `json:"value"`
+				} `json:"result"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return err
+		}
+		if payload.Status != "success" {
+			return fmt.Errorf("query api failed: %s", string(body))
+		}
+		if len(payload.Data.Result) == 0 || len(payload.Data.Result[0].Value) < 2 {
+			return fmt.Errorf("up metric not scraped yet: %s", string(body))
+		}
+		if fmt.Sprint(payload.Data.Result[0].Value[1]) != "1" {
+			return fmt.Errorf("up metric not scraped yet: %s", string(body))
+		}
+		return nil
+	})
+	if err != nil {
+		if logs, logErr := prom.Logs(t.Context()); logErr == nil {
+			t.Logf("prometheus logs:\n%s", logs)
+		}
+	}
+	require.NoError(t, err)
 }
 
 func shellBridgeSqliteTest(t *testing.T) {

--- a/mods/server/svrconf.go
+++ b/mods/server/svrconf.go
@@ -138,6 +138,7 @@ type HttpConfig struct {
 	EnableTokenAuth bool
 	DebugMode       bool
 	AllowStatz      []string
+	StatzToken      string
 	QueryCypher     string // format: "alg=AES key=1234567890abcdef pad=pkcs5"
 	DebugLatency    string
 	WriteBufSize    int

--- a/mods/server/svrconf.hcl
+++ b/mods/server/svrconf.hcl
@@ -45,6 +45,7 @@ define VARS {
     HTTP_LINGER           = flag("--http-linger", -1)       // -1 means disable so_linger, >= 0 means set so_linger
     HTTP_KEEPALIVE        = flag("--http-keepalive", 0)     // 0 means disable, > 0 means enable and set_keepalive_period in seconds
     HTTP_ALLOW_STATZ      = flag("--http-allow-statz", "")  // allow statz for the given IP address
+    HTTP_STATZ_TOKEN      = flag("--http-statz-token", "")  // Bearer token for statz
     HTTP_QUERY_CYPHER     = flag("--http-query-cypher", "") // format: "alg=AES key=1234567890abcdef pad=pkcs5"
 
     MAX_POOL_SIZE         = flag("--max-pool-size", 0)
@@ -120,6 +121,7 @@ module "machbase.com/neo-server" {
             Linger           = VARS_HTTP_LINGER
             KeepAlive        = VARS_HTTP_KEEPALIVE
             AllowStatz       = ["${VARS_HTTP_ALLOW_STATZ}"]
+            StatzToken       = VARS_HTTP_STATZ_TOKEN
             QueryCypher      = VARS_HTTP_QUERY_CYPHER
         }
         Mqtt = {

--- a/mods/server/svrmetric.go
+++ b/mods/server/svrmetric.go
@@ -3,9 +3,18 @@ package server
 import (
 	"context"
 	"errors"
+	"expvar"
+	"fmt"
+	"os"
+	"runtime"
+	"slices"
 	"strings"
+	"time"
 
 	"github.com/machbase/neo-client/api"
+	mach "github.com/machbase/neo-engine/v8"
+	"github.com/machbase/neo-server/v8/jsh/viz"
+	"github.com/machbase/neo-server/v8/mods"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/tql"
 	"github.com/machbase/neo-server/v8/mods/util"
@@ -194,4 +203,180 @@ func collectTqlCacheStatz(g *metric.Gather) error {
 	g.Add("tql:cache:misses", float64(stat.Misses), metric.GaugeType(metric.UnitShort))
 	g.Add("tql:cache:items", float64(stat.Items), metric.GaugeType(metric.UnitShort))
 	return nil
+}
+
+var maxProcessors int32
+var pid int32
+var ver *mods.Version
+
+func (s *Server) getServerInfo() (*ServerInfoResponse, error) {
+	if maxProcessors == 0 {
+		maxProcessors = int32(runtime.GOMAXPROCS(-1))
+	}
+	if ver == nil {
+		ver = mods.GetVersion()
+	}
+	if pid == 0 {
+		pid = int32(os.Getpid())
+	}
+
+	rsp := &ServerInfoResponse{
+		Version: &Version{
+			Engine:         mach.LinkInfo(),
+			Major:          int32(ver.Major),
+			Minor:          int32(ver.Minor),
+			Patch:          int32(ver.Patch),
+			GitSHA:         ver.GitSHA,
+			BuildTimestamp: mods.BuildTimestamp(),
+			BuildCompiler:  mods.BuildCompiler(),
+		},
+		Runtime: &Runtime{
+			OS:             runtime.GOOS,
+			Arch:           runtime.GOARCH,
+			Pid:            pid,
+			UptimeInSecond: int64(time.Since(s.startupTime).Seconds()),
+			Processes:      maxProcessors,
+			Goroutines:     int32(runtime.NumGoroutine()),
+		},
+	}
+
+	mem := runtime.MemStats{}
+	runtime.ReadMemStats(&mem)
+	rsp.Runtime.Mem = map[string]uint64{
+		"sys":               mem.Sys,
+		"alloc":             mem.Alloc,
+		"total_alloc":       mem.TotalAlloc,
+		"lookups":           mem.Lookups,
+		"mallocs":           mem.Mallocs,
+		"frees":             mem.Frees,
+		"lives":             mem.Mallocs - mem.Frees,
+		"heap_alloc":        mem.HeapAlloc,
+		"heap_sys":          mem.HeapSys,
+		"heap_idle":         mem.HeapIdle,
+		"heap_in_use":       mem.HeapInuse,
+		"heap_released":     mem.HeapReleased,
+		"heap_objects":      mem.HeapObjects,
+		"stack_in_use":      mem.StackInuse,
+		"stack_sys":         mem.StackSys,
+		"mspan_in_use":      mem.MSpanInuse,
+		"mspan_sys":         mem.MSpanSys,
+		"mcache_in_use":     mem.MCacheInuse,
+		"mcache_sys":        mem.MCacheSys,
+		"buck_hash_sys":     mem.BuckHashSys,
+		"gc_sys":            mem.GCSys,
+		"other_sys":         mem.OtherSys,
+		"gc_next":           mem.NextGC,
+		"gc_last":           mem.LastGC,
+		"gc_pause_total_ns": mem.PauseTotalNs,
+	}
+	return rsp, nil
+}
+
+type ServerStatzResponse struct {
+	Statz []ServerStatz `json:"statz"`
+}
+
+type ServerStatz struct {
+	Name string    `json:"name"`
+	Spec *viz.Spec `json:"spec"`
+}
+
+func statzViz(names []string) (*ServerStatzResponse, error) {
+	v := spi.Visualizer()
+	ret := &ServerStatzResponse{}
+	for i, name := range names {
+		var metricNames []string
+		var fieldNames []string
+		if strings.Contains(name, "#") {
+			// support metric with tag, e.g. "cpu_usage#host=server1"
+			parts := strings.SplitN(name, "#", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			metricNames = append(metricNames, parts[0])
+			fieldNames = append(fieldNames, parts[1])
+		} else {
+			metricNames = append(metricNames, name)
+		}
+		c := metric.Chart{ID: fmt.Sprintf("chart_%d", i), MetricNames: metricNames, FieldNames: fieldNames}
+		v.AddChart(c)
+	}
+	for i := range names {
+		spec, err := v.Generate(fmt.Sprintf("chart_%d", i), 0)
+		if err != nil {
+			return nil, err
+		}
+		ret.Statz = append(ret.Statz, ServerStatz{Name: names[i], Spec: spec})
+	}
+	return ret, nil
+}
+
+func statzKeys(pattern []string) []string {
+	prefix := spi.MetricsPrefix()
+	if len(prefix) > 0 {
+		prefix = prefix + ":"
+	}
+	if len(pattern) == 0 {
+		pattern = []string{prefix + "*"}
+	} else {
+		for i, p := range pattern {
+			pattern[i] = prefix + p
+		}
+	}
+	filter := spi.QueryStatzFilter(pattern...)
+	keys := make([]string, 0)
+	expvar.Do(func(kv expvar.KeyValue) {
+		if ok, _ := filter(kv.Key); !ok {
+			return
+		}
+		if !strings.HasPrefix(kv.Key, prefix) {
+			return
+		}
+		keys = append(keys, strings.TrimPrefix(kv.Key, prefix))
+	})
+	slices.Sort(keys)
+	return keys
+}
+
+type StatzQueryResult struct {
+	Columns []string `json:"columns"`
+	Types   []string `json:"types"`
+	Rows    [][]any  `json:"rows"`
+}
+
+func statzQuery(maxRows int, pattern []string) (*StatzQueryResult, error) {
+	prefix := spi.MetricsPrefix()
+	if len(prefix) > 0 {
+		prefix = prefix + ":"
+	}
+	for i, p := range pattern {
+		pattern[i] = prefix + strings.ToLower(p)
+	}
+
+	statz := spi.QueryStatzRows(1*time.Minute, maxRows, spi.QueryStatzFilter(pattern...))
+	if statz.Err != nil {
+		return nil, statz.Err
+	}
+
+	ret := &StatzQueryResult{
+		Columns: make([]string, len(statz.Cols)+1),
+		Types:   make([]string, len(statz.Cols)+1),
+		Rows:    make([][]any, len(statz.Rows)),
+	}
+	ret.Columns[0] = "time"
+	ret.Types[0] = "datetime"
+	for i, c := range statz.Cols {
+		ret.Columns[i+1] = strings.TrimPrefix(c.Name, prefix)
+		if statz.ValueTypes[i] == "i" {
+			ret.Types[i+1] = "int64"
+		} else {
+			ret.Types[i+1] = c.Type.String()
+		}
+	}
+	for i, r := range statz.Rows {
+		ret.Rows[i] = make([]any, 0, len(r.Values)+1)
+		ret.Rows[i] = append(ret.Rows[i], r.Timestamp.Format(time.RFC3339))
+		ret.Rows[i] = append(ret.Rows[i], r.Values...)
+	}
+	return ret, nil
 }

--- a/mods/server/svrmgmt.go
+++ b/mods/server/svrmgmt.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"crypto"
 	"errors"
-	"expvar"
 	"fmt"
 	"os"
 	"regexp"
-	"runtime"
 	"runtime/debug"
-	"slices"
 	"strings"
 	"time"
 
@@ -26,11 +23,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/machbase/neo-client/api"
 	"github.com/machbase/neo-client/machgo"
-	mach "github.com/machbase/neo-engine/v8"
 	"github.com/machbase/neo-server/v8/booter"
-	"github.com/machbase/neo-server/v8/jsh/viz"
-	"github.com/machbase/neo-server/v8/mods"
-	"github.com/machbase/neo-server/v8/mods/util/metric"
 	"github.com/machbase/neo-server/v8/spi"
 	"github.com/machbase/neo-server/v8/spi/machsvr"
 	"golang.org/x/crypto/ssh"
@@ -931,180 +924,4 @@ func (s *Server) HttpDebugMode(ctx context.Context, req *HttpDebugModeRequest) (
 	rsp.Success = true
 	rsp.Reason = "success"
 	return rsp, nil
-}
-
-var maxProcessors int32
-var pid int32
-var ver *mods.Version
-
-func (s *Server) getServerInfo() (*ServerInfoResponse, error) {
-	if maxProcessors == 0 {
-		maxProcessors = int32(runtime.GOMAXPROCS(-1))
-	}
-	if ver == nil {
-		ver = mods.GetVersion()
-	}
-	if pid == 0 {
-		pid = int32(os.Getpid())
-	}
-
-	rsp := &ServerInfoResponse{
-		Version: &Version{
-			Engine:         mach.LinkInfo(),
-			Major:          int32(ver.Major),
-			Minor:          int32(ver.Minor),
-			Patch:          int32(ver.Patch),
-			GitSHA:         ver.GitSHA,
-			BuildTimestamp: mods.BuildTimestamp(),
-			BuildCompiler:  mods.BuildCompiler(),
-		},
-		Runtime: &Runtime{
-			OS:             runtime.GOOS,
-			Arch:           runtime.GOARCH,
-			Pid:            pid,
-			UptimeInSecond: int64(time.Since(s.startupTime).Seconds()),
-			Processes:      maxProcessors,
-			Goroutines:     int32(runtime.NumGoroutine()),
-		},
-	}
-
-	mem := runtime.MemStats{}
-	runtime.ReadMemStats(&mem)
-	rsp.Runtime.Mem = map[string]uint64{
-		"sys":               mem.Sys,
-		"alloc":             mem.Alloc,
-		"total_alloc":       mem.TotalAlloc,
-		"lookups":           mem.Lookups,
-		"mallocs":           mem.Mallocs,
-		"frees":             mem.Frees,
-		"lives":             mem.Mallocs - mem.Frees,
-		"heap_alloc":        mem.HeapAlloc,
-		"heap_sys":          mem.HeapSys,
-		"heap_idle":         mem.HeapIdle,
-		"heap_in_use":       mem.HeapInuse,
-		"heap_released":     mem.HeapReleased,
-		"heap_objects":      mem.HeapObjects,
-		"stack_in_use":      mem.StackInuse,
-		"stack_sys":         mem.StackSys,
-		"mspan_in_use":      mem.MSpanInuse,
-		"mspan_sys":         mem.MSpanSys,
-		"mcache_in_use":     mem.MCacheInuse,
-		"mcache_sys":        mem.MCacheSys,
-		"buck_hash_sys":     mem.BuckHashSys,
-		"gc_sys":            mem.GCSys,
-		"other_sys":         mem.OtherSys,
-		"gc_next":           mem.NextGC,
-		"gc_last":           mem.LastGC,
-		"gc_pause_total_ns": mem.PauseTotalNs,
-	}
-	return rsp, nil
-}
-
-type ServerStatzResponse struct {
-	Statz []ServerStatz `json:"statz"`
-}
-
-type ServerStatz struct {
-	Name string    `json:"name"`
-	Spec *viz.Spec `json:"spec"`
-}
-
-func statzViz(names []string) (*ServerStatzResponse, error) {
-	v := spi.Visualizer()
-	ret := &ServerStatzResponse{}
-	for i, name := range names {
-		var metricNames []string
-		var fieldNames []string
-		if strings.Contains(name, "#") {
-			// support metric with tag, e.g. "cpu_usage#host=server1"
-			parts := strings.SplitN(name, "#", 2)
-			if len(parts) != 2 {
-				continue
-			}
-			metricNames = append(metricNames, parts[0])
-			fieldNames = append(fieldNames, parts[1])
-		} else {
-			metricNames = append(metricNames, name)
-		}
-		c := metric.Chart{ID: fmt.Sprintf("chart_%d", i), MetricNames: metricNames, FieldNames: fieldNames}
-		v.AddChart(c)
-	}
-	for i := range names {
-		spec, err := v.Generate(fmt.Sprintf("chart_%d", i), 0)
-		if err != nil {
-			return nil, err
-		}
-		ret.Statz = append(ret.Statz, ServerStatz{Name: names[i], Spec: spec})
-	}
-	return ret, nil
-}
-
-func statzKeys(pattern []string) []string {
-	prefix := spi.MetricsPrefix()
-	if len(prefix) > 0 {
-		prefix = prefix + ":"
-	}
-	if len(pattern) == 0 {
-		pattern = []string{prefix + "*"}
-	} else {
-		for i, p := range pattern {
-			pattern[i] = prefix + p
-		}
-	}
-	filter := spi.QueryStatzFilter(pattern...)
-	keys := make([]string, 0)
-	expvar.Do(func(kv expvar.KeyValue) {
-		if ok, _ := filter(kv.Key); !ok {
-			return
-		}
-		if !strings.HasPrefix(kv.Key, prefix) {
-			return
-		}
-		keys = append(keys, strings.TrimPrefix(kv.Key, prefix))
-	})
-	slices.Sort(keys)
-	return keys
-}
-
-type StatzQueryResult struct {
-	Columns []string `json:"columns"`
-	Types   []string `json:"types"`
-	Rows    [][]any  `json:"rows"`
-}
-
-func statzQuery(maxRows int, pattern []string) (*StatzQueryResult, error) {
-	prefix := spi.MetricsPrefix()
-	if len(prefix) > 0 {
-		prefix = prefix + ":"
-	}
-	for i, p := range pattern {
-		pattern[i] = prefix + strings.ToLower(p)
-	}
-
-	statz := spi.QueryStatzRows(1*time.Minute, maxRows, spi.QueryStatzFilter(pattern...))
-	if statz.Err != nil {
-		return nil, statz.Err
-	}
-
-	ret := &StatzQueryResult{
-		Columns: make([]string, len(statz.Cols)+1),
-		Types:   make([]string, len(statz.Cols)+1),
-		Rows:    make([][]any, len(statz.Rows)),
-	}
-	ret.Columns[0] = "time"
-	ret.Types[0] = "datetime"
-	for i, c := range statz.Cols {
-		ret.Columns[i+1] = strings.TrimPrefix(c.Name, prefix)
-		if statz.ValueTypes[i] == "i" {
-			ret.Types[i+1] = "int64"
-		} else {
-			ret.Types[i+1] = c.Type.String()
-		}
-	}
-	for i, r := range statz.Rows {
-		ret.Rows[i] = make([]any, 0, len(r.Values)+1)
-		ret.Rows[i] = append(ret.Rows[i], r.Timestamp.Format(time.RFC3339))
-		ret.Rows[i] = append(ret.Rows[i], r.Values...)
-	}
-	return ret, nil
 }

--- a/spi/metrics.go
+++ b/spi/metrics.go
@@ -191,6 +191,7 @@ func QueryStatzRows(interval time.Duration, rowsCount int, filter func(key strin
 var collector *metric.Collector
 var prefix string = "machbase"
 var metricsDest string
+var prometheusBearerToken string
 
 const SERIES_ID_FINEST = "METRIC_2H"
 const SERIES_ID_FINE = "METRIC_2D12H"
@@ -230,6 +231,14 @@ func MetricsPrefix() string {
 
 func MetricsDestTable() string {
 	return metricsDest
+}
+
+func PrometheusBearerToken() string {
+	return prometheusBearerToken
+}
+
+func SetPrometheusBearerToken(token string) {
+	prometheusBearerToken = strings.TrimSpace(token)
 }
 
 func SetMetricsDestTable(destTable string) error {
@@ -506,6 +515,144 @@ func HandleStatz(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewEncoder(w).Encode(ret); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
+	}
+}
+
+func HandlePrometheusMetrics(w http.ResponseWriter, r *http.Request) {
+	if !allowPrometheusRequest(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	includes := r.URL.Query()["keys"]
+	interval := r.URL.Query().Get("interval")
+	if interval == "" {
+		interval = "1m"
+	}
+	dur, err := time.ParseDuration(interval)
+	if err != nil {
+		dur = time.Minute
+	}
+
+	stat := QueryStatzRows(dur, 1, func(key string) (bool, int) {
+		return strings.HasPrefix(key, "machbase:") || slices.Contains(includes, key), 0
+	})
+	if stat.Err != nil {
+		http.Error(w, stat.Err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var sb strings.Builder
+	seen := map[string]struct{}{}
+	tsMillis := stat.Rows[0].Timestamp.UnixMilli()
+
+	for idx, col := range stat.Cols {
+		value := stat.Rows[0].Values[idx]
+		if value == nil {
+			continue
+		}
+		metricName := sanitizePromMetricName(col.Name)
+		metricValue, ok := toPromFloat(value)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[metricName]; !exists {
+			metricType := inferPromMetricType(metricName)
+			sb.WriteString("# HELP ")
+			sb.WriteString(metricName)
+			sb.WriteString(" Metric exported from machbase statz\n")
+			sb.WriteString("# TYPE ")
+			sb.WriteString(metricName)
+			sb.WriteByte(' ')
+			sb.WriteString(metricType)
+			sb.WriteByte('\n')
+			seen[metricName] = struct{}{}
+		}
+		sb.WriteString(metricName)
+		sb.WriteByte(' ')
+		sb.WriteString(fmt.Sprintf("%v", metricValue))
+		sb.WriteByte(' ')
+		sb.WriteString(fmt.Sprintf("%d", tsMillis))
+		sb.WriteByte('\n')
+	}
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = w.Write([]byte(sb.String()))
+}
+
+func allowPrometheusRequest(r *http.Request) bool {
+	token := strings.TrimSpace(prometheusBearerToken)
+	if token == "" {
+		return true
+	}
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	parts := strings.Fields(auth)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return false
+	}
+	return parts[1] == token
+}
+
+func sanitizePromMetricName(name string) string {
+	if name == "" {
+		return "neo_metric"
+	}
+	var sb strings.Builder
+	sb.Grow(len(name) + 4)
+	for i, r := range name {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+		if valid {
+			if i == 0 && r >= '0' && r <= '9' {
+				sb.WriteString("neo_")
+			}
+			sb.WriteRune(r)
+		} else {
+			sb.WriteByte('_')
+		}
+	}
+	ret := strings.Trim(sb.String(), "_")
+	if ret == "" {
+		return "neo_metric"
+	}
+	return strings.TrimPrefix(ret, "machbase_")
+}
+
+func inferPromMetricType(metricName string) string {
+	name := strings.ToLower(metricName)
+	if strings.HasSuffix(name, "_total") || strings.HasSuffix(name, "_count") || strings.Contains(name, "_bytes") {
+		return "counter"
+	}
+	return "gauge"
+}
+
+func toPromFloat(v any) (float64, bool) {
+	switch x := v.(type) {
+	case float64:
+		return x, true
+	case float32:
+		return float64(x), true
+	case int:
+		return float64(x), true
+	case int8:
+		return float64(x), true
+	case int16:
+		return float64(x), true
+	case int32:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case uint:
+		return float64(x), true
+	case uint8:
+		return float64(x), true
+	case uint16:
+		return float64(x), true
+	case uint32:
+		return float64(x), true
+	case uint64:
+		return float64(x), true
+	default:
+		return 0, false
 	}
 }
 

--- a/spi/metrics_test.go
+++ b/spi/metrics_test.go
@@ -46,6 +46,147 @@ func TestHandleStatz(t *testing.T) {
 	})
 }
 
+func TestHandlePrometheusMetrics(t *testing.T) {
+	metricKey := "machbase:test:" + uuid.Must(uuid.NewV4()).String()
+	metricValue := expvar.NewInt(metricKey)
+	metricValue.Set(42)
+
+	prevToken := PrometheusBearerToken()
+	t.Cleanup(func() {
+		SetPrometheusBearerToken(prevToken)
+	})
+
+	t.Run("exports prometheus text format", func(t *testing.T) {
+		SetPrometheusBearerToken("")
+		req := httptest.NewRequest(http.MethodGet, "/debug/metrics?interval=not-a-duration&keys="+url.QueryEscape(metricKey), nil)
+		writer := httptest.NewRecorder()
+
+		HandlePrometheusMetrics(writer, req)
+
+		require.Equal(t, http.StatusOK, writer.Code)
+		require.Contains(t, writer.Header().Get("Content-Type"), "text/plain")
+		require.Contains(t, writer.Body.String(), "# HELP test_")
+		require.Contains(t, writer.Body.String(), "# TYPE test_")
+		require.Contains(t, writer.Body.String(), "42")
+	})
+
+	t.Run("enforces bearer token when configured", func(t *testing.T) {
+		SetPrometheusBearerToken("prom-token")
+
+		t.Run("without token", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/debug/metrics?keys="+url.QueryEscape(metricKey), nil)
+			writer := httptest.NewRecorder()
+
+			HandlePrometheusMetrics(writer, req)
+
+			require.Equal(t, http.StatusUnauthorized, writer.Code)
+		})
+
+		t.Run("with wrong token", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/debug/metrics?keys="+url.QueryEscape(metricKey), nil)
+			req.Header.Set("Authorization", "Bearer wrong-token")
+			writer := httptest.NewRecorder()
+
+			HandlePrometheusMetrics(writer, req)
+
+			require.Equal(t, http.StatusUnauthorized, writer.Code)
+		})
+
+		t.Run("with matching token", func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/debug/metrics?keys="+url.QueryEscape(metricKey), nil)
+			req.Header.Set("Authorization", "Bearer prom-token")
+			writer := httptest.NewRecorder()
+
+			HandlePrometheusMetrics(writer, req)
+
+			require.Equal(t, http.StatusOK, writer.Code)
+			require.Contains(t, writer.Body.String(), "test_")
+		})
+	})
+}
+
+func TestPrometheusHelperFunctions(t *testing.T) {
+	t.Run("sanitizePromMetricName", func(t *testing.T) {
+		require.Equal(t, "neo_metric", sanitizePromMetricName(""))
+		require.Equal(t, "neo_1abc", sanitizePromMetricName("1abc"))
+		require.Equal(t, "cpu_usage", sanitizePromMetricName("machbase:cpu-usage"))
+		require.Equal(t, "neo_metric", sanitizePromMetricName("!!!"))
+	})
+
+	t.Run("inferPromMetricType", func(t *testing.T) {
+		require.Equal(t, "counter", inferPromMetricType("request_total"))
+		require.Equal(t, "counter", inferPromMetricType("request_count"))
+		require.Equal(t, "counter", inferPromMetricType("recv_bytes"))
+		require.Equal(t, "gauge", inferPromMetricType("cpu_usage"))
+	})
+
+	t.Run("toPromFloat", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			input   any
+			value   float64
+			success bool
+		}{
+			{name: "float64", input: float64(1.25), value: 1.25, success: true},
+			{name: "float32", input: float32(1.5), value: 1.5, success: true},
+			{name: "int", input: int(3), value: 3, success: true},
+			{name: "int8", input: int8(-8), value: -8, success: true},
+			{name: "int16", input: int16(-16), value: -16, success: true},
+			{name: "int32", input: int32(7), value: 7, success: true},
+			{name: "int64", input: int64(64), value: 64, success: true},
+			{name: "uint", input: uint(4), value: 4, success: true},
+			{name: "uint8", input: uint8(8), value: 8, success: true},
+			{name: "uint16", input: uint16(16), value: 16, success: true},
+			{name: "uint32", input: uint32(32), value: 32, success: true},
+			{name: "uint64", input: uint64(9), value: 9, success: true},
+			{name: "string", input: "not-number", value: 0, success: false},
+			{name: "struct", input: struct{ N int }{N: 1}, value: 0, success: false},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				f, ok := toPromFloat(tc.input)
+				require.Equal(t, tc.success, ok)
+				if tc.success {
+					require.Equal(t, tc.value, f)
+				}
+			})
+		}
+	})
+}
+
+func TestAllowPrometheusRequest(t *testing.T) {
+	prevToken := PrometheusBearerToken()
+	t.Cleanup(func() {
+		SetPrometheusBearerToken(prevToken)
+	})
+
+	t.Run("no token configured", func(t *testing.T) {
+		SetPrometheusBearerToken("")
+		req := httptest.NewRequest(http.MethodGet, "/debug/metrics", nil)
+		require.True(t, allowPrometheusRequest(req))
+	})
+
+	t.Run("token configured", func(t *testing.T) {
+		SetPrometheusBearerToken("token-123")
+
+		reqNoHeader := httptest.NewRequest(http.MethodGet, "/debug/metrics", nil)
+		require.False(t, allowPrometheusRequest(reqNoHeader))
+
+		reqWrong := httptest.NewRequest(http.MethodGet, "/debug/metrics", nil)
+		reqWrong.Header.Set("Authorization", "Bearer wrong")
+		require.False(t, allowPrometheusRequest(reqWrong))
+
+		reqCaseInsensitive := httptest.NewRequest(http.MethodGet, "/debug/metrics", nil)
+		reqCaseInsensitive.Header.Set("Authorization", "bearer token-123")
+		require.True(t, allowPrometheusRequest(reqCaseInsensitive))
+
+		reqMalformed := httptest.NewRequest(http.MethodGet, "/debug/metrics", nil)
+		reqMalformed.Header.Set("Authorization", "Bearer")
+		require.False(t, allowPrometheusRequest(reqMalformed))
+	})
+}
+
 func TestVizSpecGenerator(t *testing.T) {
 	seriesID := mustSeriesID(t, "CPU_USAGE", "CPU Usage", time.Second, 8)
 	collector := metric.NewCollector(

--- a/test/dockertest.go
+++ b/test/dockertest.go
@@ -51,6 +51,12 @@ var (
 		DefaultRepository: "nats",
 		DefaultTag:        "2.12",
 	}
+	PrometheusDockerImage = DockerImageConfig{
+		RepositoryEnvVar:  "TEST_PROMETHEUS_IMAGE_REPOSITORY",
+		TagEnvVar:         "TEST_PROMETHEUS_IMAGE_TAG",
+		DefaultRepository: "prom/prometheus",
+		DefaultTag:        "v2.53.0",
+	}
 )
 
 func SupportDockerTest() bool {


### PR DESCRIPTION
This pull request adds support for securing the Prometheus metrics endpoint with a configurable Bearer token and refactors the server metrics/statistics logic for improved maintainability. It introduces new configuration options, enhances test coverage for metrics access control, and moves statz (statistics/metrics) logic from `svrmgmt.go` to `svrmetric.go` for better separation of concerns.

**Prometheus Metrics Endpoint Security:**

- Added a `StatzToken` field to the HTTP server configuration (`HttpConfig`), allowing the `/debug/metrics` endpoint to require a Bearer token for access. The token can be set via configuration or command-line flag (`--http-statz-token`). (`[[1]](diffhunk://#diff-4159ca721f8f52bc0b46af50eba89f18220f2cd10757ecd9e8458e7d81fc20a7R141)`, `[[2]](diffhunk://#diff-9052a646e608b8dab7a4b1322be29d4606ddd1fcdf2aeabf2b3055e2e90514deR48)`, `[[3]](diffhunk://#diff-9052a646e608b8dab7a4b1322be29d4606ddd1fcdf2aeabf2b3055e2e90514deR124)`, `[[4]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR108)`, `[[5]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdR921)`)
- Updated the HTTP server startup and router logic to support and enforce the Bearer token on the `/debug/metrics` endpoint. (`[[1]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR138-R141)`, `[[2]](diffhunk://#diff-d8dfafcae5db129b8850ea0c8c290775bb3b49780da4388cee2f95590192625eR374)`, `[[3]](diffhunk://#diff-a4b781b74bdaa5caad6eb5dfe8235bbc36f99df37b2f427fab5d13820655dbb6R159-R164)`)

**Server Metrics/Statz Refactoring:**

- Moved statz-related logic (server info, statz querying, visualization, etc.) from `svrmgmt.go` to a new section in `svrmetric.go`, improving code organization and maintainability. (`[[1]](diffhunk://#diff-d525fde897d7e0cab825fd599cb4533404f3410097040abb6b120f6450cfdafbR207-R382)`, `[[2]](diffhunk://#diff-7ed17c3c1d52885fcb5de8e5f9b9bf95ea819b1ad5c54a09fd6570a0ee5cabf1L935-L1110)`, `[[3]](diffhunk://#diff-7ed17c3c1d52885fcb5de8e5f9b9bf95ea819b1ad5c54a09fd6570a0ee5cabf1L7-L13)`, `[[4]](diffhunk://#diff-7ed17c3c1d52885fcb5de8e5f9b9bf95ea819b1ad5c54a09fd6570a0ee5cabf1L29-L33)`)

**Testing and Validation:**

- Added comprehensive tests for the `/debug/metrics` endpoint, verifying correct behavior with and without the Bearer token, and ensuring remote access controls are enforced. (`[mods/server/http_test.goR66-R142](diffhunk://#diff-b19e214509fd4578d9238c3d67e3007e1ab38a34faf8032652c23887f06f54cbR66-R142)`)
- Added an integration test using Docker to verify Prometheus can successfully scrape metrics using the configured Bearer token. (`[[1]](diffhunk://#diff-85f01ad6de36ebcc7dab3bb85acf3c0713452172648770c6833215310a689a55R847-R995)`, `[[2]](diffhunk://#diff-85f01ad6de36ebcc7dab3bb85acf3c0713452172648770c6833215310a689a55R31)`)

**API and Option Improvements:**

- Introduced a new `WithHttpStatzToken` option for programmatically setting the statz token in server setup. (`[mods/server/http_opts.goR159-R164](diffhunk://#diff-a4b781b74bdaa5caad6eb5dfe8235bbc36f99df37b2f427fab5d13820655dbb6R159-R164)`)

These changes enhance the security and flexibility of the server's metrics endpoints and improve the clarity and testability of the statz/metrics subsystem.