### PR TITLE
Refactor connection handling and add SQL compatibility tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/lib/pq v1.10.9
-	github.com/machbase/neo-client v1.6.1-0.20260630024321-42fcab892b0d
+	github.com/machbase/neo-client v1.6.1-0.20260701004552-4437277f1555
 	github.com/machbase/neo-engine/v8 v8.5.6
 	github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b
 	github.com/magefile/mage v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIiZhtifTV5OUqqiP82UAl0h87xj/l9k=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/machbase/neo-client v1.6.1-0.20260630024321-42fcab892b0d h1:NmDL14hImmxsG/1BDqe/mmAcj3ClXC9cXNpBBIWIiH0=
-github.com/machbase/neo-client v1.6.1-0.20260630024321-42fcab892b0d/go.mod h1:rCaZqbs86TUVDghcOW4XH9Htodk9D7t5Cu5j3aWphPU=
+github.com/machbase/neo-client v1.6.1-0.20260701004552-4437277f1555 h1:CnI+yM7nGmTqTWBa5UnbtzqmRkP96IkhR0XduNPomEM=
+github.com/machbase/neo-client v1.6.1-0.20260701004552-4437277f1555/go.mod h1:rCaZqbs86TUVDghcOW4XH9Htodk9D7t5Cu5j3aWphPU=
 github.com/machbase/neo-engine/v8 v8.5.6 h1:4vvZcGry5fkcNmpBTyMFRhusLnh15a2nM8w+F0b11ws=
 github.com/machbase/neo-engine/v8 v8.5.6/go.mod h1:b4epDziTEbSEgO2xEWBZpGcTkVT+H2/aVc+EnnfdLYw=
 github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b h1:yVScvJT9bIGaJmajia+/xz5tkOpRQ5utmpXstV2C37k=

--- a/mods/server/http_query.go
+++ b/mods/server/http_query.go
@@ -165,26 +165,15 @@ func (svr *httpd) handleQuery(ctx *gin.Context) {
 		opts.RowsArray(req.RowsArray),
 		opts.Transpose(req.Transpose),
 	)
