### PR TITLE
refactor: update schedule methods to use structured request payloads

### DIFF
--- a/docs/jsonrpc.gen.md
+++ b/docs/jsonrpc.gen.md
@@ -523,7 +523,12 @@ registerProxy registers a service proxy entry.
 `proxy.register(req)`
 
 *Params*
-- `req` *object<ProxyRegisterRequest>* - proxy registration request
+- `req` *object* - proxy registration request
+  - `req.service` *string*
+  - `req.prefix` *string*
+  - `req.target` *string*
+  - `req.strip_prefix` *string, optional*
+  - `req.health_path` *string, optional*
 
 *Return*
 
@@ -543,7 +548,13 @@ registerProxy registers a service proxy entry.
         "id": 20,
         "method": "proxy.register",
         "params": [
-            {}
+            {
+                "health_path": "string",
+                "prefix": "string",
+                "service": "string",
+                "strip_prefix": "string",
+                "target": "string"
+            }
         ]
     }
 }
@@ -572,7 +583,9 @@ unregisterProxy removes service proxy entries by filter.
 `proxy.unregister(req)`
 
 *Params*
-- `req` *object<ProxyUnregisterRequest>* - proxy unregister request
+- `req` *object* - proxy unregister request
+  - `req.service` *string*
+  - `req.prefix` *string, optional*
 
 *Return*
 
@@ -592,7 +605,10 @@ unregisterProxy removes service proxy entries by filter.
         "id": 20,
         "method": "proxy.unregister",
         "params": [
-            {}
+            {
+                "prefix": "string",
+                "service": "string"
+            }
         ]
     }
 }
@@ -670,7 +686,9 @@ getProxy gets one service proxy entry.
 `proxy.get(req)`
 
 *Params*
-- `req` *object<ProxyGetRequest>* - proxy lookup request
+- `req` *object* - proxy lookup request
+  - `req.service` *string*
+  - `req.prefix` *string*
 
 *Return*
 
@@ -690,7 +708,10 @@ getProxy gets one service proxy entry.
         "id": 20,
         "method": "proxy.get",
         "params": [
-            {}
+            {
+                "prefix": "string",
+                "service": "string"
+            }
         ]
     }
 }
@@ -1762,13 +1783,14 @@ addTimerSchedule creates a timer schedule.
 
 return: null on success
 
-`schedule.timer.add(name, spec, command, autoStart)`
+`schedule.timer.add(req)`
 
 *Params*
-- `name` *string* - schedule name
-- `spec` *string* - cron-like timer expression
-- `command` *string* - task command to execute
-- `autoStart` *bool* - whether to start right after creation
+- `req` *object* - timer schedule request
+  - `req.name` *string*
+  - `req.spec` *string*
+  - `req.command` *string*
+  - `req.autoStart` *bool, optional*
 
 *Return*
 
@@ -1788,10 +1810,12 @@ return: null on success
         "id": 20,
         "method": "schedule.timer.add",
         "params": [
-            "string",
-            "string",
-            "string",
-            false
+            {
+                "autoStart": false,
+                "command": "string",
+                "name": "string",
+                "spec": "string"
+            }
         ]
     }
 }
@@ -1815,20 +1839,26 @@ return: null on success
 
 #### schedule.subscriber.add
 
-addSubscriberSchedule creates an MQTT subscriber schedule.
+addSubscriberSchedule creates a subscriber schedule using a structured payload.
 
 
 return: null on success
 
-`schedule.subscriber.add(name, bridge, command, autoStart, topic, qos)`
+`schedule.subscriber.add(req)`
 
 *Params*
-- `name` *string* - schedule name
-- `bridge` *string* - bridge name
-- `command` *string* - task command to execute
-- `autoStart` *bool* - whether to start right after creation
-- `topic` *string* - MQTT topic filter
-- `qos` *int* - MQTT QoS level
+- `req` *object* - subscriber schedule request with protocol-specific options
+  - `req.name` *string*
+  - `req.bridge` *string*
+  - `req.command` *string*
+  - `req.autoStart` *bool, optional*
+  - `req.mqtt` *object, optional*
+  - `req.mqtt.topic` *string*
+  - `req.mqtt.qos` *int, optional*
+  - `req.nats` *object, optional*
+  - `req.nats.subject` *string*
+  - `req.nats.queueName` *string, optional*
+  - `req.nats.streamName` *string, optional*
 
 *Return*
 
@@ -1848,12 +1878,21 @@ return: null on success
         "id": 20,
         "method": "schedule.subscriber.add",
         "params": [
-            "string",
-            "string",
-            "string",
-            false,
-            "string",
-            0
+            {
+                "autoStart": false,
+                "bridge": "string",
+                "command": "string",
+                "mqtt": {
+                    "qos": 0,
+                    "topic": "string"
+                },
+                "name": "string",
+                "nats": {
+                    "queueName": "string",
+                    "streamName": "string",
+                    "subject": "string"
+                }
+            }
         ]
     }
 }
@@ -2409,6 +2448,7 @@ splitSqlStatements splits SQL text into executable statements.
   - `beginLine`: the line number where the statement starts
   - `endLine`: the line number where the statement ends
   - `isComment`: whether the statement is a comment
+  - `stmtType`: lower-case SQL statement type derived from statement text (e.g. select, update, drop)
   - `env`: scoped environment, if any, for the statement; it MAY contain the following fields:
   - `env.error`: error message if the statement has an error
   - `env.bridge`: bridge name if the statement is executed in a bridge context
@@ -2459,7 +2499,11 @@ rpcLspDiagnostics returns diagnostics for a document.
 `lsp.diagnostics(req)`
 
 *Params*
-- `req` *object<lspDocumentRequest>* - LSP document request
+- `req` *object* - LSP document request
+  - `req.language` *string*
+  - `req.uri` *string*
+  - `req.text` *string*
+  - `req.position` *object<base.Position>*
 
 *Return*
 
