### PR TITLE
Upgrade neo-engine to v8.5.6 and update index validation tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/lib/pq v1.10.9
 	github.com/machbase/neo-client v1.6.1-0.20260629061834-5f5b6b0796b8
-	github.com/machbase/neo-engine/v8 v8.5.5
+	github.com/machbase/neo-engine/v8 v8.5.6
 	github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b
 	github.com/magefile/mage v1.16.0
 	github.com/mattn/go-colorable v0.1.14

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,8 @@ github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIi
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/machbase/neo-client v1.6.1-0.20260629061834-5f5b6b0796b8 h1:MZs5hx6Qk3K/4ZPyYUdy5ri1fsJ3+y/kWu5KDP5vnf0=
 github.com/machbase/neo-client v1.6.1-0.20260629061834-5f5b6b0796b8/go.mod h1:rCaZqbs86TUVDghcOW4XH9Htodk9D7t5Cu5j3aWphPU=
-github.com/machbase/neo-engine/v8 v8.5.5 h1:myd9emXSKSGOkgzromk5zq/KCJ5ASiqsO4IJssICRA0=
-github.com/machbase/neo-engine/v8 v8.5.5/go.mod h1:b4epDziTEbSEgO2xEWBZpGcTkVT+H2/aVc+EnnfdLYw=
+github.com/machbase/neo-engine/v8 v8.5.6 h1:4vvZcGry5fkcNmpBTyMFRhusLnh15a2nM8w+F0b11ws=
+github.com/machbase/neo-engine/v8 v8.5.6/go.mod h1:b4epDziTEbSEgO2xEWBZpGcTkVT+H2/aVc+EnnfdLYw=
 github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b h1:yVScvJT9bIGaJmajia+/xz5tkOpRQ5utmpXstV2C37k=
 github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b/go.mod h1:69acURVmR+iJA1WFXOrwJntcRxLoTp9i1s/F/qhePjQ=
 github.com/magefile/mage v1.16.0 h1:2naaPmNwrMicCdLBCRDw288hcyClO9lmnm6FMpXyJ5I=

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -605,7 +605,7 @@ func TestShellShow(t *testing.T) {
 			name: "show_tables",
 			args: append(shellArgs, "show", "table", "--format", "csv", "example"),
 			expect: []string{
-				"EXAMPLE (ID: 15, Tag Table)",
+				`/r/EXAMPLE \(ID: [0-9]+, Tag Table\)`,
 				"ROWNUM,NAME,TYPE,LENGTH,FLAG,INDEX",
 				"1,NAME,varchar,40,tag name,",
 				"2,TIME,datetime,31,basetime,",
@@ -1900,7 +1900,7 @@ func TestShellRun(t *testing.T) {
 			args: append(shellArgs, "run", "shell_run.txt"),
 			expect: []string{
 				"desc example",
-				"EXAMPLE (ID: 15, Tag Table)",
+				`/r/EXAMPLE \(ID: [0-9]+, Tag Table\)`,
 				"┌────────┬───────┬──────────┬────────┬────────────┬───────┐",
 				"│ ROWNUM │ NAME  │ TYPE     │ LENGTH │ FLAG       │ INDEX │",
 				"├────────┼───────┼──────────┼────────┼────────────┼───────┤",

--- a/mods/server/ssh_test.go
+++ b/mods/server/ssh_test.go
@@ -37,9 +37,9 @@ func TestSSH(t *testing.T) {
 			cmd:  "show tables --format csv",
 			expect: []string{
 				"ROWNUM,DATABASE_NAME,USER_NAME,TABLE_NAME,TABLE_ID,TABLE_TYPE,TABLE_FLAG",
-				"1,MACHBASEDB,SYS,EXAMPLE,15,Tag,",
-				"2,MACHBASEDB,SYS,LOG_DATA,8,Log,",
-				"3,MACHBASEDB,SYS,TAG_DATA,7,Tag,",
+				"/r/^1,MACHBASEDB,SYS,EXAMPLE,[0-9]+,Tag,$",
+				"/r/^2,MACHBASEDB,SYS,LOG_DATA,[0-9]+,Log,$",
+				"/r/^3,MACHBASEDB,SYS,TAG_DATA,[0-9]+,Tag,$",
 			},
 		},
 		{
@@ -469,7 +469,7 @@ func TestSSHSession(t *testing.T) {
 	require.NoError(t, err)
 
 	err = s.Run(t, "desc example", []string{
-		"EXAMPLE (ID: 15, Tag Table)",
+		"EXAMPLE (ID:",
 		"┌────────┬───────┬──────────┬────────┬────────────┬───────┐",
 		"│ ROWNUM │ NAME  │ TYPE     │ LENGTH │ FLAG       │ INDEX │",
 		"├────────┼───────┼──────────┼────────┼────────────┼───────┤",

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -229,12 +229,13 @@ func TestDatabaseTql(t *testing.T) {
 				SQL("show tables;")
 				CSV(header(true))
 				`,
-			ExpectCSV: []string{
-				"DATABASE,USER,NAME,ID,TYPE,FLAG",
-				"MACHBASEDB,SYS,LOG_DATA,15,Log,",
-				"MACHBASEDB,SYS,TAG_DATA,7,Tag,",
-				"MACHBASEDB,SYS,TAG_SIMPLE,14,Tag,",
-				"\n",
+			ExpectFunc: func(t *testing.T, result string) {
+				lines := strings.Split(strings.TrimSuffix(result, "\n\n"), "\n")
+				require.GreaterOrEqual(t, len(lines), 4)
+				require.Equal(t, "DATABASE,USER,NAME,ID,TYPE,FLAG", lines[0])
+				require.Regexp(t, regexp.MustCompile(`^MACHBASEDB,SYS,LOG_DATA,[0-9]+,Log,$`), lines[1])
+				require.Regexp(t, regexp.MustCompile(`^MACHBASEDB,SYS,TAG_DATA,[0-9]+,Tag,$`), lines[2])
+				require.Regexp(t, regexp.MustCompile(`^MACHBASEDB,SYS,TAG_SIMPLE,[0-9]+,Tag,$`), lines[3])
 			},
 		},
 		{
@@ -243,13 +244,39 @@ func TestDatabaseTql(t *testing.T) {
 				SQL("show indexes ")
 				CSV(header(true))
 				`,
-			ExpectCSV: []string{
-				"ID,DATABASE,USER,TABLE_NAME,COLUMN_NAME,INDEX_NAME,INDEX_TYPE,KEY_COMPRESS,MAX_LEVEL,PART_VALUE_COUNT,BITMAP_ENCODE",
-				"3,MACHBASEDB,SYS,_TAG_DATA_META,_ID,__PK_IDX__TAG_DATA_META_1,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
-				"4,MACHBASEDB,SYS,_TAG_DATA_META,NAME,_TAG_DATA_META_NAME,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
-				"10,MACHBASEDB,SYS,_TAG_SIMPLE_META,_ID,__PK_IDX__TAG_SIMPLE_META_1,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
-				"11,MACHBASEDB,SYS,_TAG_SIMPLE_META,NAME,_TAG_SIMPLE_META_NAME,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
-				"\n",
+			ExpectFunc: func(t *testing.T, result string) {
+				lines := strings.Split(strings.TrimSuffix(result, "\n\n"), "\n")
+				require.GreaterOrEqual(t, len(lines), 5)
+				require.Equal(t, "ID,DATABASE,USER,TABLE_NAME,COLUMN_NAME,INDEX_NAME,INDEX_TYPE,KEY_COMPRESS,MAX_LEVEL,PART_VALUE_COUNT,BITMAP_ENCODE", lines[0])
+
+				required := map[string]struct {
+					table  string
+					column string
+				}{
+					"__PK_IDX__TAG_DATA_META_1":   {table: "_TAG_DATA_META", column: "_ID"},
+					"_TAG_DATA_META_NAME":         {table: "_TAG_DATA_META", column: "NAME"},
+					"__PK_IDX__TAG_SIMPLE_META_1": {table: "_TAG_SIMPLE_META", column: "_ID"},
+					"_TAG_SIMPLE_META_NAME":       {table: "_TAG_SIMPLE_META", column: "NAME"},
+				}
+				seen := map[string]bool{}
+				for _, line := range lines[1:] {
+					fields := strings.Split(line, ",")
+					require.GreaterOrEqual(t, len(fields), 11)
+					idxName := fields[5]
+					req, ok := required[idxName]
+					if !ok {
+						continue
+					}
+					require.Equal(t, "MACHBASEDB", fields[1])
+					require.Equal(t, "SYS", fields[2])
+					require.Equal(t, req.table, fields[3])
+					require.Equal(t, req.column, fields[4])
+					require.Equal(t, "REDBLACK", fields[6])
+					seen[idxName] = true
+				}
+				for name := range required {
+					require.True(t, seen[name], "required index missing: %s", name)
+				}
 			},
 		},
 		{

--- a/spi/machsvr/machsvr_test.go
+++ b/spi/machsvr/machsvr_test.go
@@ -1593,6 +1593,12 @@ func testShowIndexes(t *testing.T) {
 	ret, err := spi.ListIndexes(ctx, conn)
 	require.NoError(t, err, "indexes fail")
 	require.NotEmpty(t, ret, "indexes empty")
+	required := map[string]bool{
+		"_TAG_DATA_META_NAME":         false,
+		"__PK_IDX__TAG_DATA_META_1":   false,
+		"_TAG_SIMPLE_META_NAME":       false,
+		"__PK_IDX__TAG_SIMPLE_META_1": false,
+	}
 	for _, r := range ret {
 		switch r.IndexName {
 		case "_TAG_DATA_META_NAME":
@@ -1600,25 +1606,31 @@ func testShowIndexes(t *testing.T) {
 			require.Equal(t, "_TAG_DATA_META", r.TableName)
 			require.Equal(t, "NAME", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		case "__PK_IDX__TAG_DATA_META_1":
 			require.Equal(t, "MACHBASEDB", r.Database)
 			require.Equal(t, "_TAG_DATA_META", r.TableName)
 			require.Equal(t, "_ID", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		case "_TAG_SIMPLE_META_NAME":
 			require.Equal(t, "MACHBASEDB", r.Database)
 			require.Equal(t, "_TAG_SIMPLE_META", r.TableName)
 			require.Equal(t, "NAME", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		case "__PK_IDX__TAG_SIMPLE_META_1":
 			require.Equal(t, "MACHBASEDB", r.Database)
 			require.Equal(t, "_TAG_SIMPLE_META", r.TableName)
 			require.Equal(t, "_ID", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		default:
-			t.Logf("Unknown index: %+v", r)
-			t.Fail()
+			// Ignore additional system indexes that may be added by newer engine versions.
 		}
+	}
+	for name, seen := range required {
+		require.True(t, seen, "required index missing: %s", name)
 	}
 }
 

--- a/spi/spi_test.go
+++ b/spi/spi_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -361,6 +362,62 @@ func TestDatabaseBasedCases(t *testing.T) {
 }
 
 func testCommands(t *testing.T) {
+	assertShowTables := func(t *testing.T, actual string, includeAll bool) {
+		t.Helper()
+		lines := strings.Split(strings.TrimSuffix(actual, "\n"), "\n")
+		require.GreaterOrEqual(t, len(lines), 4)
+		require.Equal(t, "ROWNUM,DATABASE,USER,NAME,ID,TYPE,FLAG", lines[0])
+
+		require.Regexp(t, regexp.MustCompile(`^1,MACHBASEDB,SYS,LOG_DATA,[0-9]+,Log,$`), lines[1])
+		require.Regexp(t, regexp.MustCompile(`^2,MACHBASEDB,SYS,TAG_DATA,[0-9]+,Tag,$`), lines[2])
+		require.Regexp(t, regexp.MustCompile(`^3,MACHBASEDB,SYS,TAG_SIMPLE,[0-9]+,Tag,$`), lines[3])
+
+		if includeAll {
+			require.GreaterOrEqual(t, len(lines), 8)
+			require.Regexp(t, regexp.MustCompile(`^4,MACHBASEDB,SYS,_TAG_DATA_DATA_0,[0-9]+,KeyValue,Data$`), lines[4])
+			require.Regexp(t, regexp.MustCompile(`^5,MACHBASEDB,SYS,_TAG_DATA_META,[0-9]+,Lookup,Meta$`), lines[5])
+			require.Regexp(t, regexp.MustCompile(`^6,MACHBASEDB,SYS,_TAG_SIMPLE_DATA_0,[0-9]+,KeyValue,Data$`), lines[6])
+			require.Regexp(t, regexp.MustCompile(`^7,MACHBASEDB,SYS,_TAG_SIMPLE_META,[0-9]+,Lookup,Meta$`), lines[7])
+		}
+	}
+
+	assertShowIndexes := func(t *testing.T, actual string) {
+		t.Helper()
+		lines := strings.Split(strings.TrimSuffix(actual, "\n"), "\n")
+		require.GreaterOrEqual(t, len(lines), 5)
+		require.Equal(t, "ROWNUM,ID,DATABASE,USER,TABLE_NAME,COLUMN_NAME,INDEX_NAME,INDEX_TYPE,KEY_COMPRESS,MAX_LEVEL,PART_VALUE_COUNT,BITMAP_ENCODE", lines[0])
+
+		required := map[string]struct {
+			table  string
+			column string
+		}{
+			"__PK_IDX__TAG_DATA_META_1":   {table: "_TAG_DATA_META", column: "_ID"},
+			"_TAG_DATA_META_NAME":         {table: "_TAG_DATA_META", column: "NAME"},
+			"__PK_IDX__TAG_SIMPLE_META_1": {table: "_TAG_SIMPLE_META", column: "_ID"},
+			"_TAG_SIMPLE_META_NAME":       {table: "_TAG_SIMPLE_META", column: "NAME"},
+		}
+
+		seen := map[string]bool{}
+		for _, line := range lines[1:] {
+			fields := strings.Split(line, ",")
+			require.GreaterOrEqual(t, len(fields), 12, "invalid index row: %s", line)
+			idxName := fields[6]
+			req, ok := required[idxName]
+			if !ok {
+				continue
+			}
+			require.Equal(t, "MACHBASEDB", fields[2])
+			require.Equal(t, "SYS", fields[3])
+			require.Equal(t, req.table, fields[4])
+			require.Equal(t, req.column, fields[5])
+			require.Equal(t, "REDBLACK", fields[7])
+			seen[idxName] = true
+		}
+		for name := range required {
+			require.True(t, seen[name], "required index missing: %s", name)
+		}
+	}
+
 	tests := []struct {
 		name              string
 		input             string
@@ -379,39 +436,22 @@ func testCommands(t *testing.T) {
 		{
 			name:  "show_tables",
 			input: "show tables",
-			expect: []string{
-				"ROWNUM,DATABASE,USER,NAME,ID,TYPE,FLAG",
-				"1,MACHBASEDB,SYS,LOG_DATA,15,Log,",
-				"2,MACHBASEDB,SYS,TAG_DATA,7,Tag,",
-				"3,MACHBASEDB,SYS,TAG_SIMPLE,14,Tag,",
+			expectFunc: func(t *testing.T, actual string) {
+				assertShowTables(t, actual, false)
 			},
 		},
 		{
 			name:  "show_tables_all",
 			input: "show tables --all",
-			expect: []string{
-				"ROWNUM,DATABASE,USER,NAME,ID,TYPE,FLAG",
-				"1,MACHBASEDB,SYS,LOG_DATA,15,Log,",
-				"2,MACHBASEDB,SYS,TAG_DATA,7,Tag,",
-				"3,MACHBASEDB,SYS,TAG_SIMPLE,14,Tag,",
-				"4,MACHBASEDB,SYS,_TAG_DATA_DATA_0,1,KeyValue,Data",
-				"5,MACHBASEDB,SYS,_TAG_DATA_META,2,Lookup,Meta",
-				"6,MACHBASEDB,SYS,_TAG_SIMPLE_DATA_0,8,KeyValue,Data",
-				"7,MACHBASEDB,SYS,_TAG_SIMPLE_META,9,Lookup,Meta",
+			expectFunc: func(t *testing.T, actual string) {
+				assertShowTables(t, actual, true)
 			},
 		},
 		{
 			name:  "show_tables_short_all",
 			input: "SHOW tables -a",
-			expect: []string{
-				"ROWNUM,DATABASE,USER,NAME,ID,TYPE,FLAG",
-				"1,MACHBASEDB,SYS,LOG_DATA,15,Log,",
-				"2,MACHBASEDB,SYS,TAG_DATA,7,Tag,",
-				"3,MACHBASEDB,SYS,TAG_SIMPLE,14,Tag,",
-				"4,MACHBASEDB,SYS,_TAG_DATA_DATA_0,1,KeyValue,Data",
-				"5,MACHBASEDB,SYS,_TAG_DATA_META,2,Lookup,Meta",
-				"6,MACHBASEDB,SYS,_TAG_SIMPLE_DATA_0,8,KeyValue,Data",
-				"7,MACHBASEDB,SYS,_TAG_SIMPLE_META,9,Lookup,Meta",
+			expectFunc: func(t *testing.T, actual string) {
+				assertShowTables(t, actual, true)
 			},
 		},
 		{
@@ -498,12 +538,8 @@ func testCommands(t *testing.T) {
 		{
 			name:  "show_indexes",
 			input: `show indexes`,
-			expect: []string{
-				"ROWNUM,ID,DATABASE,USER,TABLE_NAME,COLUMN_NAME,INDEX_NAME,INDEX_TYPE,KEY_COMPRESS,MAX_LEVEL,PART_VALUE_COUNT,BITMAP_ENCODE",
-				"1,3,MACHBASEDB,SYS,_TAG_DATA_META,_ID,__PK_IDX__TAG_DATA_META_1,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
-				"2,4,MACHBASEDB,SYS,_TAG_DATA_META,NAME,_TAG_DATA_META_NAME,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
-				"3,10,MACHBASEDB,SYS,_TAG_SIMPLE_META,_ID,__PK_IDX__TAG_SIMPLE_META_1,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
-				"4,11,MACHBASEDB,SYS,_TAG_SIMPLE_META,NAME,_TAG_SIMPLE_META_NAME,REDBLACK,UNCOMPRESS,0,100000,EQUAL",
+			expectFunc: func(t *testing.T, actual string) {
+				assertShowIndexes(t, actual)
 			},
 		},
 		{

--- a/spi/testsuite/tables.go
+++ b/spi/testsuite/tables.go
@@ -103,6 +103,12 @@ func Indexes(t *testing.T, db api.Database, ctx context.Context) {
 	ret, err := spi.ListIndexes(ctx, conn)
 	require.NoError(t, err, "indexes fail")
 	require.NotEmpty(t, ret, "indexes empty")
+	required := map[string]bool{
+		"_TAG_DATA_META_NAME":         false,
+		"__PK_IDX__TAG_DATA_META_1":   false,
+		"_TAG_SIMPLE_META_NAME":       false,
+		"__PK_IDX__TAG_SIMPLE_META_1": false,
+	}
 	for _, r := range ret {
 		switch r.IndexName {
 		case "_TAG_DATA_META_NAME":
@@ -110,25 +116,31 @@ func Indexes(t *testing.T, db api.Database, ctx context.Context) {
 			require.Equal(t, "_TAG_DATA_META", r.TableName)
 			require.Equal(t, "NAME", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		case "__PK_IDX__TAG_DATA_META_1":
 			require.Equal(t, "MACHBASEDB", r.Database)
 			require.Equal(t, "_TAG_DATA_META", r.TableName)
 			require.Equal(t, "_ID", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		case "_TAG_SIMPLE_META_NAME":
 			require.Equal(t, "MACHBASEDB", r.Database)
 			require.Equal(t, "_TAG_SIMPLE_META", r.TableName)
 			require.Equal(t, "NAME", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		case "__PK_IDX__TAG_SIMPLE_META_1":
 			require.Equal(t, "MACHBASEDB", r.Database)
 			require.Equal(t, "_TAG_SIMPLE_META", r.TableName)
 			require.Equal(t, "_ID", r.ColumnName)
 			require.Equal(t, "REDBLACK", r.IndexType)
+			required[r.IndexName] = true
 		default:
-			t.Logf("Unknown index: %+v", r)
-			t.Fail()
+			// Ignore additional system indexes that may be added by newer engine versions.
 		}
+	}
+	for name, seen := range required {
+		require.True(t, seen, "required index missing: %s", name)
 	}
 }
 


### PR DESCRIPTION
This pull request improves the robustness and flexibility of test cases related to database table and index listings by updating assertions to use regular expressions and helper functions, rather than relying on hardcoded values. This makes the tests less brittle to changes in database IDs and more tolerant of additional system indexes introduced in newer engine versions. The update also includes a minor dependency bump.

**Test robustness and flexibility:**

* Refactored tests in `spi/spi_test.go` to use helper functions (`assertShowTables`, `assertShowIndexes`) that validate output using regular expressions and required fields, instead of hardcoded values. This ensures tests are resilient to changes in table IDs and additional system tables or indexes. [[1]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4R365-R420) [[2]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L382-R454) [[3]](diffhunk://#diff-b9cc12346def4b109d7180b4bd71ca0ead67f6a3fd31744ac9346a2aac3775b4L501-R542)
* Updated tests in `mods/tql/tql_test.go` to use functions that check output with regular expressions, replacing strict string matching for table and index listings. [[1]](diffhunk://#diff-a506b05e7ab53f45329a482649de0f6366bcb0aa88017ba2ff72496da349a6b0L232-R238) [[2]](diffhunk://#diff-a506b05e7ab53f45329a482649de0f6366bcb0aa88017ba2ff72496da349a6b0L246-R279)
* Improved index validation in `spi/machsvr/machsvr_test.go` and `spi/testsuite/tables.go` by checking for the presence of required indexes and allowing for extra system indexes, making the tests forward-compatible with newer engine versions. [[1]](diffhunk://#diff-0cec5317ba3f3213236bc2741c4a7342c0769899eb411ba9fae6e1a5be6d613eR1596-R1633) [[2]](diffhunk://#diff-d3751ffc0138a5156d2e06b1c6740d8e3407229564ac2fb252e7b89cb9ebc923R106-R143)
* Changed various shell and SSH test assertions in `mods/server/server_test.go` and `mods/server/ssh_test.go` to use regular expressions for matching dynamic table IDs, increasing test resilience. [[1]](diffhunk://#diff-85f01ad6de36ebcc7dab3bb85acf3c0713452172648770c6833215310a689a55L608-R608) [[2]](diffhunk://#diff-85f01ad6de36ebcc7dab3bb85acf3c0713452172648770c6833215310a689a55L1903-R1903) [[3]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1L40-R42) [[4]](diffhunk://#diff-59c5ebf8daff291992574eab273e85c7022e7c86b5254e65a32555b13791c2b1L472-R472)

**Dependency updates:**

* Bumped `github.com/machbase/neo-engine/v8` dependency from version `v8.5.5` to `v8.5.6` in `go.mod`