-
-	pool, poolErr := spi.DefaultPool()
-	if poolErr != nil {
-		svr.log.Warnf("query pooled db unavailable: %s", poolErr.Error())
+	conn, err := getPoolConn(ctx)
+	if err != nil {
+		svr.log.Warnf("query pooled connection unavailable: %s", err.Error())
 		rsp.Reason = "service unavailable"
 		rsp.Elapse = time.Since(tick).String()
 		ctx.Header("Retry-After", "1")
 		ctx.JSON(http.StatusServiceUnavailable, rsp)
 		return
 	}
-	sqlConn, connErr := pool.Conn(ctx)
-	if connErr != nil {
-		svr.log.Warnf("query pooled connection unavailable: %s", connErr.Error())
-		rsp.Reason = "service unavailable"
-		rsp.Elapse = time.Since(tick).String()
-		ctx.Header("Retry-After", "1")
-		ctx.JSON(http.StatusServiceUnavailable, rsp)
-		return
-	}
-	conn := spi.WrapSqlConn(sqlConn)
 	defer conn.Close()
 
 	query := &spi.Query{
@@ -269,7 +258,7 @@ func (svr *httpd) handleWatchQuery(ctx *gin.Context) {
 
 	watch, err := spi.NewWatcher(ctx,
 		spi.WatcherConfig{
-			ConnProvider: func() (api.Conn, error) { return svr.getTrustConnection(ctx) },
+			ConnProvider: func() (api.Conn, error) { return getPoolConn(ctx) },
 			TableName:    ctx.Param("table"),
 			TagNames:     ctx.QueryArray("tag"),
 			Timeformat:   timeformat,
@@ -413,7 +402,7 @@ func (svr *httpd) handleFileQuery(ctx *gin.Context) {
 	}
 	ts, _ := uidTs.Time()
 
-	conn, err := svr.getTrustConnection(ctx)
+	conn, err := getPoolConn(ctx)
 	if err != nil {
 		rsp.Reason = err.Error()
 		rsp.Elapse = time.Since(tick).String()

--- a/mods/server/http_test.go
+++ b/mods/server/http_test.go
@@ -73,6 +73,51 @@ func BenchmarkHandleQuery(b *testing.B) {
 	}
 }
 
+// goos: linux
+// goarch: amd64
+// cpu: AMD Ryzen 9 3900X 12-Core Processor
+//
+// v8.5.5 (machgo+pooling)
+// == db.SetMaxOpenConns(200) db.SetMaxIdleConns(2)
+// BenchmarkHTTPQueryParallel-24    	   11654	     97116 ns/op	   81587 B/op	     224 allocs/op
+//
+// == db.SetMaxOpenConns(200) db.SetMaxIdleConns(200)
+// BenchmarkHTTPQueryParallel-24    	   99537	     11865 ns/op	   19512 B/op	     175 allocs/op
+func BenchmarkHTTPQueryParallel(b *testing.B) {
+	db, _ := spi.DefaultPool()
+	db.SetMaxOpenConns(200)
+	db.SetMaxIdleConns(2)
+	sql := "SELECT 1"
+	target := httpServerAddress + "/db/query?q=" + url.QueryEscape(sql) + "&tz=Asia/Seoul&timeformat=Default"
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        200,
+			MaxIdleConnsPerHost: 200,
+			MaxConnsPerHost:     0,
+		},
+	}
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req, err := http.NewRequest(http.MethodGet, target, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			rsp, err := client.Do(req)
+			if err != nil {
+				b.Fatal(err)
+			}
+			io.Copy(io.Discard, rsp.Body)
+			rsp.Body.Close()
+			if rsp.StatusCode != http.StatusOK {
+				b.Fatalf("unexpected status: %d", rsp.StatusCode)
+			}
+		}
+	})
+}
+
 func TestStatz(t *testing.T) {
 	at, _, err := jwtLogin("sys", "manager")
 	require.NoError(t, err)

--- a/mods/server/http_write.go
+++ b/mods/server/http_write.go
@@ -76,9 +76,13 @@ func (svr *httpd) handleWrite(ctx *gin.Context) {
 	default:
 	}
 
-	conn, err := svr.getTrustConnection(ctx)
+	conn, err := getPoolConn(ctx)
 	if err != nil {
-		errRsp(http.StatusUnauthorized, err.Error())
+		svr.log.Warnf("query pooled connection unavailable: %s", err.Error())
+		rsp.Reason = "service unavailable"
+		rsp.Elapse = time.Since(tick).String()
+		ctx.Header("Retry-After", "1")
+		ctx.JSON(http.StatusServiceUnavailable, rsp)
 		return
 	}
 	defer conn.Close()
@@ -477,7 +481,7 @@ func (svr *httpd) handleLineProtocol(ctx *gin.Context) {
 }
 
 func (svr *httpd) handleLineWrite(ctx *gin.Context) {
-	conn, err := svr.getTrustConnection(ctx)
+	conn, err := getPoolConn(ctx)
 	if err != nil {
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		return

--- a/mods/server/http_write.go
+++ b/mods/server/http_write.go
@@ -139,13 +139,6 @@ func (svr *httpd) handleWrite(ctx *gin.Context) {
 			opts.ColumnTypes(colTypes...),
 		)
 	} else { // insert
-		if tableDesc, err := api.DescribeTable(ctx, conn, tableName, false); err != nil {
-			errRsp(http.StatusInternalServerError, fmt.Sprintf("fail to get table info '%s', %s", tableName, err.Error()))
-			return
-		} else {
-			desc = tableDesc
-		}
-
 		var columnNames []string
 		var columnTypes []api.DataType
 		if format == "json" {

--- a/mods/server/mqtt_query.go
+++ b/mods/server/mqtt_query.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/machbase/neo-client/api"
 	"github.com/machbase/neo-server/v8/mods/codec"
 	"github.com/machbase/neo-server/v8/mods/codec/opts"
 	"github.com/machbase/neo-server/v8/mods/tql"
@@ -103,7 +102,7 @@ func (s *mqttd) handleQuery(cl *mqtt.Client, pk packets.Packet) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conn, err := spi.Default().Connect(ctx, api.WithAuthKey("sys", spi.DefaultKey()))
+	conn, err := getPoolConn(ctx)
 	if err != nil {
 		rsp.Reason = err.Error()
 		return

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -536,6 +536,19 @@ func (s *Server) startMachbaseCli() error {
 	return nil
 }
 
+func getPoolConn(ctx context.Context) (api.Conn, error) {
+	pool, poolErr := spi.DefaultPool()
+	if poolErr != nil {
+		return nil, poolErr
+	}
+	sqlConn, connErr := pool.Conn(ctx)
+	if connErr != nil {
+		return nil, connErr
+	}
+	conn := spi.WrapSqlConn(sqlConn)
+	return conn, nil
+}
+
 func (s *Server) AddServicePort(svc string, addr string) error {
 	svc = strings.ToLower(svc)
 	if strings.HasPrefix(addr, "tcp://") {

--- a/spi/sql_test.go
+++ b/spi/sql_test.go
@@ -1,0 +1,437 @@
+package spi_test
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/machbase/neo-client/machbase"
+	"github.com/stretchr/testify/require"
+)
+
+type sqlCompatFixture struct {
+	db        *sql.DB
+	tableName string
+}
+
+func newSQLCompatFixture(t *testing.T) *sqlCompatFixture {
+	t.Helper()
+
+	dsn := fmt.Sprintf("server=127.0.0.1:%d;user=sys;password=manager;fetch_rows=100", testServer.MachPort())
+	db, err := sql.Open("machbase", dsn)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(2)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	require.NoError(t, db.PingContext(t.Context()))
+
+	tableName := fmt.Sprintf("SQL_COMPAT_%d", time.Now().UnixNano())
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`CREATE TABLE %s (ID LONG NOT NULL, NAME VARCHAR(100))`, tableName))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(t.Context(), fmt.Sprintf(`DROP TABLE %s`, tableName))
+	})
+
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`INSERT INTO %s VALUES(?, ?)`, tableName), int64(1), "neo")
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`INSERT INTO %s VALUES(?, ?)`, tableName), int64(2), "machbase")
+	require.NoError(t, err)
+	_, err = db.ExecContext(t.Context(), fmt.Sprintf(`INSERT INTO %s VALUES(?, ?)`, tableName), int64(99), nil)
+	require.NoError(t, err)
+
+	return &sqlCompatFixture{db: db, tableName: tableName}
+}
+
+func TestMachbaseSQLCompatibilitySupported(t *testing.T) {
+	fixture := newSQLCompatFixture(t)
+	db := fixture.db
+	tableName := fixture.tableName
+
+	t.Run("db ping exec query row and prepare", func(t *testing.T) {
+		require.NoError(t, db.PingContext(t.Context()))
+
+		res, err := db.ExecContext(
+			t.Context(),
+			fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+			int64(3),
+			"driver",
+		)
+		require.NoError(t, err)
+		affected, err := res.RowsAffected()
+		require.NoError(t, err)
+		require.Equal(t, int64(1), affected)
+
+		rows, err := db.QueryContext(t.Context(), fmt.Sprintf("SELECT ID, NAME FROM %s ORDER BY ID", tableName))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, rows.Close())
+		})
+
+		require.True(t, rows.Next())
+		var id int64
+		var name string
+		require.NoError(t, rows.Scan(&id, &name))
+		require.Equal(t, int64(1), id)
+		require.Equal(t, "neo", name)
+
+		types, err := rows.ColumnTypes()
+		require.NoError(t, err)
+		require.Len(t, types, 2)
+		require.Equal(t, "ID", strings.ToUpper(types[0].Name()))
+		require.Equal(t, "LONG", strings.ToUpper(types[0].DatabaseTypeName()))
+
+		require.NoError(t, rows.Close())
+
+		var idByQueryRow int64
+		var nameByQueryRow string
+		require.NoError(
+			t,
+			db.QueryRowContext(
+				t.Context(),
+				fmt.Sprintf("SELECT ID, NAME FROM %s WHERE ID = ?", tableName),
+				int64(2),
+			).Scan(&idByQueryRow, &nameByQueryRow),
+		)
+		require.Equal(t, int64(2), idByQueryRow)
+		require.Equal(t, "machbase", nameByQueryRow)
+
+		stmt, err := db.PrepareContext(t.Context(), fmt.Sprintf("SELECT ID, NAME FROM %s WHERE ID = ?", tableName))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, stmt.Close())
+		})
+
+		stmtRows, err := stmt.QueryContext(t.Context(), int64(3))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, stmtRows.Close())
+		})
+		require.True(t, stmtRows.Next())
+		var sid int64
+		var sname string
+		require.NoError(t, stmtRows.Scan(&sid, &sname))
+		require.Equal(t, int64(3), sid)
+		require.Equal(t, "driver", sname)
+
+		stmtExec, err := db.PrepareContext(t.Context(), fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, stmtExec.Close())
+		})
+		execRes, err := stmtExec.ExecContext(t.Context(), int64(4), "prepared")
+		require.NoError(t, err)
+		execAffected, err := execRes.RowsAffected()
+		require.NoError(t, err)
+		require.Equal(t, int64(1), execAffected)
+	})
+
+	t.Run("sql conn raw exposes optional driver interfaces", func(t *testing.T) {
+		conn, err := db.Conn(t.Context())
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		require.NoError(t, conn.PingContext(t.Context()))
+
+		var support map[string]bool
+		err = conn.Raw(func(dc any) error {
+			support = map[string]bool{
+				"driver.Conn":               false,
+				"driver.ConnPrepareContext": false,
+				"driver.ExecerContext":      false,
+				"driver.QueryerContext":     false,
+				"driver.Pinger":             false,
+				"driver.NamedValueChecker":  false,
+				"driver.Validator":          false,
+				"driver.SessionResetter":    false,
+				"driver.ConnBeginTx":        false,
+			}
+			if _, ok := dc.(driver.Conn); ok {
+				support["driver.Conn"] = true
+			}
+			if _, ok := dc.(driver.ConnPrepareContext); ok {
+				support["driver.ConnPrepareContext"] = true
+			}
+			if _, ok := dc.(driver.ExecerContext); ok {
+				support["driver.ExecerContext"] = true
+			}
+			if _, ok := dc.(driver.QueryerContext); ok {
+				support["driver.QueryerContext"] = true
+			}
+			if _, ok := dc.(driver.Pinger); ok {
+				support["driver.Pinger"] = true
+			}
+			if _, ok := dc.(driver.NamedValueChecker); ok {
+				support["driver.NamedValueChecker"] = true
+			}
+			if _, ok := dc.(driver.Validator); ok {
+				support["driver.Validator"] = true
+			}
+			if _, ok := dc.(driver.SessionResetter); ok {
+				support["driver.SessionResetter"] = true
+			}
+			if _, ok := dc.(driver.ConnBeginTx); ok {
+				support["driver.ConnBeginTx"] = true
+			}
+			return nil
+		})
+		require.NoError(t, err)
+
+		require.True(t, support["driver.Conn"])
+		require.True(t, support["driver.ConnPrepareContext"])
+		require.True(t, support["driver.ExecerContext"])
+		require.True(t, support["driver.QueryerContext"])
+		require.True(t, support["driver.Pinger"])
+		require.True(t, support["driver.NamedValueChecker"])
+		require.True(t, support["driver.Validator"])
+		require.True(t, support["driver.SessionResetter"])
+		require.True(t, support["driver.ConnBeginTx"])
+	})
+}
+
+func TestMachbaseSQLCompatibilityGaps(t *testing.T) {
+	fixture := newSQLCompatFixture(t)
+	db := fixture.db
+	tableName := fixture.tableName
+
+	t.Run("transactions are not supported", func(t *testing.T) {
+		// TODO: implement transaction support in neo-client/machbase (Begin/BeginTx, Commit, Rollback).
+		tx, err := db.BeginTx(t.Context(), nil)
+		require.Error(t, err)
+		require.Nil(t, tx)
+		require.Contains(t, strings.ToLower(err.Error()), "does not support explicit transactions")
+	})
+
+	t.Run("named parameters are not supported", func(t *testing.T) {
+		// TODO: add named parameter binding support in neo-client/machbase driver (sql.Named / :name / @name).
+		_, err := db.ExecContext(
+			t.Context(),
+			fmt.Sprintf("UPDATE %s SET NAME = @name WHERE ID = 1", tableName),
+			sql.Named("name", "neo"),
+		)
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), "named parameters")
+	})
+
+	t.Run("last insert id is not implemented", func(t *testing.T) {
+		// TODO: provide LastInsertId mapping if machbase engine can expose deterministic inserted row identifier.
+		res, err := db.ExecContext(
+			t.Context(),
+			fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+			int64(10),
+			"gap",
+		)
+		require.NoError(t, err)
+		_, err = res.LastInsertId()
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), "not implemented")
+	})
+}
+
+func TestMachbaseSQLCompatibilityCoreTypes(t *testing.T) {
+	fixture := newSQLCompatFixture(t)
+	db := fixture.db
+	tableName := fixture.tableName
+
+	t.Run("sql.Result compatibility", func(t *testing.T) {
+		res, err := db.ExecContext(
+			t.Context(),
+			fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+			int64(11),
+			"result-check",
+		)
+		require.NoError(t, err)
+
+		affected, err := res.RowsAffected()
+		require.NoError(t, err)
+		require.Equal(t, int64(1), affected)
+
+		affectedAgain, err := res.RowsAffected()
+		require.NoError(t, err)
+		require.Equal(t, int64(1), affectedAgain)
+	})
+
+	t.Run("sql.Rows compatibility", func(t *testing.T) {
+		rows, err := db.QueryContext(
+			t.Context(),
+			fmt.Sprintf("SELECT ID, NAME FROM %s WHERE ID >= ? AND NAME IS NOT NULL ORDER BY ID", tableName),
+			int64(1),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, rows.Close())
+		})
+
+		cols, err := rows.Columns()
+		require.NoError(t, err)
+		require.Equal(t, []string{"ID", "NAME"}, []string{strings.ToUpper(cols[0]), strings.ToUpper(cols[1])})
+
+		count := 0
+		for rows.Next() {
+			var id int64
+			var name string
+			require.NoError(t, rows.Scan(&id, &name))
+			require.NotEmpty(t, name)
+			count++
+		}
+		require.GreaterOrEqual(t, count, 2)
+		require.NoError(t, rows.Err())
+
+		// EOF after exhaustion should keep returning false.
+		require.False(t, rows.Next())
+		require.NoError(t, rows.Err())
+
+		require.NoError(t, rows.Close())
+		require.NoError(t, rows.Close())
+	})
+
+	t.Run("sql.Row compatibility", func(t *testing.T) {
+		t.Run("single row scan", func(t *testing.T) {
+			var id int64
+			var name string
+			err := db.QueryRowContext(
+				t.Context(),
+				fmt.Sprintf("SELECT ID, NAME FROM %s WHERE ID = ?", tableName),
+				int64(1),
+			).Scan(&id, &name)
+			require.NoError(t, err)
+			require.Equal(t, int64(1), id)
+			require.Equal(t, "neo", name)
+		})
+
+		t.Run("no rows returns sql.ErrNoRows", func(t *testing.T) {
+			var id int64
+			err := db.QueryRowContext(
+				t.Context(),
+				fmt.Sprintf("SELECT ID FROM %s WHERE ID = ?", tableName),
+				int64(-1),
+			).Scan(&id)
+			require.ErrorIs(t, err, sql.ErrNoRows)
+		})
+
+		t.Run("scan type mismatch returns error", func(t *testing.T) {
+			var invalidDest time.Time
+			err := db.QueryRowContext(
+				t.Context(),
+				fmt.Sprintf("SELECT NAME FROM %s WHERE ID = ?", tableName),
+				int64(1),
+			).Scan(&invalidDest)
+			require.Error(t, err)
+		})
+	})
+}
+
+func TestMachbaseSQLCompatibilityAdvanced(t *testing.T) {
+	fixture := newSQLCompatFixture(t)
+	db := fixture.db
+	tableName := fixture.tableName
+
+	t.Run("column types metadata", func(t *testing.T) {
+		rows, err := db.QueryContext(
+			t.Context(),
+			fmt.Sprintf("SELECT ID, NAME FROM %s ORDER BY ID", tableName),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, rows.Close())
+		})
+
+		types, err := rows.ColumnTypes()
+		require.NoError(t, err)
+		require.Len(t, types, 2)
+
+		require.Equal(t, "ID", strings.ToUpper(types[0].Name()))
+		require.Equal(t, "NAME", strings.ToUpper(types[1].Name()))
+		require.Equal(t, "LONG", strings.ToUpper(types[0].DatabaseTypeName()))
+		require.Equal(t, "VARCHAR", strings.ToUpper(types[1].DatabaseTypeName()))
+
+		require.Equal(t, reflect.TypeOf(int64(0)), types[0].ScanType())
+		require.Equal(t, reflect.TypeOf(""), types[1].ScanType())
+
+		nullableID, okID := types[0].Nullable()
+		require.True(t, okID)
+		// TODO: verify NOT NULL fidelity for machbase metadata path. ID is declared NOT NULL,
+		// but current metadata can report nullable=true depending on backend metadata source.
+		_ = nullableID
+
+		nullableName, okName := types[1].Nullable()
+		require.True(t, okName)
+		require.True(t, nullableName)
+
+		length, okLength := types[1].Length()
+		require.True(t, okLength)
+		require.Equal(t, int64(100), length)
+	})
+
+	t.Run("null scan compatibility", func(t *testing.T) {
+		row := db.QueryRowContext(
+			t.Context(),
+			fmt.Sprintf("SELECT ID, NAME FROM %s WHERE ID = ?", tableName),
+			int64(99),
+		)
+
+		var id int64
+		var name sql.NullString
+		err := row.Scan(&id, &name)
+		require.NoError(t, err)
+		require.Equal(t, int64(99), id)
+		require.False(t, name.Valid)
+	})
+
+	t.Run("context cancellation and deadline propagation", func(t *testing.T) {
+		cancelCtx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		_, err := db.QueryContext(
+			cancelCtx,
+			fmt.Sprintf("SELECT ID, NAME FROM %s WHERE ID = ?", tableName),
+			int64(1),
+		)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+
+		expiredCtx, cancelExpired := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+		defer cancelExpired()
+
+		_, err = db.QueryContext(
+			expiredCtx,
+			fmt.Sprintf("SELECT ID, NAME FROM %s WHERE ID = ?", tableName),
+			int64(1),
+		)
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("connection pool max open connections", func(t *testing.T) {
+		db.SetMaxOpenConns(1)
+		db.SetMaxIdleConns(1)
+
+		conn1, err := db.Conn(t.Context())
+		require.NoError(t, err)
+
+		acquireCtx, cancelAcquire := context.WithTimeout(t.Context(), 200*time.Millisecond)
+		defer cancelAcquire()
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, acqErr := db.Conn(acquireCtx)
+			errCh <- acqErr
+		}()
+
+		acqErr := <-errCh
+		require.Error(t, acqErr)
+		require.ErrorIs(t, acqErr, context.DeadlineExceeded)
+
+		require.NoError(t, conn1.Close())
+		require.Equal(t, 1, db.Stats().MaxOpenConnections)
+	})
+}

