### PR TITLE
Enhance client certificate generation for DNS names and URIs

### DIFF
--- a/mods/bridge/service_test.go
+++ b/mods/bridge/service_test.go
@@ -80,12 +80,13 @@ func sqliteBridgePath(t *testing.T) string {
 
 func TestServiceStartStop(t *testing.T) {
 	bridge.UnregisterAll()
+	sqlitePath := sqliteBridgePath(t) // register TempDir cleanup before UnregisterAll (LIFO fix)
 	t.Cleanup(bridge.UnregisterAll)
 
 	provider := newBridgeProviderStub(&model.BridgeDefinition{
 		Name: "bridge_start_stop",
 		Type: model.BRIDGE_SQLITE,
-		Path: sqliteBridgePath(t),
+		Path: sqlitePath,
 	})
 	svc := bridge.NewService(bridge.WithProvider(provider))
 
@@ -101,6 +102,7 @@ func TestServiceStartStop(t *testing.T) {
 
 func TestServiceSqliteLifecycle(t *testing.T) {
 	bridge.UnregisterAll()
+	sqlitePath := sqliteBridgePath(t) // register TempDir cleanup before UnregisterAll (LIFO fix)
 	t.Cleanup(bridge.UnregisterAll)
 
 	provider := newBridgeProviderStub()
@@ -111,7 +113,7 @@ func TestServiceSqliteLifecycle(t *testing.T) {
 	addRsp, err := svc.AddBridge(ctx, &bridge.AddBridgeRequest{
 		Name: name,
 		Type: "sqlite",
-		Path: sqliteBridgePath(t),
+		Path: sqlitePath,
 	})
 	require.NoError(t, err)
 	require.True(t, addRsp.Success)

--- a/mods/server/svrkey.go
+++ b/mods/server/svrkey.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"io"
 	"math/big"
+	"net/url"
 	"reflect"
 	"strings"
 	"time"
@@ -175,7 +176,7 @@ func GenerateServerCertificate(priKey *ecdsa.PrivateKey, pubKey *ecdsa.PublicKey
 	return out.Bytes(), nil
 }
 
-func GenerateClientCertificate(subject pkix.Name, notBefore time.Time, notAfter time.Time, ca *x509.Certificate, caKey crypto.PrivateKey, pubKey crypto.PublicKey) ([]byte, error) {
+func GenerateClientCertificate(subject pkix.Name, dnsNames []string, uris []*url.URL, notBefore time.Time, notAfter time.Time, ca *x509.Certificate, caKey crypto.PrivateKey, pubKey crypto.PublicKey) ([]byte, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
@@ -187,6 +188,8 @@ func GenerateClientCertificate(subject pkix.Name, notBefore time.Time, notAfter 
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		Subject:               subject,
+		DNSNames:              dnsNames,
+		URIs:                  uris,
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,

--- a/mods/server/svrkey_test.go
+++ b/mods/server/svrkey_test.go
@@ -144,7 +144,7 @@ func TestCert(t *testing.T) {
 	require.True(t, len(cliKeyPEM) > 0)
 
 	// client cert
-	cliCertPEM, err := GenerateClientCertificate(pkix.Name{CommonName: "TheClient"}, time.Now(), time.Now().Add(time.Hour), svrCert, svrPri, cliPub)
+	cliCertPEM, err := GenerateClientCertificate(pkix.Name{CommonName: "TheClient"}, []string{"TheClient"}, nil, time.Now(), time.Now().Add(time.Hour), svrCert, svrPri, cliPub)
 	require.Nil(t, err)
 	require.NotNil(t, cliCertPEM)
 

--- a/mods/server/svrmgmt.go
+++ b/mods/server/svrmgmt.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"runtime/debug"
@@ -133,10 +134,17 @@ func (s *Server) GenKey(ctx context.Context, req *GenKeyRequest) (*GenKeyRespons
 	if err != nil {
 		return nil, err
 	}
+	clientURN, err := url.Parse(fmt.Sprintf("urn:machbase:neo:client:%s", req.Id))
+	if err != nil {
+		rsp.Reason = fmt.Sprintf("invalid client urn, %s", err.Error())
+		return rsp, nil
+	}
 	gen := GenCertReq{
 		Name: pkix.Name{
 			CommonName: req.Id,
 		},
+		DNSNames:  []string{req.Id},
+		URIs:      []*url.URL{clientURN},
 		NotBefore: time.Unix(req.NotBefore, 0),
 		NotAfter:  time.Unix(req.NotAfter, 0),
 		Issuer:    ca,
@@ -218,6 +226,8 @@ func (s *Server) ServerKey(ctx context.Context) (*ServerKeyResponse, error) {
 
 type GenCertReq struct {
 	pkix.Name
+	DNSNames  []string
+	URIs      []*url.URL
 	NotBefore time.Time
 	NotAfter  time.Time
 	Issuer    *x509.Certificate
@@ -276,7 +286,7 @@ func generateClientKey(req *GenCertReq) ([]byte, []byte, string, error) {
 		return nil, nil, "", err
 	}
 
-	certBytes, err := GenerateClientCertificate(req.Name, req.NotBefore, req.NotAfter, req.Issuer, req.IssuerKey, clientPub)
+	certBytes, err := GenerateClientCertificate(req.Name, req.DNSNames, req.URIs, req.NotBefore, req.NotAfter, req.Issuer, req.IssuerKey, clientPub)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("client certificate: %s", err.Error())
 	}

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -905,6 +905,23 @@ func TestDatabaseBinaryTql(t *testing.T) {
 				"\n",
 			},
 		},
+		// FLUSH before DROP TABLE
+		{
+			Name: "flush-before-drop",
+			Script: `
+				FAKE( once(1) )
+				DISCARD()`,
+			ExpectFunc: func(t *testing.T, result string) {
+				// flush appender workers to ensure all pending writes are done
+				spi.FlushAppendWorkers("tqlbin")
+
+				// flush table
+				conn, _ := spi.Default().Connect(t.Context(), api.WithPassword("sys", "manager"))
+				time.Sleep(100 * time.Millisecond)
+				conn.Exec(t.Context(), "EXEC table_flush(tqlbin)")
+				conn.Close()
+			},
+		},
 		// DROP TABLE
 		{
 			Name: "drop-table",


### PR DESCRIPTION
This pull request enhances client certificate generation by allowing the inclusion of DNS names and URIs, improving certificate identity and validation. The changes update both the implementation and usage of the certificate generation functions, and ensure that generated certificates include the relevant subject information.

**Certificate generation improvements:**

* The `GenerateClientCertificate` function in `svrkey.go` now accepts `dnsNames` and `uris` parameters, and sets the `DNSNames` and `URIs` fields in the generated certificate. [[1]](diffhunk://#diff-239eba580c200c3a61cf4202ffffa9ef90e09240c2447dcb853beb6dfbfebe89L178-R179) [[2]](diffhunk://#diff-239eba580c200c3a61cf4202ffffa9ef90e09240c2447dcb853beb6dfbfebe89R191-R192)
* The `GenCertReq` struct in `svrmgmt.go` is extended to include `DNSNames` and `URIs`, allowing these fields to be passed through the certificate generation process.
* The `generateClientKey` function is updated to pass `DNSNames` and `URIs` to `GenerateClientCertificate`.

**Client certificate request handling:**

* When handling a client certificate request in `GenKey`, the code now constructs a client URN and populates the `DNSNames` and `URIs` fields in the certificate request.

**Testing updates:**

* The test for client certificate generation in `svrkey_test.go` is updated to provide the new `dnsNames` and `uris` parameters.…update related tests