@@ -2479,7 +2523,12 @@ rpcLspDiagnostics returns diagnostics for a document.
         "id": 20,
         "method": "lsp.diagnostics",
         "params": [
-            {}
+            {
+                "language": "string",
+                "position": {},
+                "text": "string",
+                "uri": "string"
+            }
         ]
     }
 }
@@ -2508,7 +2557,11 @@ rpcLspCompletion returns completion items for a document position.
 `lsp.completion(req)`
 
 *Params*
-- `req` *object<lspDocumentRequest>* - LSP document request
+- `req` *object* - LSP document request
+  - `req.language` *string*
+  - `req.uri` *string*
+  - `req.text` *string*
+  - `req.position` *object<base.Position>*
 
 *Return*
 
@@ -2528,7 +2581,12 @@ rpcLspCompletion returns completion items for a document position.
         "id": 20,
         "method": "lsp.completion",
         "params": [
-            {}
+            {
+                "language": "string",
+                "position": {},
+                "text": "string",
+                "uri": "string"
+            }
         ]
     }
 }
@@ -2557,7 +2615,11 @@ rpcLspHover returns hover information for a document position.
 `lsp.hover(req)`
 
 *Params*
-- `req` *object<lspDocumentRequest>* - LSP document request
+- `req` *object* - LSP document request
+  - `req.language` *string*
+  - `req.uri` *string*
+  - `req.text` *string*
+  - `req.position` *object<base.Position>*
 
 *Return*
 
@@ -2577,7 +2639,12 @@ rpcLspHover returns hover information for a document position.
         "id": 20,
         "method": "lsp.hover",
         "params": [
-            {}
+            {
+                "language": "string",
+                "position": {},
+                "text": "string",
+                "uri": "string"
+            }
         ]
     }
 }
@@ -2606,7 +2673,11 @@ rpcLspSignatureHelp returns signature help for a document position.
 `lsp.signature(req)`
 
 *Params*
-- `req` *object<lspDocumentRequest>* - LSP document request
+- `req` *object* - LSP document request
+  - `req.language` *string*
+  - `req.uri` *string*
+  - `req.text` *string*
+  - `req.position` *object<base.Position>*
 
 *Return*
 
@@ -2626,7 +2697,12 @@ rpcLspSignatureHelp returns signature help for a document position.
         "id": 20,
         "method": "lsp.signature",
         "params": [
-            {}
+            {
+                "language": "string",
+                "position": {},
+                "text": "string",
+                "uri": "string"
+            }
         ]
     }
 }
@@ -2655,7 +2731,8 @@ rpcLspMetadata returns language metadata.
 `lsp.metadata(req)`
 
 *Params*
-- `req` *object<lspMetadataRequest>* - LSP metadata request
+- `req` *object* - LSP metadata request
+  - `req.language` *string*
 
 *Return*
 
@@ -2675,7 +2752,9 @@ rpcLspMetadata returns language metadata.
         "id": 20,
         "method": "lsp.metadata",
         "params": [
-            {}
+            {
+                "language": "string"
+            }
         ]
     }
 }