--- a/spi/watch.go
+++ b/spi/watch.go
@@ -95,6 +95,7 @@ func (w *Watcher) init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	if tableType, err := QueryTableType(ctx, conn, w.TableName); err != nil {
 		return err
 	} else if tableType != api.TableTypeTag && tableType != api.TableTypeLog {


### PR DESCRIPTION
This pull request refactors database connection handling across the server codebase to centralize and standardize the use of pooled connections. The changes replace previous ad-hoc or context-specific connection acquisition with a new `getPoolConn` helper function, improving maintainability and consistency. Additionally, a new parallel HTTP query benchmark is introduced, and minor improvements are made to resource management.

**Database Connection Refactoring:**

* Added a new `getPoolConn` helper function in `server.go` to encapsulate pooled connection acquisition and wrapping, replacing repetitive connection logic throughout the codebase.
* Updated all HTTP and MQTT query/write handlers (`http_query.go`, `http_write.go`, `mqtt_query.go`) to use `getPoolConn` instead of previous connection methods, ensuring consistent pooled connection usage and error handling. [[1]](diffhunk://#diff-7dbcb2816ab1b320be3db5cde03ad796cf3583ce6eb8375f49310162305408c0L168-L187) [[2]](diffhunk://#diff-7dbcb2816ab1b320be3db5cde03ad796cf3583ce6eb8375f49310162305408c0L416-R405) [[3]](diffhunk://#diff-1052c4d89cd222dc9d84c2f24c064bade1be414b9a81006e30e44d57b8241dcfL79-R85) [[4]](diffhunk://#diff-1052c4d89cd222dc9d84c2f24c064bade1be414b9a81006e30e44d57b8241dcfL480-R477) [[5]](diffhunk://#diff-7c7b320f0d0d89e0d85ac6c75bf62f280a1c4053ff506e2fe4bd14101ef104eeL106-R105)

**Benchmarking and Resource Management:**

* Added a new `BenchmarkHTTPQueryParallel` benchmark in `http_test.go` to measure parallel HTTP query performance under different database pool settings, aiding performance analysis and tuning.
* Ensured proper connection closure in the watcher initialization logic to prevent resource leaks.

**Dependency Update:**

* Updated the `github.com/machbase/neo-client` dependency in `go.mod` to a newer commit.