### PR TITLE
Enhance: SQL() can be SRC, MAP and SINK in TQL

### DIFF
--- a/docs/jsonrpc.gen.md
+++ b/docs/jsonrpc.gen.md
@@ -2071,6 +2071,59 @@ setHttpDebug updates and returns HTTP debug settings.
 
 </details>
 
+#### http.split
+
+splitHttpStatements splits HTTP script text into executable statements.
+It parses multiple HTTP statements from the given content, each statement is separated by at least three continuous '#' characters.
+
+`http.split(content)`
+
+*Params*
+- `content` *string* - HTTP script text
+
+*Return*
+
+- `array<object<util.HttpStatement>>|error - parsed HTTP statements array, each statement contains the following fields:`
+  - `text`: the original HTTP statement text
+  - `beginLine`: the line number where the statement starts
+  - `endLine`: the line number where the statement ends
+
+<details>
+<summary>Request/Response JSON</summary>
+
+*Request*
+
+```json
+{
+    "type": "rpc_req",
+    "session": "client-session-#1",
+    "rpc": {
+        "jsonrpc": "2.0",
+        "id": 20,
+        "method": "http.split",
+        "params": [
+            "string"
+        ]
+    }
+}
+```
+
+*Response*
+
+```json
+{
+    "type": "rpc_rsp",
+    "session": "client-session-#1",
+    "rpc": {
+        "jsonrpc": "2.0",
+        "id": 20,
+        "result": []
+    }
+}
+```
+
+</details>
+
 
 ### Session
 
@@ -2339,7 +2392,14 @@ splitSqlStatements splits SQL text into executable statements.
 
 *Return*
 
-- `array<object<util.SqlStatement>>|error - parsed SQL statements`
+- `array<object<util.SqlStatement>>|error - parsed SQL statements array, each statement contains the following fields:`
+  - `text`: the original SQL statement text
+  - `beginLine`: the line number where the statement starts
+  - `endLine`: the line number where the statement ends
+  - `isComment`: whether the statement is a comment
+  - `env`: scoped environment, if any, for the statement; it MAY contain the following fields:
+  - `env.error`: error message if the statement has an error
+  - `env.bridge`: bridge name if the statement is executed in a bridge context
 
 <details>
 <summary>Request/Response JSON</summary>

--- a/mods/tql/fm_context.go
+++ b/mods/tql/fm_context.go
@@ -14,6 +14,10 @@ type NodeContext struct {
 	node *Node
 }
 
