### PR TITLE
update session management and connection settings in various components

### DIFF
--- a/docs/jsonrpc.gen.md
+++ b/docs/jsonrpc.gen.md
@@ -2537,13 +2537,16 @@ statSession returns session statistics.
 
 *Return*
 
-- `object<spi.Statz>|error - session statistics`
-  - `queryExecHwm` *uint64*
-  - `queryExecAvg` *uint64*
-  - `queryWaitHwm` *uint64*
-  - `queryWaitAvg` *uint64*
-  - `queryFetchHwm` *uint64*
-  - `queryFetchAvg` *uint64*
+- `object<SessionStats>|error - session statistics`
+  - `maxOpenConnections` *int*
+  - `openConnections` *int*
+  - `inUse` *int*
+  - `idle` *int*
+  - `waitCount` *int64*
+  - `waitAvgDuration` *string*
+  - `maxIdleClosed` *int64*
+  - `maxIdleTimeClosed` *int64*
+  - `maxLifetimeClosed` *int64*
 
 <details>
 <summary>Request/Response JSON</summary>
@@ -2594,11 +2597,10 @@ getSessionLimit returns session pool limit settings.
 *Return*
 
 - `object<SessionLimit>|error - session limit information`
-  - `MaxPoolSize` *int*
-  - `MaxOpenConn` *int*
-  - `RemainedOpenConn` *int*
-  - `MaxOpenQuery` *int*
-  - `RemainedOpenQuery` *int*
+  - `maxOpenConn` *int*
+  - `maxIdleConn` *int*
+  - `connMaxIdleTime` *string*
+  - `connMaxLifetime` *string*
 
 <details>
 <summary>Request/Response JSON</summary>
@@ -2644,7 +2646,11 @@ return: null on success
 `session.limit.set(m)`
 
 *Params*
-- `m` *object* - limit setting map with MaxPoolSize, MaxOpenConn, and MaxOpenQuery keys
+- `m` *object* - limit setting map with the following keys:
+  - m.maxOpenConn: maximum number of open connections
+  - m.maxIdleConn: maximum number of idle connections
+  - m.connMaxIdleTime: maximum idle time for connections (duration string)
+  - m.connMaxLifetime: maximum lifetime for connections (duration string)
 
 *Return*
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/lib/pq v1.10.9
-	github.com/machbase/neo-client v1.7.0
+	github.com/machbase/neo-client v1.7.1-0.20260702064531-ddc84c031098
 	github.com/machbase/neo-engine/v8 v8.5.6
 	github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b
 	github.com/magefile/mage v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIiZhtifTV5OUqqiP82UAl0h87xj/l9k=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/machbase/neo-client v1.7.0 h1:hcrVKbGcJHc6eq5N0sVidqL1BS1Mjxc/aUuwMnoJS/w=
-github.com/machbase/neo-client v1.7.0/go.mod h1:rCaZqbs86TUVDghcOW4XH9Htodk9D7t5Cu5j3aWphPU=
+github.com/machbase/neo-client v1.7.1-0.20260702064531-ddc84c031098 h1:7Zzyw0ENQ3RVjwplw85TjL6qsMBUW/SvQwHndib7Ce8=
+github.com/machbase/neo-client v1.7.1-0.20260702064531-ddc84c031098/go.mod h1:rCaZqbs86TUVDghcOW4XH9Htodk9D7t5Cu5j3aWphPU=
 github.com/machbase/neo-engine/v8 v8.5.6 h1:4vvZcGry5fkcNmpBTyMFRhusLnh15a2nM8w+F0b11ws=
 github.com/machbase/neo-engine/v8 v8.5.6/go.mod h1:b4epDziTEbSEgO2xEWBZpGcTkVT+H2/aVc+EnnfdLYw=
 github.com/machbase/neo-pkgdev v0.0.0-20240911234518-701b00a03b6b h1:yVScvJT9bIGaJmajia+/xz5tkOpRQ5utmpXstV2C37k=