--- a/jsh/usr/lib/neoapi.js
+++ b/jsh/usr/lib/neoapi.js
@@ -342,11 +342,23 @@ class Client extends _Client {
 
         return this._executeWithAuth(() => {
             if (type === 'SUBSCRIBER') {
-                return this._rpcRequest('schedule.subscriber.add',
-                    [name, bridge, task, true, topic, qos]);
+                return this._rpcRequest('schedule.subscriber.add', [{
+                    name,
+                    bridge,
+                    command: task,
+                    autoStart: !!autostart,
+                    mqtt: {
+                        topic,
+                        qos,
+                    },
+                }]);
             } else if (type === 'TIMER') {
-                return this._rpcRequest('schedule.timer.add',
-                    [name, spec, task, autostart]);
+                return this._rpcRequest('schedule.timer.add', [{
+                    name,
+                    spec,
+                    command: task,
+                    autoStart: !!autostart,
+                }]);
             } else {
                 throw new Error(`Unsupported schedule type: ${type}`);
             }

--- a/mods/server/docgen/docgen_test.go
+++ b/mods/server/docgen/docgen_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"go/ast"
+	"go/parser"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -288,4 +293,258 @@ func TestSplitDocAndParamDocEmptyComment(t *testing.T) {
 	require.Empty(t, paramDoc)
 	require.Empty(t, returnDoc)
 	require.Empty(t, returnFieldDoc)
+}
+
+func TestDocgenHelpers(t *testing.T) {
+	current, err := currentDir()
+	require.NoError(t, err)
+	require.NotEmpty(t, current)
+
+	require.Equal(t, "jsonrpc.gen.md", pathBase("/tmp/jsonrpc.gen.md"))
+	require.Equal(t, "neo", pathBase("github.com/machbase/neo-server/v8/neo"))
+
+	importSpec := &ast.ImportSpec{Path: &ast.BasicLit{Value: `"github.com/machbase/neo-server/v8/mods/scheduler"`}}
+	require.Equal(t, "scheduler", importAlias(importSpec, "github.com/machbase/neo-server/v8/mods/scheduler"))
+	importSpec.Name = &ast.Ident{Name: "sched"}
+	require.Equal(t, "sched", importAlias(importSpec, "github.com/machbase/neo-server/v8/mods/scheduler"))
+
+	require.Equal(t, "Server", normalizeReceiverType(&ast.Ident{Name: "Server"}))
+	require.Equal(t, "Server", normalizeReceiverType(&ast.StarExpr{X: &ast.Ident{Name: "Server"}}))
+
+	quoted := &ast.BasicLit{Value: "`json:\"name,omitempty\"`"}
+	name, optional, skip := jsonFieldName("Name", quoted)
+	require.False(t, skip)
+	require.Equal(t, "name", name)
+	require.True(t, optional)
+
+	name, optional, skip = jsonFieldName("Name", &ast.BasicLit{Value: "`json:\"-\"`"})
+	require.True(t, skip)
+	require.False(t, optional)
+	require.Empty(t, name)
+
+	name, optional, skip = jsonFieldName("Name", nil)
+	require.False(t, skip)
+	require.False(t, optional)
+	require.Equal(t, "Name", name)
+
+	require.True(t, isPointerExpr(&ast.StarExpr{X: &ast.Ident{Name: "Meta"}}))
+	require.False(t, isPointerExpr(&ast.Ident{Name: "Meta"}))
+
+	require.True(t, isImplicitParam("context.Context"))
+	require.True(t, isImplicitParam("json.RawMessage"))
+	require.False(t, isImplicitParam("string"))
+
+	retKey, retDesc, ok := parseReturnHeaderLine("return: result description", map[string]struct{}{}, 1, 1)
+	require.True(t, ok)
+	require.Equal(t, "1", retKey)
+	require.Equal(t, "result description", retDesc)
+
+	var desc string
+	name, desc, ok = parseSectionItem("- field: field description")
+	require.True(t, ok)
+	require.Equal(t, "field", name)
+	require.Equal(t, "field description", desc)
+
+	retKey, ok = matchReturnDocKey("result", map[string]struct{}{}, 2, 1)
+	require.True(t, ok)
+	require.Equal(t, "1", retKey)
+	retKey, ok = matchReturnDocKey("return2", map[string]struct{}{}, 3, 1)
+	require.True(t, ok)
+	require.Equal(t, "2", retKey)
+
+	params := []fieldInfo{{Name: "first"}, {Name: "second"}}
+	require.Equal(t, []string{"first", "second"}, paramNames(params))
+
+	returns := []fieldInfo{{Name: "value", Type: "string"}, {Name: "err", Type: "error"}}
+	filtered := explicitReturns(returns)
+	require.Len(t, filtered, 1)
+	require.Equal(t, "value", filtered[0].Name)
+	require.True(t, isImplicitParam("context.Context"))
+
+	ident := func(expr string) ast.Expr {
+		parsed, err := parser.ParseExpr(expr)
+		require.NoError(t, err)
+		return parsed
+	}
+	require.Equal(t, "string", jsonType(ident("string"), ""))
+	require.Equal(t, "bool", jsonType(ident("bool"), ""))
+	require.Equal(t, "int", jsonType(ident("int"), ""))
+	require.Equal(t, "any", jsonType(ident("any"), ""))
+	require.Equal(t, "array<string>", jsonType(ident("[]string"), ""))
+	require.Equal(t, "object", jsonType(ident("map[string]any"), ""))
+	require.Equal(t, "object<example.Type>", jsonType(ident("example.Type"), ""))
+
+	require.Equal(t, "string", sampleValue(ident("string"), ""))
+}
+
+func TestDocgenEndToEndRenderAndResolution(t *testing.T) {
+	tmp := t.TempDir()
+	moduleRoot := filepath.Join(tmp)
+	hostDir := filepath.Join(moduleRoot, "docgentesthost")
+	depDir := filepath.Join(moduleRoot, "testpkg")
+	require.NoError(t, os.MkdirAll(hostDir, 0o755))
+	require.NoError(t, os.MkdirAll(depDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "dep.go"), []byte(`package testpkg
+
+type Payload struct {
+	Name string `+"`json:\"name\"`"+`
+}
+
+func Add(name string) error {
+	return nil
+}
+`), 0o644))
+
+	require.NoError(t, os.WriteFile(filepath.Join(hostDir, "host.go"), []byte(`package docgentesthost
+
+import (
+	"context"
+	tp "github.com/machbase/neo-server/v8/testpkg"
+)
+
+type Meta struct {
+	Count int `+"`json:\"count\"`"+`
+}
+
+type Request struct {
+	Name string `+"`json:\"name\"`"+`
+	Meta *Meta `+"`json:\"meta,omitempty\"`"+`
+	Tags []string `+"`json:\"tags,omitempty\"`"+`
+	Opts map[string]any `+"`json:\"opts,omitempty\"`"+`
+}
+
+type Response struct {
+	ID string `+"`json:\"id\"`"+`
+	Meta *Meta `+"`json:\"meta,omitempty\"`"+`
+}
+
+type Server struct{}
+
+// Handle processes a request.
+//
+// params:
+// - req: request payload
+//
+// return: response payload
+// - id: response identifier
+func (s *Server) Handle(ctx context.Context, req Request) (Response, error) {
+	return Response{ID: req.Name}, nil
+}
+
+func (s *Server) Ping(ctx context.Context) error {
+	return nil
+}
+
+func register(ctl interface{ RegisterJsonRpcHandler(string, any) }, s *Server) {
+	ctl.RegisterJsonRpcHandler("local.handle", s.Handle)
+	ctl.RegisterJsonRpcHandler("local.ping", s.Ping)
+	ctl.RegisterJsonRpcHandler("dep.add", tp.Add)
+}
+`), 0o644))
+
+	serverPkg, err := parsePackage(hostDir)
+	require.NoError(t, err)
+	require.Equal(t, "docgentesthost", serverPkg.Name)
+	require.Contains(t, serverPkg.Structs, "Request")
+	require.Contains(t, serverPkg.Methods, "Server.Handle")
+
+	depPkg, err := loadImportedPackage("github.com/machbase/neo-server/v8/testpkg", map[string]*packageInfo{}, moduleRoot)
+	require.NoError(t, err)
+	require.Equal(t, "testpkg", depPkg.Name)
+	require.Contains(t, depPkg.Functions, "Add")
+
+	regs, err := collectRegistrations(filepath.Join(hostDir, "host.go"), serverPkg, moduleRoot)
+	require.NoError(t, err)
+	require.Len(t, regs, 3)
+
+	md, err := renderMarkdown(regs)
+	require.NoError(t, err)
+	output := string(md)
+	require.Contains(t, output, "#### local.handle")
+	require.Contains(t, output, "`local.handle(req)`")
+	require.Contains(t, output, "req.meta.count")
+	require.Contains(t, output, "req.opts")
+	require.Contains(t, output, "#### dep.add")
+	require.Contains(t, output, "`dep.add(name)`")
+	require.Contains(t, output, "response payload")
+
+	request, response := sampleMessages("local.handle", explicitParams(serverPkg.Methods["Server.Handle"].Params), explicitReturns(serverPkg.Methods["Server.Handle"].Returns), serverPkg)
+	require.Equal(t, "local.handle", request.RPC.Method)
+	require.NotEmpty(t, request.RPC.Params)
+	require.IsType(t, map[string]any{}, request.RPC.Params[0])
+	require.NotNil(t, response.RPC.Result)
+
+	encodedReq, err := json.Marshal(request)
+	require.NoError(t, err)
+	require.Contains(t, string(encodedReq), "\"meta\"")
+
+	writeJSONBuffer := &bytes.Buffer{}
+	writeJSON(writeJSONBuffer, map[string]any{"ok": true})
+	require.Contains(t, writeJSONBuffer.String(), "```json")
+
+	respBuf := &bytes.Buffer{}
+	writeRequestResponseJSON(respBuf, request, response)
+	require.Contains(t, respBuf.String(), "Request/Response JSON")
+
+	entries := paramSchemaEntries("req", serverPkg.Methods["Server.Handle"].Params[1], serverPkg)
+	require.NotEmpty(t, entries)
+	require.Contains(t, entries[0].Path, "req.")
+
+	structName, st, ok := resolveStructType(serverPkg, serverPkg.Methods["Server.Handle"].Params[1].Expr)
+	require.True(t, ok)
+	require.Contains(t, structName, "Request")
+	require.NotNil(t, st)
+
+	require.True(t, isStructLikeField(serverPkg, serverPkg.Methods["Server.Handle"].Params[1].Expr))
+
+	titleCases := map[string]string{
+		"service.port.list": "Service Port List",
+		"lsp":               "Lsp",
+		"":                  "RPC",
+	}
+	for input, want := range titleCases {
+		require.Equal(t, want, title(input))
+	}
+
+	require.Equal(t, "Hello", upperFirst("hello"))
+	require.Equal(t, "", upperFirst(""))
+}
+
+func TestDocgenReturnRenderingHelpers(t *testing.T) {
+	docs := map[string]string{
+		"value": "named return",
+		"1":     "first return",
+		"2":     "second return",
+	}
+	fields := map[string][]docEntry{
+		"1": {
+			{Name: "id", Desc: "identifier"},
+		},
+		"value": {
+			{Name: "count", Desc: "value count"},
+		},
+	}
+	returns := []fieldInfo{
+		{Name: "value", Type: "string"},
+		{Name: "other", Type: "int"},
+	}
+
+	require.Equal(t, []string{"string|error - named return", "int|error - second return"}, returnLines(returns, docs))
+	require.Equal(t, "first return", returnDocByIndexOrName(docs, 1, ""))
+	require.Equal(t, "named return", returnDocByIndexOrName(docs, 1, "value"))
+	require.Equal(t, "", returnDocByIndexOrName(nil, 1, "value"))
+
+	buf := &bytes.Buffer{}
+	renderReturnLines(buf, returns, docs, fields)
+	output := buf.String()
+	require.Contains(t, output, "`string|error - named return`")
+	require.Contains(t, output, "`count`: value count")
+
+	require.Nil(t, sampleReturnValue(nil))
+	require.Equal(t, "string", sampleValue(&ast.Ident{Name: "string"}, ""))
+	require.Equal(t, map[string]any{}, sampleValue(&ast.MapType{}, ""))
+	request, response := sampleMessages("demo.method", []fieldInfo{{Expr: &ast.Ident{Name: "string"}, Type: "string"}}, []fieldInfo{{Expr: &ast.Ident{Name: "string"}, Type: "string"}}, nil)
+	require.Equal(t, "demo.method", request.RPC.Method)
+	require.NotNil(t, response.RPC.Result)
 }

--- a/mods/server/docgen/main.go
+++ b/mods/server/docgen/main.go
@@ -10,6 +10,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -22,6 +23,7 @@ type registeredMethod struct {
 	Name       string
 	Handler    string
 	Function   *functionInfo
+	Package    *packageInfo
 	SourceFile string
 }
 
@@ -51,6 +53,25 @@ type packageInfo struct {
 	Imports   map[string]string
 	Functions map[string]*functionInfo
 	Methods   map[string]*functionInfo
+	Structs   map[string]*structInfo
+}
+
+type structInfo struct {
+	Name   string
+	Fields []structFieldInfo
+}
+
+type structFieldInfo struct {
+	Name     string
+	Type     string
+	Expr     ast.Expr
+	Optional bool
+}
+
+type schemaEntry struct {
+	Path     string
+	Type     string
+	Optional bool
 }
 
 type rpcRequestEnvelope struct {
@@ -140,6 +161,7 @@ func parsePackage(dir string) (*packageInfo, error) {
 		Imports:   map[string]string{},
 		Functions: map[string]*functionInfo{},
 		Methods:   map[string]*functionInfo{},
+		Structs:   map[string]*structInfo{},
 	}
 
 	for _, file := range parsedPackage.Files {
@@ -152,6 +174,21 @@ func parsePackage(dir string) (*packageInfo, error) {
 		}
 
 		for _, declaration := range file.Decls {
+			gen, ok := declaration.(*ast.GenDecl)
+			if ok && gen.Tok == token.TYPE {
+				for _, spec := range gen.Specs {
+					typeSpec, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					st, ok := typeSpec.Type.(*ast.StructType)
+					if !ok {
+						continue
+					}
+					info.Structs[typeSpec.Name.Name] = parseStructInfo(typeSpec.Name.Name, st)
+				}
+			}
+
 			function, ok := declaration.(*ast.FuncDecl)
 			if !ok {
 				continue
@@ -170,6 +207,66 @@ func parsePackage(dir string) (*packageInfo, error) {
 		}
 	}
 	return info, nil
+}
+
+func parseStructInfo(name string, st *ast.StructType) *structInfo {
+	ret := &structInfo{Name: name}
+	if st == nil || st.Fields == nil {
+		return ret
+	}
+	for _, field := range st.Fields.List {
+		if len(field.Names) == 0 {
+			continue
+		}
+		for _, fieldName := range field.Names {
+			jsonName, optional, skip := jsonFieldName(fieldName.Name, field.Tag)
+			if skip {
+				continue
+			}
+			ret.Fields = append(ret.Fields, structFieldInfo{
+				Name:     jsonName,
+				Type:     renderExpr(field.Type),
+				Expr:     field.Type,
+				Optional: optional || isPointerExpr(field.Type),
+			})
+		}
+	}
+	return ret
+}
+
+func jsonFieldName(defaultName string, tag *ast.BasicLit) (string, bool, bool) {
+	if tag == nil {
+		return defaultName, false, false
+	}
+	tagValue, err := strconv.Unquote(tag.Value)
+	if err != nil {
+		return defaultName, false, false
+	}
+	jsonTag := reflect.StructTag(tagValue).Get("json")
+	if jsonTag == "" {
+		return defaultName, false, false
+	}
+	parts := strings.Split(jsonTag, ",")
+	name := strings.TrimSpace(parts[0])
+	if name == "-" {
+		return "", false, true
+	}
+	if name == "" {
+		name = defaultName
+	}
+	optional := false
+	for _, part := range parts[1:] {
+		if strings.TrimSpace(part) == "omitempty" {
+			optional = true
+			break
+		}
+	}
+	return name, optional, false
+}
+
+func isPointerExpr(expr ast.Expr) bool {
+	_, ok := expr.(*ast.StarExpr)
+	return ok
 }
 
 func importAlias(importSpec *ast.ImportSpec, importPath string) string {
@@ -486,7 +583,7 @@ func collectRegistrations(path string, serverPackage *packageInfo, moduleRoot st
 			firstErr = fmt.Errorf("unquote json-rpc method at %s: %w", fileSet.Position(methodLiteral.Pos()), err)
 			return false
 		}
-		handlerName, function, err := resolveHandler(call.Args[1], serverPackage, importedPackages, moduleRoot)
+		handlerName, function, ownerPackage, err := resolveHandler(call.Args[1], serverPackage, importedPackages, moduleRoot)
 		if err != nil {
 			firstErr = fmt.Errorf("resolve handler for %s: %w", methodName, err)
 			return false
@@ -495,6 +592,7 @@ func collectRegistrations(path string, serverPackage *packageInfo, moduleRoot st
 			Name:       methodName,
 			Handler:    handlerName,
 			Function:   function,
+			Package:    ownerPackage,
 			SourceFile: path,
 		})
 		return true
@@ -510,39 +608,39 @@ func isRegisterJsonRpcHandlerCall(call *ast.CallExpr) bool {
 	return ok && selector.Sel.Name == "RegisterJsonRpcHandler"
 }
 
-func resolveHandler(expr ast.Expr, serverPackage *packageInfo, importedPackages map[string]*packageInfo, moduleRoot string) (string, *functionInfo, error) {
+func resolveHandler(expr ast.Expr, serverPackage *packageInfo, importedPackages map[string]*packageInfo, moduleRoot string) (string, *functionInfo, *packageInfo, error) {
 	switch handler := expr.(type) {
 	case *ast.Ident:
 		fn := serverPackage.Functions[handler.Name]
 		if fn == nil {
-			return handler.Name, nil, fmt.Errorf("function %s not found", handler.Name)
+			return handler.Name, nil, nil, fmt.Errorf("function %s not found", handler.Name)
 		}
-		return handler.Name, fn, nil
+		return handler.Name, fn, serverPackage, nil
 	case *ast.SelectorExpr:
 		owner := renderExpr(handler.X)
 		if owner == "s" {
 			key := "Server." + handler.Sel.Name
 			fn := serverPackage.Methods[key]
 			if fn == nil {
-				return key, nil, fmt.Errorf("method %s not found", key)
+				return key, nil, nil, fmt.Errorf("method %s not found", key)
 			}
-			return key, fn, nil
+			return key, fn, serverPackage, nil
 		}
 		importPath, ok := serverPackage.Imports[owner]
 		if !ok {
-			return owner + "." + handler.Sel.Name, nil, fmt.Errorf("import alias %s not found", owner)
+			return owner + "." + handler.Sel.Name, nil, nil, fmt.Errorf("import alias %s not found", owner)
 		}
 		pkg, err := loadImportedPackage(importPath, importedPackages, moduleRoot)
 		if err != nil {
-			return owner + "." + handler.Sel.Name, nil, err
+			return owner + "." + handler.Sel.Name, nil, nil, err
 		}
 		fn := pkg.Functions[handler.Sel.Name]
 		if fn == nil {
-			return owner + "." + handler.Sel.Name, nil, fmt.Errorf("function %s not found in %s", handler.Sel.Name, importPath)
+			return owner + "." + handler.Sel.Name, nil, nil, fmt.Errorf("function %s not found in %s", handler.Sel.Name, importPath)
 		}
-		return owner + "." + handler.Sel.Name, fn, nil
+		return owner + "." + handler.Sel.Name, fn, pkg, nil
 	default:
-		return renderExpr(expr), nil, fmt.Errorf("unsupported handler expression %s", renderExpr(expr))
+		return renderExpr(expr), nil, nil, fmt.Errorf("unsupported handler expression %s", renderExpr(expr))
 	}
 }
 
@@ -621,11 +719,23 @@ func renderMethod(buffer *bytes.Buffer, registration registeredMethod) {
 			if name == "" {
 				name = fmt.Sprintf("param%d", index+1)
 			}
+			entries := paramSchemaEntries(name, param, registration.Package)
+			paramType := jsonType(param.Expr, param.Type)
+			if len(entries) > 0 {
+				paramType = "object"
+			}
 			desc := strings.TrimSpace(registration.Function.ParamDoc[name])
 			if desc == "" {
-				fmt.Fprintf(buffer, "- `%s` *%s*\n", name, jsonType(param.Expr, param.Type))
+				fmt.Fprintf(buffer, "- `%s` *%s*\n", name, paramType)
 			} else {
-				fmt.Fprintf(buffer, "- `%s` *%s* - %s\n", name, jsonType(param.Expr, param.Type), desc)
+				fmt.Fprintf(buffer, "- `%s` *%s* - %s\n", name, paramType, desc)
+			}
+			for _, entry := range entries {
+				typ := entry.Type
+				if entry.Optional {
+					typ += ", optional"
+				}
+				fmt.Fprintf(buffer, "  - `%s` *%s*\n", entry.Path, typ)
 			}
 		}
 	}
@@ -633,7 +743,7 @@ func renderMethod(buffer *bytes.Buffer, registration registeredMethod) {
 	buffer.WriteString("\n*Return*\n\n")
 	renderReturnLines(buffer, returns, registration.Function.ReturnDoc, registration.Function.ReturnFieldDoc)
 
-	request, response := sampleMessages(registration.Name, params, returns)
+	request, response := sampleMessages(registration.Name, params, returns, registration.Package)
 	buffer.WriteByte('\n')
 	writeRequestResponseJSON(buffer, request, response)
 	buffer.WriteByte('\n')
@@ -680,6 +790,63 @@ func paramNames(params []fieldInfo) []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+func paramSchemaEntries(paramName string, param fieldInfo, pkg *packageInfo) []schemaEntry {
+	if pkg == nil {
+		return nil
+	}
+	entries := []schemaEntry{}
+	collectSchemaEntries(&entries, pkg, param.Expr, paramName, map[string]bool{})
+	return entries
+}
+
+func collectSchemaEntries(entries *[]schemaEntry, pkg *packageInfo, expr ast.Expr, prefix string, visited map[string]bool) {
+	structName, structInfo, ok := resolveStructType(pkg, expr)
+	if !ok || structInfo == nil {
+		return
+	}
+	if visited[structName] {
+		return
+	}
+	visited[structName] = true
+	for _, field := range structInfo.Fields {
+		path := prefix + "." + field.Name
+		fieldType := jsonType(field.Expr, field.Type)
+		if isStructLikeField(pkg, field.Expr) {
+			fieldType = "object"
+		}
+		*entries = append(*entries, schemaEntry{
+			Path:     path,
+			Type:     fieldType,
+			Optional: field.Optional,
+		})
+		collectSchemaEntries(entries, pkg, field.Expr, path, visited)
+	}
+	delete(visited, structName)
+}
+
+func isStructLikeField(pkg *packageInfo, expr ast.Expr) bool {
+	_, _, ok := resolveStructType(pkg, expr)
+	return ok
+}
+
+func resolveStructType(pkg *packageInfo, expr ast.Expr) (string, *structInfo, bool) {
+	if pkg == nil {
+		return "", nil, false
+	}
+	switch typed := expr.(type) {
+	case *ast.StarExpr:
+		return resolveStructType(pkg, typed.X)
+	case *ast.Ident:
+		st, ok := pkg.Structs[typed.Name]
+		if !ok {
+			return "", nil, false
+		}
+		return pkg.Name + "." + typed.Name, st, true
+	default:
+		return "", nil, false
+	}
 }
 
 func returnLines(returns []fieldInfo, docs map[string]string) []string {
@@ -737,10 +904,10 @@ func returnDocByIndexOrName(docs map[string]string, idx int, name string) string
 	return ""
 }
 
-func sampleMessages(method string, params []fieldInfo, returns []fieldInfo) (rpcRequestEnvelope, rpcResponseEnvelope) {
+func sampleMessages(method string, params []fieldInfo, returns []fieldInfo, pkg *packageInfo) (rpcRequestEnvelope, rpcResponseEnvelope) {
 	sampleParams := make([]any, 0, len(params))
 	for _, param := range params {
-		sampleParams = append(sampleParams, sampleValue(param.Expr, param.Type))
+		sampleParams = append(sampleParams, sampleParamValue(param.Expr, param.Type, pkg, map[string]bool{}))
 	}
 	request := rpcRequestEnvelope{
 		Type:    "rpc_req",
@@ -762,6 +929,33 @@ func sampleMessages(method string, params []fieldInfo, returns []fieldInfo) (rpc
 		},
 	}
 	return request, response
+}
+
+func sampleParamValue(expr ast.Expr, fallback string, pkg *packageInfo, visited map[string]bool) any {
+	if pkg != nil {
+		if structName, st, ok := resolveStructType(pkg, expr); ok {
+			if visited[structName] {
+				return map[string]any{}
+			}
+			visited[structName] = true
+			obj := map[string]any{}
+			for _, field := range st.Fields {
+				obj[field.Name] = sampleParamValue(field.Expr, field.Type, pkg, visited)
+			}
+			delete(visited, structName)
+			return obj
+		}
+	}
+	switch typed := expr.(type) {
+	case *ast.StarExpr:
+		return sampleParamValue(typed.X, renderExpr(typed.X), pkg, visited)
+	case *ast.ArrayType:
+		return []any{}
+	case *ast.MapType:
+		return map[string]any{}
+	default:
+		return sampleValue(expr, fallback)
+	}
 }
 
 func sampleReturnValue(returns []fieldInfo) any {

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -1819,24 +1819,28 @@ func (s *Server) listSchedules(ctx context.Context) ([]*scheduler.Schedule, erro
 	return rsp.Schedules, nil
 }
 
+type addTimerScheduleRequest struct {
+	Name      string `json:"name"`
+	Spec      string `json:"spec"`
+	Command   string `json:"command"`
+	AutoStart bool   `json:"autoStart,omitempty"`
+}
+
 // addTimerSchedule creates a timer schedule.
 //
 // params:
-//   - name: schedule name
-//   - spec: cron-like timer expression
-//   - command: task command to execute
-//   - autoStart: whether to start right after creation
+//   - req: timer schedule request
 //
 // return: null on success
-func (s *Server) addTimerSchedule(ctx context.Context, name string, spec string, command string, autoStart bool) error {
-	req := &scheduler.AddScheduleRequest{
-		Name:      strings.ToLower(name),
+func (s *Server) addTimerSchedule(ctx context.Context, req addTimerScheduleRequest) error {
+	scheduleReq := &scheduler.AddScheduleRequest{
+		Name:      strings.ToLower(req.Name),
 		Type:      "TIMER",
-		AutoStart: autoStart,
-		Schedule:  spec,
-		Task:      command,
+		AutoStart: req.AutoStart,
+		Schedule:  req.Spec,
+		Task:      req.Command,
 	}
-	rsp, err := s.schedSvc.AddSchedule(ctx, req)
+	rsp, err := s.schedSvc.AddSchedule(ctx, scheduleReq)
 	if err != nil {
 		return err
 	}
@@ -1846,32 +1850,35 @@ func (s *Server) addTimerSchedule(ctx context.Context, name string, spec string,
 	return nil
 }
 
-// addSubscriberSchedule creates an MQTT subscriber schedule.
+// addSubscriberSchedule creates a subscriber schedule using a structured payload.
 //
 // params:
-//   - name: schedule name
-//   - bridge: bridge name
-//   - command: task command to execute
-//   - autoStart: whether to start right after creation
-//   - topic: MQTT topic filter
-//   - qos: MQTT QoS level
+//   - req: subscriber schedule request with protocol-specific options
 //
 // return: null on success
-func (s *Server) addSubscriberSchedule(ctx context.Context, name string, bridge string, command string, autoStart bool, topic string, qos int) error {
-	req := scheduler.AddScheduleRequest{
-		Name:      strings.ToLower(name),
+func (s *Server) addSubscriberSchedule(ctx context.Context, req addSubscriberScheduleRequest) error {
+	scheduleReq := scheduler.AddScheduleRequest{
+		Name:      strings.ToLower(req.Name),
 		Type:      "SUBSCRIBER",
-		AutoStart: autoStart,
-		Task:      command,
-		Bridge:    bridge,
-		Opt: scheduler.AddScheduleOption{
-			Mqtt: &scheduler.MqttOption{
-				Topic: topic,
-				QoS:   int32(qos),
-			},
-		},
+		AutoStart: req.AutoStart,
+		Task:      req.Command,
+		Bridge:    req.Bridge,
 	}
-	rsp, err := s.schedSvc.AddSchedule(ctx, &req)
+	if req.Mqtt != nil {
+		scheduleReq.Opt.Mqtt = &scheduler.MqttOption{
+			Topic: req.Mqtt.Topic,
+			QoS:   int32(req.Mqtt.QoS),
+		}
+	}
+	if req.Nats != nil {
+		scheduleReq.Opt.Nats = &scheduler.NatsOption{
+			Subject:    req.Nats.Subject,
+			QueueName:  req.Nats.QueueName,
+			StreamName: req.Nats.StreamName,
+		}
+	}
+
+	rsp, err := s.schedSvc.AddSchedule(ctx, &scheduleReq)
 	if err != nil {
 		return err
 	}
@@ -1879,6 +1886,26 @@ func (s *Server) addSubscriberSchedule(ctx context.Context, name string, bridge 
 		return errors.New(rsp.Reason)
 	}
 	return nil
+}
+
+type addSubscriberScheduleMqttOption struct {
+	Topic string `json:"topic"`
+	QoS   int    `json:"qos,omitempty"`
+}
+
+type addSubscriberScheduleNatsOption struct {
+	Subject    string `json:"subject"`
+	QueueName  string `json:"queueName,omitempty"`
+	StreamName string `json:"streamName,omitempty"`
+}
+
+type addSubscriberScheduleRequest struct {
+	Name      string                           `json:"name"`
+	Bridge    string                           `json:"bridge"`
+	Command   string                           `json:"command"`
+	AutoStart bool                             `json:"autoStart,omitempty"`
+	Mqtt      *addSubscriberScheduleMqttOption `json:"mqtt,omitempty"`
+	Nats      *addSubscriberScheduleNatsOption `json:"nats,omitempty"`
 }
 
 // deleteSchedule removes a schedule by name.

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -2206,7 +2206,12 @@ func TestServerCoverage_ScheduleWrappers(t *testing.T) {
 	ctx := context.Background()
 
 	name := fmt.Sprintf("cov_timer_%d", time.Now().UnixNano())
-	err := svr.addTimerSchedule(ctx, name, "@every 1m", "definitely_not_existing_command", false)
+	err := svr.addTimerSchedule(ctx, addTimerScheduleRequest{
+		Name:      name,
+		Spec:      "@every 1m",
+		Command:   "definitely_not_existing_command",
+		AutoStart: false,
+	})
 	require.Error(t, err)
 
 	err = svr.startSchedule(ctx, name)
@@ -2398,15 +2403,22 @@ func TestServerCoverage_AddSubscriberScheduleAndRunInitScripts(t *testing.T) {
 	ctx := context.Background()
 
 	name := fmt.Sprintf("cov_sub_%d", time.Now().UnixNano())
-	err := svr.addSubscriberSchedule(ctx,
-		name,
-		"missing-bridge",
-		"select 1",
-		false,
-		"test/topic",
-		1,
-	)
+	err := svr.addSubscriberSchedule(ctx, addSubscriberScheduleRequest{
+		Name:      name,
+		Bridge:    "missing-bridge",
+		Command:   "select 1",
+		AutoStart: false,
+		Mqtt: &addSubscriberScheduleMqttOption{
+			Topic: "test/topic",
+			QoS:   1,
+		},
+	})
 	require.NoError(t, err)
+	legacyDef, err := svr.models.ScheduleProvider().LoadSchedule(strings.ToLower(name))
+	require.NoError(t, err)
+	require.Equal(t, model.SCHEDULE_SUBSCRIBER, legacyDef.Type)
+	require.Equal(t, "test/topic", legacyDef.Topic)
+	require.Equal(t, 1, legacyDef.QoS)
 	t.Cleanup(func() {
 		_ = svr.stopSchedule(context.Background(), name)
 		_ = svr.deleteSchedule(context.Background(), name)
@@ -2435,6 +2447,64 @@ func TestServerCoverage_AddSubscriberScheduleAndRunInitScripts(t *testing.T) {
 	svr.StartupScriptFiles = []string{"", scriptPath}
 
 	require.NoError(t, svr.runInitScripts())
+}
+
+func TestServerCoverage_AddSubscriberSchedule(t *testing.T) {
+	svr := coverageRunningServer(t)
+	ctx := context.Background()
+
+	t.Run("nats_only", func(t *testing.T) {
+		name := fmt.Sprintf("cov_sub_v2_nats_%d", time.Now().UnixNano())
+		err := svr.addSubscriberSchedule(ctx, addSubscriberScheduleRequest{
+			Name:      name,
+			Bridge:    "missing-bridge",
+			Command:   "select 1",
+			AutoStart: false,
+			Nats: &addSubscriberScheduleNatsOption{
+				Subject:    "subject.>",
+				QueueName:  "workers",
+				StreamName: "orders",
+			},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = svr.stopSchedule(context.Background(), name)
+			_ = svr.deleteSchedule(context.Background(), name)
+		})
+
+		def, err := svr.models.ScheduleProvider().LoadSchedule(strings.ToLower(name))
+		require.NoError(t, err)
+		require.Equal(t, model.SCHEDULE_SUBSCRIBER, def.Type)
+		require.Equal(t, "subject.>", def.Topic)
+		require.Equal(t, "workers", def.QueueName)
+		require.Equal(t, "orders", def.StreamName)
+	})
+
+	t.Run("mqtt_only", func(t *testing.T) {
+		name := fmt.Sprintf("cov_sub_v2_mqtt_%d", time.Now().UnixNano())
+		err := svr.addSubscriberSchedule(ctx, addSubscriberScheduleRequest{
+			Name:      name,
+			Bridge:    "missing-bridge",
+			Command:   "select 1",
+			AutoStart: true,
+			Mqtt: &addSubscriberScheduleMqttOption{
+				Topic: "factory/#",
+				QoS:   2,
+			},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = svr.stopSchedule(context.Background(), name)
+			_ = svr.deleteSchedule(context.Background(), name)
+		})
+
+		def, err := svr.models.ScheduleProvider().LoadSchedule(strings.ToLower(name))
+		require.NoError(t, err)
+		require.Equal(t, model.SCHEDULE_SUBSCRIBER, def.Type)
+		require.Equal(t, true, def.AutoStart)
+		require.Equal(t, "factory/#", def.Topic)
+		require.Equal(t, 2, def.QoS)
+	})
 }
 
 func TestServerCoverage_PreparePortsHeadOnlyInvalid(t *testing.T) {


### PR DESCRIPTION
This pull request updates the API documentation and code generation for several JSON-RPC methods, moving from loosely-typed or positional parameter lists to explicit, structured request objects. It also enhances the Go doc generator to extract and render detailed request/response schemas from Go struct definitions, improving the accuracy and clarity of the generated API docs.

**API documentation and request structure improvements:**

* Updated the documentation for multiple JSON-RPC methods (such as `proxy.register`, `proxy.unregister`, `proxy.get`, `schedule.timer.add`, `schedule.subscriber.add`, and LSP methods) to describe their parameters as structured objects, detailing each field and its type, rather than referencing Go types or using positional arguments. Example requests in the docs now use object literals. [[1]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L526-R531) [[2]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L546-R557) [[3]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L575-R588) [[4]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L595-R611) [[5]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L673-R691) [[6]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L693-R714) [[7]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L1765-R1793) [[8]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L1791-R1818) [[9]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L1818-R1861) [[10]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L1851-R1895) [[11]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2462-R2506) [[12]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2482-R2531) [[13]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2511-R2564) [[14]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2531-R2589) [[15]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2560-R2622) [[16]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2580-R2647) [[17]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2609-R2680) [[18]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2629-R2705) [[19]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2658-R2735) [[20]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2678-R2757)

* Added new fields to documentation, such as `stmtType` for SQL statement splitting, and expanded protocol-specific options for subscriber schedules (e.g., MQTT and NATS). [[1]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1R2451) [[2]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L1818-R1861)

**Code generation and docgen enhancements:**

* Refactored the Go doc generator (`mods/server/docgen/main.go`) to:
    - Parse struct type definitions and their fields, including handling JSON tags for field names and optionality.
    - Track which package owns each struct and function for more accurate schema extraction.
    - Expose detailed schema information for documentation generation. [[1]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272R13) [[2]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272R26) [[3]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272R56-R74) [[4]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272R164) [[5]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272R177-R191) [[6]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272R212-R271) [[7]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272L489-R586) [[8]](diffhunk://#diff-e073c4d7f0794e0c447da677335939aafc277e5b847183be791371ea112c2272R595)

**Client and example updates:**

* Updated the JavaScript client (`neoapi.js`) to send requests as structured objects matching the new API documentation, instead of positional argument lists.

These changes make the API documentation more precise, enable better client/server code generation, and ensure that future documentation stays in sync with the Go type definitions.