+type recordValueRef struct {
+	index int
+}
+
 // tql function: context()
 func (node *Node) GetContext() *NodeContext {
 	return &NodeContext{
@@ -33,28 +37,25 @@ func (node *Node) GetRecordKey() any {
 // tql function: value()
 func (node *Node) GetRecordValue(args ...any) (any, error) {
 	inflight := node.Inflight()
-	if inflight == nil || inflight.value == nil {
+	if inflight == nil {
+		if len(args) == 0 {
+			return nil, nil
+		}
+		idx, err := parseRecordValueIndex(args[0])
+		if err != nil {
+			return nil, err
+		}
+		return &recordValueRef{index: idx}, nil
+	}
+	if inflight.value == nil {
 		return nil, nil
 	}
 	if len(args) == 0 {
 		return inflight.value, nil
 	}
-	idx := 0
-	switch v := args[0].(type) {
-	case int:
-		idx = v
-	case float32:
-		idx = int(v)
-	case float64:
-		idx = int(v)
-	case string:
-		if parsed, err := strconv.ParseInt(v, 10, 32); err != nil {
-			return nil, err
-		} else {
-			idx = int(parsed)
-		}
-	default:
-		return nil, ErrWrongTypeOfArgs("value", 0, "index of value tuple ", v)
+	idx, err := parseRecordValueIndex(args[0])
+	if err != nil {
+		return nil, err
 	}
 	switch val := inflight.value.(type) {
 	case []any:
@@ -70,6 +71,25 @@ func (node *Node) GetRecordValue(args ...any) (any, error) {
 		}
 	default:
 		return nil, ErrArgs("value", 0, "out of index value tuple in "+node.Name())
+	}
+}
+
+func parseRecordValueIndex(arg any) (int, error) {
+	switch v := arg.(type) {
+	case int:
+		return v, nil
+	case float32:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	case string:
+		if parsed, err := strconv.ParseInt(v, 10, 32); err != nil {
+			return 0, err
+		} else {
+			return int(parsed), nil
+		}
+	default:
+		return 0, ErrWrongTypeOfArgs("value", 0, "index of value tuple ", v)
 	}
 }
 

--- a/mods/tql/fm_dbsink.go
+++ b/mods/tql/fm_dbsink.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/machbase/neo-client/api"
 	"github.com/machbase/neo-server/v8/mods/bridge"
+	"github.com/machbase/neo-server/v8/mods/bridge/connector"
 	"github.com/machbase/neo-server/v8/spi"
 )
 
@@ -250,4 +251,174 @@ func (app *appender) AddRow(values []any) error {
 		app.nrows++
 	}
 	return err
+}
+
+func (x *Node) fmSqlSink(args ...any) (*sqlSink, error) {
+	if len(args) == 0 {
+		return nil, ErrInvalidNumOfArgs("SQL", 1, 0)
+	}
+
+	ret := &sqlSink{node: x}
+	var paramStart int
+
+	switch v := args[0].(type) {
+	case string:
+		ret.databaseProvider = func(ctx context.Context) (api.Conn, error) {
+			return x.task.ConnDatabase(ctx)
+		}
+		ret.sqlText = strings.TrimSuffix(strings.TrimSpace(v), ";")
+		paramStart = 1
+	case *bridgeName:
+		ret.databaseProvider = func(ctx context.Context) (api.Conn, error) {
+			db, err := connector.New(v.name)
+			if err != nil {
+				return nil, err
+			}
+			return db.Connect(ctx)
+		}
+		if len(args) < 2 {
+			return nil, ErrInvalidNumOfArgs("SQL", 2, len(args))
+		}
+		sqlText, ok := args[1].(string)
+		if !ok {
+			return nil, ErrWrongTypeOfArgs("SQL", 1, "sql text", args[1])
+		}
+		ret.sqlText = strings.TrimSuffix(strings.TrimSpace(sqlText), ";")
+		paramStart = 2
+	default:
+		return nil, ErrWrongTypeOfArgs("SQL", 0, "sql text or bridge('name')", args[0])
+	}
+
+	if len(ret.sqlText) == 0 {
+		return nil, fmt.Errorf("f(SQL) Empty SQL text")
+	}
+	ret.stmtType = spi.DetectSQLStatementType(ret.sqlText)
+	if err := validateSqlVerbForSink(ret.sqlText); err != nil {
+		return nil, err
+	}
+
+	ret.rawParams = make([]any, 0, len(args)-paramStart)
+	for i := paramStart; i < len(args); i++ {
+		ret.rawParams = append(ret.rawParams, args[i])
+	}
+	return ret, nil
+}
+
+type sqlSink struct {
+	node             *Node
+	databaseProvider func(ctx context.Context) (api.Conn, error)
+	sqlText          string
+	stmtType         spi.SQLStatementType
+	rawParams        []any
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+	conn      api.Conn
+
+	affectedRows int64
+	resultMsg    string
+}
+
+func (s *sqlSink) Open(task *Task) error {
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+	conn, err := s.databaseProvider(s.ctx)
+	if err != nil {
+		return err
+	}
+	s.conn = conn
+	return nil
+}
+
+func (s *sqlSink) Close() (string, error) {
+	if s.conn != nil {
+		s.conn.Close()
+	}
+	if s.ctxCancel != nil {
+		s.ctxCancel()
+	}
+	if s.affectedRows > 0 {
+		return formatSqlSinkMessage(s.stmtType, s.affectedRows), nil
+	}
+	if s.resultMsg != "" {
+		return s.resultMsg, nil
+	}
+	return "0 rows affected.", nil
+}
+
+func (s *sqlSink) AddRow(values []any) error {
+	params := make([]any, 0, len(s.rawParams))
+	for _, p := range s.rawParams {
+		switch v := p.(type) {
+		case *recordValueRef:
+			if v == nil {
+				params = append(params, nil)
+				continue
+			}
+			if v.index < 0 || v.index >= len(values) {
+				return fmt.Errorf("f(SQL) value(%d) is out of range of input tuple(len:%d)", v.index, len(values))
+			}
+			params = append(params, values[v.index])
+		default:
+			params = append(params, p)
+		}
+	}
+	result := s.conn.Exec(s.ctx, s.sqlText, params...)
+	if err := result.Err(); err != nil {
+		return err
+	}
+	s.resultMsg = result.Message()
+	if n, ok := parseRowsAffectedFromMessage(s.resultMsg); ok {
+		s.affectedRows += n
+	} else {
+		s.affectedRows++
+	}
+	return nil
+}
+
+func validateSqlVerbForSink(sqlText string) error {
+	stmtType := spi.DetectSQLStatementType(sqlText)
+	if stmtType.IsFetch() {
+		verb := strings.ToUpper(strings.Fields(sqlText)[0])
+		return fmt.Errorf("f(SQL) sink does not allow fetch verb %q", verb)
+	}
+	return nil
+}
+
+func formatSqlSinkMessage(stmtType spi.SQLStatementType, rows int64) string {
+	unit := "rows"
+	if rows == 1 {
+		unit = "row"
+	}
+	switch stmtType {
+	case spi.SQLStatementTypeInsert:
+		return fmt.Sprintf("%d %s inserted.", rows, unit)
+	case spi.SQLStatementTypeUpdate:
+		return fmt.Sprintf("%d %s updated.", rows, unit)
+	case spi.SQLStatementTypeDelete:
+		return fmt.Sprintf("%d %s deleted.", rows, unit)
+	default:
+		return fmt.Sprintf("%d %s affected.", rows, unit)
+	}
+}
+
+func parseRowsAffectedFromMessage(msg string) (int64, bool) {
+	trimmed := strings.TrimSpace(strings.ToLower(msg))
+	if trimmed == "" {
+		return 0, false
+	}
+	if strings.HasPrefix(trimmed, "a row ") {
+		return 1, true
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) < 3 {
+		return 0, false
+	}
+	if fields[1] != "row" && fields[1] != "rows" {
+		return 0, false
+	}
+	var n int64
+	if _, err := fmt.Sscan(fields[0], &n); err != nil {
+		return 0, false
+	}
+	return n, true
 }

--- a/mods/tql/fm_dbsink_sql_test.go
+++ b/mods/tql/fm_dbsink_sql_test.go
@@ -1,0 +1,40 @@
+package tql
+
+import (
+	"testing"
+
+	"github.com/machbase/neo-server/v8/spi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSqlVerbForSink(t *testing.T) {
+	require.NoError(t, validateSqlVerbForSink("insert into t values(1)"))
+	require.NoError(t, validateSqlVerbForSink("update t set v = 1"))
+	require.NoError(t, validateSqlVerbForSink("delete from t"))
+	require.NoError(t, validateSqlVerbForSink("show tables"))
+
+	err := validateSqlVerbForSink("select * from t")
+	require.Error(t, err)
+	require.Equal(t, `f(SQL) sink does not allow fetch verb "SELECT"`, err.Error())
+}
+
+func TestFormatSqlSinkMessage(t *testing.T) {
+	require.Equal(t, "2 rows inserted.", formatSqlSinkMessage(spi.SQLStatementTypeInsert, 2))
+	require.Equal(t, "1 row updated.", formatSqlSinkMessage(spi.SQLStatementTypeUpdate, 1))
+	require.Equal(t, "3 rows deleted.", formatSqlSinkMessage(spi.SQLStatementTypeDelete, 3))
+	require.Equal(t, "4 rows affected.", formatSqlSinkMessage(spi.SQLStatementTypeCreate, 4))
+}
+
+func TestParseRowsAffectedFromMessage(t *testing.T) {
+	n, ok := parseRowsAffectedFromMessage("2 rows inserted.")
+	require.True(t, ok)
+	require.EqualValues(t, 2, n)
+
+	n, ok = parseRowsAffectedFromMessage("a row updated.")
+	require.True(t, ok)
+	require.EqualValues(t, 1, n)
+
+	n, ok = parseRowsAffectedFromMessage("Created successfully.")
+	require.False(t, ok)
+	require.EqualValues(t, 0, n)
+}

--- a/mods/tql/fm_dbsrc.go
+++ b/mods/tql/fm_dbsrc.go
@@ -291,6 +291,10 @@ func (dc *DataGenMachbase) gen(node *Node) {
 // SQL('select ....', arg1, arg2)
 // SQL(bridge('sqlite'), 'SELECT * ...', arg1, arg2)
 func (x *Node) fmSql(args ...any) (any, error) {
+	if x.Inflight() == nil {
+		return x.fmSqlSink(args...)
+	}
+
 	if len(args) == 0 {
 		return nil, ErrInvalidNumOfArgs("SQL", 1, 0)
 	}

--- a/mods/tql/func_test.go
+++ b/mods/tql/func_test.go
@@ -37,6 +37,10 @@ func TestStatementKindByFunctionName(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, tql.StatementSourceOrSink, kind)
 
+	kind, ok = tql.StatementKindByFunctionName("SQL()")
+	require.True(t, ok)
+	require.Equal(t, tql.StatementSourceOrMapOrSink, kind)
+
 	kind, ok = tql.StatementKindByFunctionName("customMap")
 	require.True(t, ok)
 	require.Equal(t, tql.StatementMap, kind)

--- a/mods/tql/fx_definitions.go
+++ b/mods/tql/fx_definitions.go
@@ -14,7 +14,7 @@ type Definition struct {
 }
 
 var fxStatementKinds = map[string]StatementKind{
-	"SQL":             StatementSource,
+	"SQL":             StatementSourceOrMapOrSink,
 	"SQL_SELECT":      StatementSource,
 	"QUERY":           StatementSource,
 	"FAKE":            StatementSource,

--- a/mods/tql/script_parser_test.go
+++ b/mods/tql/script_parser_test.go
@@ -60,7 +60,7 @@ func TestValidateScriptStructureInvalidSource(t *testing.T) {
 }
 
 func TestValidateScriptStructureInvalidMap(t *testing.T) {
-	script, err := ParseScript("FAKE(json({[1]}))\nSQL(`select 1`)\nCSV()", nil)
+	script, err := ParseScript("FAKE(json({[1]}))\nINSERT(table('example'))\nCSV()", nil)
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}

--- a/mods/tql/script_parser_test.go
+++ b/mods/tql/script_parser_test.go
@@ -77,6 +77,16 @@ func TestValidateScriptStructureInvalidMap(t *testing.T) {
 	}
 }
 
+func TestValidateScriptStructureSqlAsMapAndSink(t *testing.T) {
+	script, err := ParseScript("FAKE(json({[1]}))\nSQL('select 1')\nSQL('insert into example values(1)')", nil)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if err := ValidateScriptStructure(script); err != nil {
+		t.Fatalf("unexpected validation error: %v", err)
+	}
+}
+
 func TestParseScriptKeepsCommentAndPragmaStatements(t *testing.T) {
 	script, err := ParseScript("FAKE(json({[1]}))\n//+ stateful\n// comment\nCSV()", nil)
 	if err != nil {

--- a/mods/tql/script_types.go
+++ b/mods/tql/script_types.go
@@ -13,6 +13,7 @@ const (
 	StatementSink
 	StatementSourceOrMap
 	StatementSourceOrSink
+	StatementSourceOrMapOrSink
 )
 
 type TQLScript struct {

--- a/mods/tql/script_validate.go
+++ b/mods/tql/script_validate.go
@@ -42,7 +42,7 @@ func ValidateScriptStructure(script *TQLScript) error {
 
 func isApplicableForSource(kind StatementKind) bool {
 	switch kind {
-	case StatementSource, StatementSourceOrMap, StatementSourceOrSink:
+	case StatementSource, StatementSourceOrMap, StatementSourceOrSink, StatementSourceOrMapOrSink:
 		return true
 	default:
 		return false
@@ -51,7 +51,7 @@ func isApplicableForSource(kind StatementKind) bool {
 
 func isApplicableForMap(kind StatementKind) bool {
 	switch kind {
-	case StatementMap, StatementSourceOrMap:
+	case StatementMap, StatementSourceOrMap, StatementSourceOrMapOrSink:
 		return true
 	default:
 		return false
@@ -60,7 +60,7 @@ func isApplicableForMap(kind StatementKind) bool {
 
 func isApplicableForSink(kind StatementKind) bool {
 	switch kind {
-	case StatementSink, StatementSourceOrSink:
+	case StatementSink, StatementSourceOrSink, StatementSourceOrMapOrSink:
 		return true
 	default:
 		return false

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -2612,6 +2612,12 @@ func TestSrcError(t *testing.T) {
 		"JSON()",
 	}
 	runTest(t, codeLines, resultLines, CompileErr("line 1, column 1: \"MAPVALUE()\" is not applicable for SRC [statement: MAPVALUE(0, 1)]"))
+
+	codeLines = []string{
+		"FAKE( arrange(0, 1, 1) )",
+		"SQL('select * from example')",
+	}
+	runTest(t, codeLines, resultLines, CompileErr("line 2, column 1: f(SQL) sink does not allow fetch verb \"SELECT\" [statement: SQL('select * from example')]"))
 }
 
 func TestSinkMarkdown(t *testing.T) {

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -2599,12 +2599,12 @@ func TestDict(t *testing.T) {
 
 func TestSrcError(t *testing.T) {
 	codeLines := []string{
-		"SQL('select * from example')",
-		"SQL('select * from example')",
+		"FAKE( arrange(0, 1, 1) )",
+		"INSERT(table('example'))",
 		"JSON()",
 	}
 	resultLines := []string{}
-	runTest(t, codeLines, resultLines, CompileErr("line 2, column 1: \"SQL()\" is not applicable for MAP [statement: SQL('select * from example')]"))
+	runTest(t, codeLines, resultLines, CompileErr("line 2, column 1: \"INSERT()\" is not applicable for MAP [statement: INSERT(table('example'))]"))
 
 	codeLines = []string{
 		"MAPVALUE(0, 1)",

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -442,6 +442,52 @@ func TestDatabaseTql(t *testing.T) {
 			},
 		},
 		{
+			Name: "SQL_map-select",
+			Script: `
+				FAKE(json({["tag1"]}))
+				SQL("select TIME, VALUE from tag_simple where name = ?", value(0))
+				CSV( precision(3), header(true) )
+				`,
+			ExpectCSV: []string{
+				"TIME,VALUE",
+				"1692686707380411000,0.100",
+				"1692686708380411000,0.200",
+				"\n",
+			},
+		},
+		{
+			Name: "SQL_SQL",
+			Script: `
+				SQL("select TIME, VALUE from tag_simple where name = ?", param("name"))
+				SQL("insert into tag_simple (name, time, value) values (?, ?, ?)", "tag2", value(0), value(1))
+			`,
+			Params: map[string][]string{
+				"name": {"tag1"},
+			},
+			ExpectFunc: func(t *testing.T, result string) {
+				require.True(t, gjson.Get(result, "success").Bool(), "result: %q", result)
+				require.Equal(t, "success", gjson.Get(result, "reason").String(), result)
+				require.Equal(t, "2 rows inserted.", gjson.Get(result, "data.message").String(), result)
+				require.NoError(t, flushTable(t.Context(), "tag_simple"))
+			},
+		},
+		{
+			Name: "SQL_SQL-cleanup",
+			Script: `
+				SQL("delete from tag_simple where name = ?", param("name"))
+				MARKDOWN()
+			`,
+			Params: map[string][]string{
+				"name": {"tag2"},
+			},
+			ExpectText: []string{
+				`|MESSAGE|`,
+				`|:-----|`,
+				`|2 rows deleted.|`,
+				``,
+			},
+		},
+		{
 			Name: "SQL_create-tag-table",
 			Script: `
 				SQL({create tag table if not exists tag_simple(

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -2381,6 +2381,37 @@ func TestBridgeSqlite(t *testing.T) {
 			ExpectCSV: []string{"a row updated.", "\n"},
 		},
 		{
+			Name: "sqlite-source-to-sink-insert",
+			Script: `
+				SQL(bridge('sqlite'), "select 400 as id, 'delta' as name, 40 as age, 'street-400' as address union all select 500, 'echo' as name, 50 as age, 'street-500' as address")
+				SQL(bridge('sqlite'), "insert into example_sql(id,name,age,address) values(?,?,?,?)", value(0), value(1), value(2), value(3))
+			`,
+			ExpectFunc: func(t *testing.T, result string) {
+				require.True(t, gjson.Get(result, "success").Bool())
+				require.Equal(t, "success", gjson.Get(result, "reason").String())
+				require.Equal(t, "2 rows inserted.", gjson.Get(result, "data.message").String())
+			},
+		},
+		{
+			Name: "sqlite-source-to-sink-count",
+			Script: `
+				SQL(bridge('sqlite'), "select count(*) as cnt from example_sql where id in (400,500)")
+				JSON()
+			`,
+			ExpectFunc: func(t *testing.T, result string) {
+				require.True(t, gjson.Get(result, "success").Bool())
+				require.Equal(t, `[["2"]]`, gjson.Get(result, "data.rows").Raw)
+			},
+		},
+		{
+			Name: "sqlite-source-to-sink-cleanup",
+			Script: `
+				SQL(bridge('sqlite'), "delete from example_sql where id in (400,500)")
+				CSV(heading(false))
+			`,
+			ExpectCSV: []string{"2 rows deleted.", "\n"},
+		},
+		{
 			Name: "sqlite-select-updated",
 			Script: `
 				SQL(bridge('sqlite'), "select * from example_sql")


### PR DESCRIPTION
This pull request introduces significant improvements to the TQL engine, mainly by enhancing the flexibility of the `SQL` statement so it can now act as a source, map, or sink, depending on its context. It also adds a new implementation for SQL sinks, better argument handling for value references, and updates the documentation and tests to reflect these changes.

**Major enhancements to SQL statement handling:**

- **Flexible SQL Statement Role:**
  - The `SQL` statement can now be used as a source, map, or sink, depending on where it appears in the TQL script. This is achieved by introducing the new `StatementSourceOrMapOrSink` kind and updating the relevant logic and definitions. [[1]](diffhunk://#diff-b5c86d742744ee0f3883c65448915c7f263f6dd8f7805e8dad6a6be86c204e1eL17-R17) [[2]](diffhunk://#diff-f778624a998d2976b3df173556f0016ee11e62afa58ae7f2296808fcc40ee944R16) [[3]](diffhunk://#diff-1434219914a5852a9dd5805496e5d089b78c3991ebf54434d0fc306897f22e6fL45-R45) [[4]](diffhunk://#diff-1434219914a5852a9dd5805496e5d089b78c3991ebf54434d0fc306897f22e6fL54-R54) [[5]](diffhunk://#diff-1434219914a5852a9dd5805496e5d089b78c3991ebf54434d0fc306897f22e6fL63-R63)
  - The SQL function (`fmSql`) now delegates to a new sink implementation (`fmSqlSink`) when used as a sink, supporting both direct database connections and bridge connectors. [[1]](diffhunk://#diff-ca904daacbca593f92b0f26bdf32204ba2cdc1a0ab71b59216df7c7c7f733b6fR294-R297) [[2]](diffhunk://#diff-44ba0e8453dfde660a42296eef43601918089b50ccdb6cee84ec08ecad0c0e30R255-R424)

- **SQL Sink Implementation:**
  - Introduces the `sqlSink` type, which manages SQL execution as a sink, including parameter mapping, context management, and result message formatting. It also validates that only non-fetch SQL verbs are used in sinks.

**Improvements to value reference handling:**

- **Record Value Reference Abstraction:**
  - Adds `recordValueRef` and a helper function `parseRecordValueIndex` to robustly handle arguments that refer to tuple values by index, supporting multiple types (int, float, string). [[1]](diffhunk://#diff-7793461b983bcc697b9660fac94aa96c60037f4d8acbfc4e79bbd664fb0bed1eR17-R20) [[2]](diffhunk://#diff-7793461b983bcc697b9660fac94aa96c60037f4d8acbfc4e79bbd664fb0bed1eL36-L57) [[3]](diffhunk://#diff-7793461b983bcc697b9660fac94aa96c60037f4d8acbfc4e79bbd664fb0bed1eR77-R95)

**Documentation updates:**

- **Expanded JSON-RPC Documentation:**
  - Documents the new `http.split` method and enhances the description of `splitSqlStatements` to clarify the structure of returned statements, including new fields. [[1]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1R2074-R2126) [[2]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2342-R2402)

**Test and validation updates:**

- **Test Coverage and Validation:**
  - Updates and adds tests to ensure the new SQL behaviors are validated, including use as a map and sink, error handling for invalid usage, and integration with other statements. [[1]](diffhunk://#diff-5cc5624d95cf1cbe7753671ecc2848db86a0f863585cc619eb4e3c1887877c22L63-R63) [[2]](diffhunk://#diff-076220c4234b516f5e4b521a78b0d30f58ddb9cb42a72af199e1cb44707414fbL2602-R2607) [[3]](diffhunk://#diff-a506b05e7ab53f45329a482649de0f6366bcb0aa88017ba2ff72496da349a6b0R444-R489)

**Other:**

- **Dependency Update:**
  - Adds an import for the bridge connector to support the new SQL sink implementation.…ove script parsing, and update validation logic