--- a/jsh/lib/machcli/machcli.go
+++ b/jsh/lib/machcli/machcli.go
@@ -66,10 +66,8 @@ func newDatabase(ctx context.Context, data string) (*Database, error) {
 		return nil, err
 	}
 	conf := &machgo.Config{
-		Host:         obj.Host,
-		Port:         obj.Port,
-		MaxOpenConn:  -1,
-		MaxOpenQuery: -1,
+		Host: obj.Host,
+		Port: obj.Port,
 	}
 	if obj.AlternativeHost != "" {
 		conf.AlternativeHost = obj.AlternativeHost

--- a/jsh/usr/bin/session.js
+++ b/jsh/usr/bin/session.js
@@ -73,9 +73,10 @@ const setLimitConfig = {
     description: 'Set session limits',
     options: {
         help: optionHelp,
-        conn: { type: 'integer', description: 'Maximum number of concurrent sessions' },
-        query: { type: 'integer', description: 'Maximum number of the concurrent queries' },
-        pool: { type: 'integer', description: 'Maximum number of the connection pool size' },
+        maxOpenConn: { type: 'integer', description: 'Maximum number of open connections to the database' },
+        maxIdleConn: { type: 'integer', description: 'Maximum number of idle connections to the database' },
+        connMaxIdleTime: { type: 'string', description: 'Maximum idle time for a connection (e.g., "30s", "5m")' },
+        connMaxLifetime: { type: 'string', description: 'Maximum lifetime for a connection (e.g., "1h", "24h")' },
     }
 }
 
@@ -196,37 +197,20 @@ function doStat(config, args) {
     const reset = args.reset || false;
     client.statSession(reset)
         .then((statz) => {
-            let connUse = statz.conns;
-            let connWaitTimePerUse = 0;
-            let connUseTimePerUse = 0;
-            if (connUse > 0) {
-                connWaitTimePerUse = statz.connWaitTime / connUse;
-                connUseTimePerUse = statz.connUseTime / connUse;
-            }
             let box = pretty.Table(config);
             box.appendHeader(["METRIC", "VALUE"]);
             box.setColumnConfigs([
                 { align: pretty.Align.left, alignHeader: pretty.Align.left },
                 { align: pretty.Align.right, alignHeader: pretty.Align.left }]);
-            box.append(["CONNS", pretty.Ints(statz.connsInUse)]);
-            box.append(["CONNS_USED", pretty.Ints(statz.conns)]);
-            box.append(["CONNS_WAIT_AVG", pretty.Durations(connWaitTimePerUse)]);
-            box.append(["CONNS_USE_AVG", pretty.Durations(connUseTimePerUse)]);
-            box.append(["STMTS", pretty.Ints(statz.stmtsInUse)]);
-            box.append(["STMTS_USED", pretty.Ints(statz.stmts)]);
-            box.append(["APPENDERS", pretty.Ints(statz.appendersInUse)]);
-            box.append(["APPENDERS_USED", pretty.Ints(statz.appenders)]);
-            box.append(["RAW_CONNS", pretty.Ints(statz.rawConns)]);
-            box.append(["QUERY_EXEC_HWM", pretty.Durations(statz.queryExecHwm)])
-            box.append(["QUERY_EXEC_AVG", pretty.Durations(statz.queryExecAvg)]);
-            box.append(["QUERY_WAIT_HWM", pretty.Durations(statz.queryWaitHwm)]);
-            box.append(["QUERY_WAIT_AVG", pretty.Durations(statz.queryWaitAvg)]);
-            box.append(["QUERY_FETCH_HWM", pretty.Durations(statz.queryFetchHwm)]);
-            box.append(["QUERY_FETCH_AVG", pretty.Durations(statz.queryFetchAvg)]);
-            box.append(["QUERY_HWM", pretty.Durations(statz.queryHwm)]);
-            box.append(["QUERY_HWM_EXEC", pretty.Durations(statz.queryHwmExec)]);
-            box.append(["QUERY_HWM_WAIT", pretty.Durations(statz.queryHwmWait)]);
-            box.append(["QUERY_HWM_FETCH", pretty.Durations(statz.queryHwmFetch)]);
+            box.append(["MAX OPEN CONN", pretty.Ints(statz.maxOpenConnections)]);
+            box.append(["OPEN CONN", pretty.Ints(statz.openConnections)]);
+            box.append(["IDLE", pretty.Ints(statz.idle)]);
+            box.append(["IN USE", pretty.Ints(statz.inUse)]);
+            box.append(["MAX IDLE CLOSED", pretty.Ints(statz.maxIdleClosed)]);
+            box.append(["MAX IDLE TIME CLOSED", pretty.Ints(statz.maxIdleTimeClosed)]);
+            box.append(["MAX LIFETIME CLOSED", pretty.Ints(statz.maxLifetimeClosed)]);
+            box.append(["WAIT COUNT", pretty.Ints(statz.waitCount)]);
+            box.append(["WAIT DURATION (AVG)", statz.waitAvgDuration]);
             console.println(box.render());
         })
         .catch((err) => {
@@ -249,11 +233,10 @@ function doLimit(config, args) {
                 }
                 return pretty.Ints(v);
             }
-            box.append(["POOL SIZE", numberOrUnlimited(limits.MaxPoolSize)]);
-            box.append(["CONN LIMIT", numberOrUnlimited(limits.MaxOpenConn)]);
-            box.append(["CONN REMAINS", numberOrUnlimited(limits.RemainedOpenConn)]);
-            box.append(["QUERY LIMIT", numberOrUnlimited(limits.MaxOpenQuery)]);
-            box.append(["QUERY REMAINS", numberOrUnlimited(limits.RemainedOpenQuery)]);
+            box.append(["MAX OPEN CONN", numberOrUnlimited(limits.maxOpenConn)]);
+            box.append(["MAX IDLE CONN", numberOrUnlimited(limits.maxIdleConn)]);
+            box.append(["CONN MAX IDLE TIME", pretty.Durations(limits.connMaxIdleTime)]);
+            box.append(["CONN MAX LIFETIME", pretty.Durations(limits.connMaxLifetime)]);
             console.println(box.render());
         })
         .catch((err) => {
@@ -263,14 +246,17 @@ function doLimit(config, args) {
 
 function doSetLimit(config, args) {
     let limits = {};
-    if (config.conn !== undefined) {
-        limits.MaxOpenConn = config.conn;
+    if (config.maxOpenConn !== undefined) {
+        limits.maxOpenConn = config.maxOpenConn;
     }
-    if (config.query !== undefined) {
-        limits.MaxOpenQuery = config.query;
+    if (config.maxIdleConn !== undefined) {
+        limits.maxIdleConn = config.maxIdleConn;
     }
-    if (config.pool !== undefined) {
-        limits.MaxPoolSize = config.pool;
+    if (config.connMaxIdleTime !== undefined) {
+        limits.connMaxIdleTime = config.connMaxIdleTime;
+    }
+    if (config.connMaxLifetime !== undefined) {
+        limits.connMaxLifetime = config.connMaxLifetime;
     }
     const client = new neoapi.Client(config);
     client.setSessionLimit(limits)

--- a/mods/backup/backupd_test.go
+++ b/mods/backup/backupd_test.go
@@ -129,10 +129,8 @@ func setupDefaultSPI() error {
 	}
 
 	testMachgoDB, err = machgo.NewDatabase(&machgo.Config{
-		Host:         "127.0.0.1",
-		Port:         port,
-		MaxOpenConn:  -1,
-		MaxOpenQuery: -1,
+		Host: "127.0.0.1",
+		Port: port,
 	})
 	if err != nil {
 		return err

--- a/mods/bridge/connector/connector.go
+++ b/mods/bridge/connector/connector.go
@@ -119,8 +119,6 @@ func NewWithDataSource(driverName string, dataSource string) (api.Database, []ap
 		var port int
 		var user string = "sys"
 		var password string = "manager"
-		var maxOpenConn = -1
-		var maxOpenQuery = -1
 		var conType = 1
 		if strings.Contains(dataSource, "SERVER=") {
 			// input := `SERVER=value1;UID=value2;PWD=value3;CONNTYPE=1;PORT_NO=1234`
@@ -160,14 +158,6 @@ func NewWithDataSource(driverName string, dataSource string) (api.Database, []ap
 					user = pair.Value
 				case "password":
 					password = pair.Value
-				case "maxopenconn":
-					if p, err := strconv.Atoi(pair.Value); err == nil {
-						maxOpenConn = p
-					}
-				case "maxopenquery":
-					if p, err := strconv.Atoi(pair.Value); err == nil {
-						maxOpenQuery = p
-					}
 				}
 			}
 		}
@@ -175,11 +165,9 @@ func NewWithDataSource(driverName string, dataSource string) (api.Database, []ap
 			opts = append(opts, api.WithPassword(user, password))
 		}
 		db, err := machgo.NewDatabase(&machgo.Config{
-			Host:         host,
-			Port:         port,
-			MaxOpenConn:  maxOpenConn,
-			MaxOpenQuery: maxOpenQuery,
-			ConType:      conType,
+			Host:    host,
+			Port:    port,
+			ConType: conType,
 		})
 		if err != nil {
 			return nil, nil, err

--- a/mods/server/http_rpc_test.go
+++ b/mods/server/http_rpc_test.go
@@ -24,7 +24,7 @@ func TestHttpRpc(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, at)
 
-	var originalSessionLimit map[string]int
+	var originalSessionLimit map[string]any
 	generatedKeyID := fmt.Sprintf("rpc-test-key-%d", time.Now().UnixNano())
 	sshFixture := newTestSSHKeyFixture(t)
 	sshKeyMaterial := sshFixture.AuthorizedKey
@@ -86,22 +86,15 @@ func TestHttpRpc(t *testing.T) {
 			params: []interface{}{},
 			expectFunc: func(t *testing.T, rsp gjson.Result) {
 				result := rsp.Get("result")
-				require.True(t, result.Get("MaxPoolSize").Exists(), rsp.String())
-				require.True(t, result.Get("MaxOpenConn").Exists(), rsp.String())
-				require.True(t, result.Get("RemainedOpenConn").Exists(), rsp.String())
-				require.True(t, result.Get("MaxOpenQuery").Exists(), rsp.String())
-				require.True(t, result.Get("RemainedOpenQuery").Exists(), rsp.String())
-				require.GreaterOrEqual(t, int(result.Get("MaxPoolSize").Int()), -1, rsp.String())
-				require.GreaterOrEqual(t, int(result.Get("MaxOpenConn").Int()), -1, rsp.String())
-				require.GreaterOrEqual(t, int(result.Get("RemainedOpenConn").Int()), -1, rsp.String())
-				require.GreaterOrEqual(t, int(result.Get("MaxOpenQuery").Int()), -1, rsp.String())
-				require.GreaterOrEqual(t, int(result.Get("RemainedOpenQuery").Int()), -1, rsp.String())
-				originalSessionLimit = map[string]int{
-					"MaxPoolSize":       int(result.Get("MaxPoolSize").Int()),
-					"MaxOpenConn":       int(result.Get("MaxOpenConn").Int()),
-					"RemainedOpenConn":  int(result.Get("RemainedOpenConn").Int()),
-					"MaxOpenQuery":      int(result.Get("MaxOpenQuery").Int()),
-					"RemainedOpenQuery": int(result.Get("RemainedOpenQuery").Int()),
+				require.True(t, result.Get("maxOpenConn").Exists(), rsp.String())
+				require.True(t, result.Get("maxIdleConn").Exists(), rsp.String())
+				require.True(t, result.Get("connMaxIdleTime").Exists(), rsp.String())
+				require.True(t, result.Get("connMaxLifetime").Exists(), rsp.String())
+				originalSessionLimit = map[string]any{
+					"maxOpenConn":     int(result.Get("maxOpenConn").Int()),
+					"maxIdleConn":     int(result.Get("maxIdleConn").Int()),
+					"connMaxIdleTime": result.Get("connMaxIdleTime").String(),
+					"connMaxLifetime": result.Get("connMaxLifetime").String(),
 				}
 			},
 		},

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -400,6 +400,9 @@ func (s *Server) Stop() {
 
 	tql.Deinit()
 
+	if pool, _ := spi.DefaultPool(); pool != nil {
+		pool.Close()
+	}
 	if db, ok := spi.Default().(*machgo.Database); ok {
 		if err := db.Close(); err != nil {
 			s.log.Warnf("db close; %s", err.Error())
@@ -462,13 +465,9 @@ func (s *Server) startMachbaseSvr() error {
 	conn.Close()
 
 	db, err := machgo.NewDatabase(&machgo.Config{
-		Host:               "127.0.0.1",
-		Port:               s.Machbase.PORT_NO,
-		MaxOpenConn:        s.Config.MaxOpenConn,
-		MaxOpenConnFactor:  s.Config.MaxOpenConnFactor,
-		MaxOpenQuery:       s.Config.MaxOpenQuery,
-		MaxOpenQueryFactor: s.Config.MaxOpenQueryFactor,
-		StatementCache:     api.StatementCacheAuto,
+		Host:           "127.0.0.1",
+		Port:           s.Machbase.PORT_NO,
+		StatementCache: api.StatementCacheAuto,
 	})
 	if key, err := machgo.LoadPrivateKeyFromFile(s.ServerPrivateKeyPath()); err != nil {
 		return fmt.Errorf("load server private key failed, %s", err.Error())
@@ -494,12 +493,8 @@ func (s *Server) startMachbaseCli() error {
 	}
 
 	db, err := machgo.NewDatabase(&machgo.Config{
-		Host:               host,
-		Port:               port,
-		MaxOpenConn:        s.Config.MaxOpenConn,
-		MaxOpenConnFactor:  s.Config.MaxOpenConnFactor,
-		MaxOpenQuery:       s.Config.MaxOpenQuery,
-		MaxOpenQueryFactor: s.Config.MaxOpenQueryFactor,
+		Host: host,
+		Port: port,
 	})
 	if err != nil {
 		return err
@@ -2095,25 +2090,55 @@ func (s *Server) killSession(ctx context.Context, id string, force bool) error {
 //   - reset: whether to reset accumulated stats
 //
 // return: session statistics
-func (s *Server) statSession(ctx context.Context, reset bool) (*spi.Statz, error) {
-	rsp, err := s.Sessions(ctx, &SessionsRequest{
-		Statz: true, Sessions: false, ResetStatz: reset,
-	})
+func (s *Server) statSession(ctx context.Context, reset bool) (*SessionStats, error) {
+	pool, err := spi.DefaultPool()
 	if err != nil {
 		return nil, err
 	}
-	if !rsp.Success {
-		return nil, errors.New(rsp.Reason)
+	if pool == nil {
+		return nil, fmt.Errorf("session pool not available")
 	}
-	return &spi.Statz{}, nil
+	stat := pool.Stats()
+	waitAvg := time.Duration(0)
+	if stat.WaitCount > 0 {
+		waitAvg = stat.WaitDuration / time.Duration(stat.WaitCount)
+	}
+	ret := &SessionStats{
+		MaxOpenConnections: stat.MaxOpenConnections,
+		OpenConnections:    stat.OpenConnections,
+		InUse:              stat.InUse,
+		Idle:               stat.Idle,
+		WaitCount:          stat.WaitCount,
+		WaitAvgDuration:    waitAvg.String(),
+		MaxIdleClosed:      stat.MaxIdleClosed,
+		MaxIdleTimeClosed:  stat.MaxIdleTimeClosed,
+		MaxLifetimeClosed:  stat.MaxLifetimeClosed,
+	}
+	return ret, nil
+}
+
+type SessionStats struct {
+	// Maximum number of open connections to the database.
+	MaxOpenConnections int `json:"maxOpenConnections"`
+
+	// Pool Status
+	OpenConnections int `json:"openConnections"` // The number of established connections both in use and idle.
+	InUse           int `json:"inUse"`           // The number of connections currently in use.
+	Idle            int `json:"idle"`            // The number of idle connections.
+
+	// Counters
+	WaitCount         int64  `json:"waitCount"`         // The total number of connections waited for.
+	WaitAvgDuration   string `json:"waitAvgDuration"`   // The average time blocked waiting for a new connection.
+	MaxIdleClosed     int64  `json:"maxIdleClosed"`     // The total number of connections closed due to SetMaxIdleConns.
+	MaxIdleTimeClosed int64  `json:"maxIdleTimeClosed"` // The total number of connections closed due to SetConnMaxIdleTime.
+	MaxLifetimeClosed int64  `json:"maxLifetimeClosed"` // The total number of connections closed due to SetConnMaxLifetime.
 }
 
 type SessionLimit struct {
-	MaxPoolSize       int
-	MaxOpenConn       int
-	RemainedOpenConn  int
-	MaxOpenQuery      int
-	RemainedOpenQuery int
+	MaxOpenConn     int    `json:"maxOpenConn"`
+	MaxIdleConn     int    `json:"maxIdleConn"`
+	ConnMaxIdleTime string `json:"connMaxIdleTime"`
+	ConnMaxLifetime string `json:"connMaxLifetime"`
 }
 
 // getSessionLimit returns session pool limit settings.
@@ -2122,21 +2147,12 @@ type SessionLimit struct {
 //
 // return: session limit information
 func (s *Server) getSessionLimit(ctx context.Context) (*SessionLimit, error) {
-	rsp, err := s.LimitSession(ctx, &LimitSessionRequest{
-		Cmd: "get",
-	})
-	if err != nil {
-		return nil, err
-	}
-	if !rsp.Success {
-		return nil, errors.New(rsp.Reason)
-	}
-	ret := &SessionLimit{
-		MaxPoolSize:       int(rsp.MaxPoolSize),
-		MaxOpenConn:       int(rsp.MaxOpenConn),
-		RemainedOpenConn:  int(rsp.RemainedOpenConn),
-		MaxOpenQuery:      int(rsp.MaxOpenQuery),
-		RemainedOpenQuery: int(rsp.RemainedOpenQuery),
+	ret := &SessionLimit{}
+	if pool, err := spi.DefaultPool(); err == nil && pool != nil {
+		ret.MaxOpenConn = s.MaxOpenConn
+		ret.MaxIdleConn = s.MaxIdleConn
+		ret.ConnMaxIdleTime = s.ConnMaxIdleTime.String()
+		ret.ConnMaxLifetime = s.ConnMaxLifetime.String()
 	}
 	return ret, nil
 }
@@ -2144,42 +2160,48 @@ func (s *Server) getSessionLimit(ctx context.Context) (*SessionLimit, error) {
 // setSessionLimit updates session pool limit settings.
 //
 // params:
-//   - m: limit setting map with MaxPoolSize, MaxOpenConn, and MaxOpenQuery keys
+//   - m: limit setting map with the following keys:
+//   - m.maxOpenConn: maximum number of open connections
+//   - m.maxIdleConn: maximum number of idle connections
+//   - m.connMaxIdleTime: maximum idle time for connections (duration string)
+//   - m.connMaxLifetime: maximum lifetime for connections (duration string)
 //
 // return: null on success
 func (s *Server) setSessionLimit(ctx context.Context, m map[string]any) error {
-	var limit = SessionLimit{
-		MaxPoolSize:  -1,
-		MaxOpenConn:  -1,
-		MaxOpenQuery: -1,
-	}
-	if v, ok := m["MaxPoolSize"]; ok {
-		if vi, ok := v.(float64); ok {
-			limit.MaxPoolSize = int(vi)
-		}
-	}
-	if v, ok := m["MaxOpenConn"]; ok {
-		if vi, ok := v.(float64); ok {
-			limit.MaxOpenConn = int(vi)
-		}
-	}
-	if v, ok := m["MaxOpenQuery"]; ok {
-		if vi, ok := v.(float64); ok {
-			limit.MaxOpenQuery = int(vi)
-		}
-	}
-
-	rsp, err := s.LimitSession(ctx, &LimitSessionRequest{
-		Cmd:          "set",
-		MaxPoolSize:  int32(limit.MaxPoolSize),
-		MaxOpenConn:  int32(limit.MaxOpenConn),
-		MaxOpenQuery: int32(limit.MaxOpenQuery),
-	})
+	pool, err := spi.DefaultPool()
 	if err != nil {
 		return err
 	}
-	if !rsp.Success {
-		return errors.New(rsp.Reason)
+	if pool == nil {
+		return fmt.Errorf("session pool not available")
+	}
+	if v, ok := m["maxOpenConn"]; ok {
+		if vi, ok := v.(float64); ok {
+			s.MaxOpenConn = int(vi)
+			pool.SetMaxOpenConns(int(vi))
+		}
+	}
+	if v, ok := m["maxIdleConn"]; ok {
+		if vi, ok := v.(float64); ok {
+			s.MaxIdleConn = int(vi)
+			pool.SetMaxIdleConns(int(vi))
+		}
+	}
+	if v, ok := m["connMaxIdleTime"]; ok {
+		if vi, ok := v.(string); ok {
+			if d, err := time.ParseDuration(vi); err == nil {
+				s.ConnMaxIdleTime = d
+				pool.SetConnMaxIdleTime(d)
+			}
+		}
+	}
+	if v, ok := m["connMaxLifetime"]; ok {
+		if vi, ok := v.(string); ok {
+			if d, err := time.ParseDuration(vi); err == nil {
+				s.ConnMaxLifetime = d
+				pool.SetConnMaxLifetime(d)
+			}
+		}
 	}
 	return nil
 }

--- a/mods/server/server_test.go
+++ b/mods/server/server_test.go
@@ -2191,9 +2191,10 @@ func TestServerCoverage_SessionWrappers(t *testing.T) {
 	require.NotNil(t, limit)
 
 	err = svr.setSessionLimit(ctx, map[string]any{
-		"MaxPoolSize":  float64(limit.MaxPoolSize),
-		"MaxOpenConn":  float64(limit.MaxOpenConn),
-		"MaxOpenQuery": float64(limit.MaxOpenQuery),
+		"maxOpenConn": float64(limit.MaxOpenConn),
+		"maxIdleConn": float64(limit.MaxIdleConn),
+		"maxLifetime": limit.ConnMaxLifetime,
+		"maxIdleTime": limit.ConnMaxIdleTime,
 	})
 	require.NoError(t, err)
 

--- a/mods/util/metric/output/machcli.go
+++ b/mods/util/metric/output/machcli.go
@@ -28,10 +28,8 @@ var _ metric.Output = (*MachCli)(nil)
 func (m *MachCli) openConn(ctx context.Context) (api.Conn, error) {
 	if m.db == nil {
 		if db, err := machgo.NewDatabase(&machgo.Config{
-			Host:         m.Host,
-			Port:         m.Port,
-			MaxOpenConn:  -1,
-			MaxOpenQuery: -1,
+			Host: m.Host,
+			Port: m.Port,
 		}); err != nil {
 			return nil, err
 		} else {

--- a/spi/machsvr/machsvr_test.go
+++ b/spi/machsvr/machsvr_test.go
@@ -133,10 +133,8 @@ func startServer(ctx context.Context) {
 
 	// machgo database
 	if db, err := machgo.NewDatabase(&machgo.Config{
-		Host:         "127.0.0.1",
-		Port:         machsvrPort,
-		MaxOpenConn:  -1,
-		MaxOpenQuery: -1,
+		Host: "127.0.0.1",
+		Port: machsvrPort,
 	}); err != nil {
 		panic(err)
 	} else {
@@ -795,10 +793,8 @@ func TestUserAuthWithKey(t *testing.T) {
 			require.Greater(t, keyID, 0)
 
 			authDB, err := machgo.NewDatabase(&machgo.Config{
-				Host:         host,
-				Port:         port,
-				MaxOpenConn:  1,
-				MaxOpenQuery: 1,
+				Host: host,
+				Port: port,
 			})
 			require.NoError(t, err)
 			defer authDB.Close()

--- a/spi/testsuite/authkey.go
+++ b/spi/testsuite/authkey.go
@@ -57,10 +57,8 @@ func AuthKeyConnect(t *testing.T, db api.Database, ctx context.Context) {
 			require.Greater(t, keyID, 0)
 
 			authDB, err := machgo.NewDatabase(&machgo.Config{
-				Host:         host,
-				Port:         port,
-				MaxOpenConn:  1,
-				MaxOpenQuery: 1,
+				Host: host,
+				Port: port,
 			})
 			require.NoError(t, err)
 			defer authDB.Close()

--- a/spi/testsuite/fetch.go
+++ b/spi/testsuite/fetch.go
@@ -24,11 +24,9 @@ func FetchRowsChunk(t *testing.T, db api.Database, ctx context.Context) {
 	const totalRows = 10000
 
 	fetchDB, err := machgo.NewDatabase(&machgo.Config{
-		Host:         host,
-		Port:         port,
-		MaxOpenConn:  -1,
-		MaxOpenQuery: -1,
-		FetchRows:    fetchRows,
+		Host:      host,
+		Port:      port,
+		FetchRows: fetchRows,
 	})
 	require.NoError(t, err)
 	defer fetchDB.Close()

--- a/spi/testsuite/testsuite.go
+++ b/spi/testsuite/testsuite.go
@@ -278,10 +278,8 @@ func (s *Server) StartServer() {
 
 	// machgo database
 	if db, err := machgo.NewDatabase(&machgo.Config{
-		Host:         "127.0.0.1",
-		Port:         s.machsvrPort,
-		MaxOpenConn:  -1,
-		MaxOpenQuery: -1,
+		Host: "127.0.0.1",
+		Port: s.machsvrPort,
 	}); err != nil {
 		panic(err)
 	} else {


### PR DESCRIPTION
This pull request refactors the session pool statistics and limit management in the server, updating both the implementation and the associated documentation and tests. The main focus is to modernize and standardize how session pool stats and limits are reported and set, aligning them with Go's standard `sql.DB` pool fields and removing legacy fields and code paths.

**Key changes include:**

### Session Pool Statistics and Limit Refactoring

* Replaced the old `spi.Statz` and legacy session pool metrics with a new `SessionStats` struct, which now reports fields such as `maxOpenConnections`, `openConnections`, `inUse`, `idle`, `waitCount`, `waitAvgDuration`, `maxIdleClosed`, `maxIdleTimeClosed`, and `maxLifetimeClosed`. The implementation now pulls stats directly from the connection pool using standard Go APIs. [[1]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL2098-R2141) [[2]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2540-R2549)
* Updated the `SessionLimit` struct and related logic to use new fields: `maxOpenConn`, `maxIdleConn`, `connMaxIdleTime`, and `connMaxLifetime`. The getter and setter methods now directly interact with the connection pool, removing the previous indirection and legacy fields. [[1]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL2125-R2204) [[2]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2597-R2603) [[3]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2647-R2653)
* All code that previously referenced `MaxOpenConn`, `MaxOpenQuery`, and similar legacy fields has been updated or removed, including configuration, initialization, and connection string parsing logic. [[1]](diffhunk://#diff-db9f6595b2a3732fa8458ce50b83ee8bdccab8aa3310c1e50e3a00b6e0547adcL71-L72) [[2]](diffhunk://#diff-71d0a939e6c4b5c3e038a6b59351ffb129c4416bb08073ee5e8c58419d70b88cL134-L135) [[3]](diffhunk://#diff-b2fd3ce9db9cb8f00a5cd087c6f9e976958d24aed7107ba3557fcfe8329c69caL122-L123) [[4]](diffhunk://#diff-b2fd3ce9db9cb8f00a5cd087c6f9e976958d24aed7107ba3557fcfe8329c69caL163-L170) [[5]](diffhunk://#diff-b2fd3ce9db9cb8f00a5cd087c6f9e976958d24aed7107ba3557fcfe8329c69caL180-L181) [[6]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL467-L470) [[7]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL499-L502) [[8]](diffhunk://#diff-656e68f0b3a9e4cf130e681bb7d2ae84989e0a24e5ab083f47ad30b3e9e0d598L33-L34) [[9]](diffhunk://#diff-0cec5317ba3f3213236bc2741c4a7342c0769899eb411ba9fae6e1a5be6d613eL138-L139) [[10]](diffhunk://#diff-0cec5317ba3f3213236bc2741c4a7342c0769899eb411ba9fae6e1a5be6d613eL800-L801) [[11]](diffhunk://#diff-66a6f041342726eddd5aea1b05d00cd4102d319a36a7a4bb5aab8b74fe652e31L62-L63) [[12]](diffhunk://#diff-1e0dd1fd18b5a1424a5ec33db8819f88ff5421a9de910ccf0f16c8ecc13d7ac2L29-L30) [[13]](diffhunk://#diff-1df2ed7b2231cae0d86652c52eb19de663d3f382c8f356a21c742c7ca33eb46eL283-L284)

### Documentation and Test Updates

* Updated the JSON-RPC API documentation to reflect the new session statistics and limit fields, including example return values and parameter descriptions. [[1]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2540-R2549) [[2]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2597-R2603) [[3]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L2647-R2653)
* Refactored related tests to check for the new fields and types, ensuring they match the updated API and internal logic. [[1]](diffhunk://#diff-5b6f43bcef13a92e4eeb9c6d2674ab5b1d48c137a8f042a3e190bbaf8eab4ac0L27-R27) [[2]](diffhunk://#diff-5b6f43bcef13a92e4eeb9c6d2674ab5b1d48c137a8f042a3e190bbaf8eab4ac0L89-R97) [[3]](diffhunk://#diff-85f01ad6de36ebcc7dab3bb85acf3c0713452172648770c6833215310a689a55L2194-R2197)

### Dependency Update

* Updated the `github.com/machbase/neo-client` dependency to a newer version to support the new session pool features.

### Resource Management

* Ensured that the connection pool is properly closed when the server stops to prevent resource leaks