### PR TITLE
refactor connection pool configuration and update related tests

### DIFF
--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -474,6 +474,11 @@ func (s *Server) startMachbaseSvr() error {
 		return fmt.Errorf("load server private key failed, %s", err.Error())
 	} else {
 		spi.SetDefault(db, key)
+		spi.SetDefaultPoolConfig(
+			s.Config.MaxOpenConn,
+			s.Config.MaxIdleConn,
+			s.Config.ConnMaxLifetime,
+			s.Config.ConnMaxIdleTime)
 	}
 	spi.StartAppendWorkers()
 	util.AddShutdownHook(func() {

--- a/mods/server/svrconf.go
+++ b/mods/server/svrconf.go
@@ -86,11 +86,14 @@ type Config struct {
 	ExperimentMode bool
 
 	MachbaseInitOption machsvr.InitOption
-	MaxPoolSize        int
+	MaxPoolSize        int // deprecated
 	MaxOpenConn        int
-	MaxOpenConnFactor  float64
-	MaxOpenQuery       int
-	MaxOpenQueryFactor float64
+	MaxIdleConn        int
+	ConnMaxLifetime    time.Duration
+	ConnMaxIdleTime    time.Duration
+	MaxOpenConnFactor  float64 // deprecated
+	MaxOpenQuery       int     // deprecated
+	MaxOpenQueryFactor float64 // deprecated
 	StatzOut           string
 }
 

--- a/mods/server/svrconf.hcl
+++ b/mods/server/svrconf.hcl
@@ -48,11 +48,15 @@ define VARS {
     HTTP_STATZ_TOKEN      = flag("--http-statz-token", "")  // Bearer token for statz
     HTTP_QUERY_CYPHER     = flag("--http-query-cypher", "") // format: "alg=AES key=1234567890abcdef pad=pkcs5"
 
-    MAX_POOL_SIZE         = flag("--max-pool-size", 0)
     MAX_OPEN_CONN         = flag("--max-open-conn", -1)
-    MAX_OPEN_CONN_FACTOR  = flag("--max-open-conn-factor", 2.0)
-    MAX_OPEN_QUERY        = flag("--max-open-query", 0)
-    MAX_OPEN_QUERY_FACTOR = flag("--max-open-query-factor", 2.0)
+    MAX_IDLE_CONN         = flag("--max-idle-conn", 2)
+    CONN_MAX_LIFETIME     = flag("--conn-max-lifetime", "10m")
+    CONN_MAX_IDLETIME     = flag("--conn-max-idletime", "1m")
+
+    MAX_POOL_SIZE         = flag("--max-pool-size", 0)           // deprecated
+    MAX_OPEN_CONN_FACTOR  = flag("--max-open-conn-factor", 2.0)  // deprecated
+    MAX_OPEN_QUERY        = flag("--max-open-query", 0)          // deprecated
+    MAX_OPEN_QUERY_FACTOR = flag("--max-open-query-factor", 2.0) // deprecated
 
     EXPERIMENT_MODE       = flag("--experiment", false)
     MACHBASE_INIT_OPTION  = flag("--machbase-init-option", 2)
@@ -95,6 +99,9 @@ module "machbase.com/neo-server" {
         CreateDBScriptFiles = [ VARS_CREATEDB_SCRIPT_FILES ]
         MaxPoolSize          = VARS_MAX_POOL_SIZE
         MaxOpenConn          = VARS_MAX_OPEN_CONN
+        MaxIdleConn          = VARS_MAX_IDLE_CONN
+        ConnMaxLifetime      = VARS_CONN_MAX_LIFETIME
+        ConnMaxIdleTime      = VARS_CONN_MAX_IDLETIME
         MaxOpenConnFactor    = VARS_MAX_OPEN_CONN_FACTOR
         MaxOpenQuery         = VARS_MAX_OPEN_QUERY
         MaxOpenQueryFactor   = VARS_MAX_OPEN_QUERY_FACTOR

--- a/spi/database.go
+++ b/spi/database.go
@@ -153,7 +153,18 @@ var (
 	defaultPoolOnce sync.Once
 	defaultPoolDB   *sql.DB
 	defaultPoolErr  error
+	maxOpenConn     = 20
+	maxIdleConn     = 2
+	connMaxLifetime = 10 * time.Minute
+	connMaxIdleTime = 1 * time.Minute
 )
+
+func SetDefaultPoolConfig(maxOpen, maxIdle int, maxLifetime, maxIdleTime time.Duration) {
+	maxOpenConn = maxOpen
+	maxIdleConn = maxIdle
+	connMaxLifetime = maxLifetime
+	connMaxIdleTime = maxIdleTime
+}
 
 // DefaultPool returns the shared SQL connection pool for the default database.
 func DefaultPool() (*sql.DB, error) {
@@ -170,10 +181,10 @@ func DefaultPool() (*sql.DB, error) {
 			}
 			return []api.ConnectOption{api.WithAuthKey("sys", key)}, nil
 		})
-		defaultPoolDB.SetMaxOpenConns(20)
-		defaultPoolDB.SetMaxIdleConns(2)
-		defaultPoolDB.SetConnMaxLifetime(10 * time.Minute)
-		defaultPoolDB.SetConnMaxIdleTime(1 * time.Minute)
+		defaultPoolDB.SetMaxOpenConns(maxOpenConn)
+		defaultPoolDB.SetMaxIdleConns(maxIdleConn)
+		defaultPoolDB.SetConnMaxLifetime(connMaxLifetime)
+		defaultPoolDB.SetConnMaxIdleTime(connMaxIdleTime)
 		defaultPoolErr = defaultPoolDB.Ping()
 	})
 	if defaultPoolErr != nil {

--- a/spi/database_test.go
+++ b/spi/database_test.go
@@ -79,6 +79,14 @@ func resetDefaultPoolForTest(t *testing.T) {
 	defaultPoolErr = nil
 }
 
+func resetDefaultPoolConfigForTest(t *testing.T) {
+	t.Helper()
+	maxOpenConn = 20
+	maxIdleConn = 2
+	connMaxLifetime = 10 * time.Minute
+	connMaxIdleTime = 1 * time.Minute
+}
+
 func setDefaultForTest(t *testing.T, db api.Database, key crypto.PrivateKey) {
 	t.Helper()
 	defaultDatabase = db
@@ -170,6 +178,7 @@ func TestDefaultPoolSuccessAndCachedInstance(t *testing.T) {
 		defaultDatabase = oldDB
 		defaultDatabaseKey = oldKey
 		resetDefaultPoolForTest(t)
+		resetDefaultPoolConfigForTest(t)
 	})
 
 	stubDB := &poolStubDatabase{}
@@ -192,6 +201,42 @@ func TestDefaultPoolSuccessAndCachedInstance(t *testing.T) {
 	pool2, err := DefaultPool()
 	require.NoError(t, err)
 	require.Same(t, pool1, pool2)
+}
+
+func TestDefaultPoolUsesConfiguredPoolSettings(t *testing.T) {
+	oldDB := defaultDatabase
+	oldKey := defaultDatabaseKey
+	t.Cleanup(func() {
+		defaultDatabase = oldDB
+		defaultDatabaseKey = oldKey
+		resetDefaultPoolForTest(t)
+		resetDefaultPoolConfigForTest(t)
+	})
+
+	stubDB := &poolStubDatabase{}
+	setDefaultForTest(t, stubDB, newTestAuthKey(t))
+	resetDefaultPoolForTest(t)
+
+	wantMaxOpen := 31
+	wantMaxIdle := 7
+	wantConnMaxLifetime := 3 * time.Minute
+	wantConnMaxIdleTime := 45 * time.Second
+	SetDefaultPoolConfig(wantMaxOpen, wantMaxIdle, wantConnMaxLifetime, wantConnMaxIdleTime)
+
+	pool, err := DefaultPool()
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	t.Cleanup(func() {
+		require.NoError(t, pool.Close())
+	})
+
+	stats := pool.Stats()
+	require.Equal(t, wantMaxOpen, stats.MaxOpenConnections)
+	require.Equal(t, wantMaxOpen, maxOpenConn)
+	require.Equal(t, wantMaxIdle, maxIdleConn)
+	require.Equal(t, wantConnMaxLifetime, connMaxLifetime)
+	require.Equal(t, wantConnMaxIdleTime, connMaxIdleTime)
+	require.GreaterOrEqual(t, stubDB.connectCount, 1)
 }
 
 func TestDefaultPoolErrorIsCachedByOnce(t *testing.T) {


### PR DESCRIPTION
This pull request introduces configurable connection pool settings for the default SQL database pool, deprecates several old pool-related configuration options, and updates related tests. The main goal is to provide more granular control over the database connection pool and modernize configuration management.

**Connection Pool Configuration Improvements:**

* Added new configuration options `MaxIdleConn`, `ConnMaxLifetime`, and `ConnMaxIdleTime` to the server config (`Config` struct, `svrconf.go`, and `svrconf.hcl`), allowing explicit control over connection pool behavior. (`[[1]](diffhunk://#diff-4159ca721f8f52bc0b46af50eba89f18220f2cd10757ecd9e8458e7d81fc20a7L89-R96)`, `[[2]](diffhunk://#diff-9052a646e608b8dab7a4b1322be29d4606ddd1fcdf2aeabf2b3055e2e90514deL51-R59)`, `[[3]](diffhunk://#diff-9052a646e608b8dab7a4b1322be29d4606ddd1fcdf2aeabf2b3055e2e90514deR102-R104)`)
* Deprecated old pool configuration options such as `MaxPoolSize`, `MaxOpenConnFactor`, `MaxOpenQuery`, and `MaxOpenQueryFactor` in favor of the new, more precise settings. (`[[1]](diffhunk://#diff-4159ca721f8f52bc0b46af50eba89f18220f2cd10757ecd9e8458e7d81fc20a7L89-R96)`, `[[2]](diffhunk://#diff-9052a646e608b8dab7a4b1322be29d4606ddd1fcdf2aeabf2b3055e2e90514deL51-R59)`)

**Database Pool Implementation:**

* Introduced `SetDefaultPoolConfig` in `spi/database.go` to update pool parameters, and refactored `DefaultPool` to use these configurable values instead of hardcoded defaults. (`[[1]](diffhunk://#diff-57fac1ba3b9056bea898adf1476933f10d89ee6c51ab6c43c5aba26f68a704d0R156-R168)`, `[[2]](diffhunk://#diff-57fac1ba3b9056bea898adf1476933f10d89ee6c51ab6c43c5aba26f68a704d0L173-R187)`)
* Updated `Server.startMachbaseSvr` to set the default pool configuration using the new options from `s.Config`. (`[mods/server/server.goR477-R481](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdR477-R481)`)

**Testing Enhancements:**

* Added and refactored tests in `spi/database_test.go` to verify that the connection pool uses the configured settings and to reset configuration between tests for isolation. (`[[1]](diffhunk://#diff-f5ee5d226c2a264a812dbaef12f3244ebbc7ff838303de20bd26e6ee5d5977f6R82-R89)`, `[[2]](diffhunk://#diff-f5ee5d226c2a264a812dbaef12f3244ebbc7ff838303de20bd26e6ee5d5977f6R181)`, `[[3]](diffhunk://#diff-f5ee5d226c2a264a812dbaef12f3244ebbc7ff838303de20bd26e6ee5d5977f6R206-R241)`)