### PR TITLE
implement X.509 certificate generation and add corresponding tests

### DIFF
--- a/jsh/lib/crypto/crypto.go
+++ b/jsh/lib/crypto/crypto.go
@@ -7,12 +7,18 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	_ "embed"
 	"encoding/pem"
 	"fmt"
+	"math/big"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/dop251/goja"
 )
@@ -29,7 +35,150 @@ func Files() map[string][]byte {
 func Module(_ context.Context, _ *goja.Runtime, module *goja.Object) {
 	exports := module.Get("exports").(*goja.Object)
 	exports.Set("generateAuthKeyPair", generateAuthKeyPair)
+	exports.Set("generateX509Certificate", generateX509Certificate)
 	exports.Set("writeHostFile", writeHostFile)
+}
+
+type CertificateRequest struct {
+	Days int      `json:"days"` // number of days the certificate is valid for
+	CN   string   `json:"cn"`   // common name for the certificate
+	O    []string `json:"o"`    // organization names for the certificate
+	OU   []string `json:"ou"`   // organizational unit names for the certificate
+	L    []string `json:"l"`    // localities for the certificate
+	ST   []string `json:"st"`   // states or provinces for the certificate
+	C    []string `json:"c"`    // country names for the certificate
+	DNS  []string `json:"dns"`  // DNS names for the certificate
+	URI  []string `json:"uri"`  // URIs for the certificate
+	SAN  []string `json:"san"`  // SANs for the certificate
+}
+
+// generateX509Certificate generates an X.509 certificate based on the provided certificate request,
+// public key, and signer private key.
+// It returns the PEM-encoded certificate as a string, or an error if the certificate generation fails.
+//
+// - r is the certificate request containing CN, O, OU, L, ST, C, DNS, URI, and SAN fields for the certificate.
+// - publicKey is the public key to be included in the certificate.
+// - signerPrivateKey is the private key used to sign the certificate. For self-signed certificates, this is the same as the public key.
+func generateX509Certificate(request map[string]any, publicKey string, signerPrivateKey string) (string, error) {
+	r, err := normalizeCertificateRequest(request)
+	if err != nil {
+		return "", err
+	}
+	pub, err := parsePublicKeyPEM(publicKey)
+	if err != nil {
+		return "", err
+	}
+	signer, err := parsePrivateKeyPEM(signerPrivateKey)
+	if err != nil {
+		return "", err
+	}
+	if r.Days <= 0 {
+		return "", fmt.Errorf("invalid certificate validity days %d", r.Days)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          mustSerialNumber(),
+		Subject:               buildCertificateSubject(r),
+		NotBefore:             time.Now().UTC().Add(-time.Minute),
+		NotAfter:              time.Now().UTC().Add(time.Duration(r.Days) * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	applyCertificateNames(template, r)
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, pub, signer)
+	if err != nil {
+		return "", fmt.Errorf("create certificate: %w", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})), nil
+}
+
+func normalizeCertificateRequest(request map[string]any) (CertificateRequest, error) {
+	r := CertificateRequest{}
+	if request == nil {
+		return r, nil
+	}
+	r.CN = stringField(request, "cn", "CN")
+	r.Days = intField(request, "days", "Days")
+	r.O = stringSliceField(request, "o", "O")
+	r.OU = stringSliceField(request, "ou", "OU")
+	r.L = stringSliceField(request, "l", "L")
+	r.ST = stringSliceField(request, "st", "ST")
+	r.C = stringSliceField(request, "c", "C")
+	r.DNS = stringSliceField(request, "dns", "DNS")
+	r.URI = stringSliceField(request, "uri", "URI")
+	r.SAN = stringSliceField(request, "san", "SAN")
+	return r, nil
+}
+
+func stringField(request map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := request[key]; ok {
+			if text, ok := value.(string); ok {
+				return text
+			}
+			return fmt.Sprint(value)
+		}
+	}
+	return ""
+}
+
+func intField(request map[string]any, keys ...string) int {
+	for _, key := range keys {
+		value, ok := request[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case int:
+			return typed
+		case int32:
+			return int(typed)
+		case int64:
+			return int(typed)
+		case float32:
+			return int(typed)
+		case float64:
+			return int(typed)
+		case uint:
+			return int(typed)
+		case uint32:
+			return int(typed)
+		case uint64:
+			return int(typed)
+		case string:
+			if n, err := strconv.Atoi(strings.TrimSpace(typed)); err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}
+
+func stringSliceField(request map[string]any, keys ...string) []string {
+	for _, key := range keys {
+		value, ok := request[key]
+		if !ok || value == nil {
+			continue
+		}
+		switch typed := value.(type) {
+		case []string:
+			return typed
+		case []interface{}:
+			items := make([]string, 0, len(typed))
+			for _, item := range typed {
+				items = append(items, fmt.Sprint(item))
+			}
+			return items
+		case string:
+			if typed == "" {
+				return nil
+			}
+			return []string{typed}
+		default:
+			return []string{fmt.Sprint(typed)}
+		}
+	}
+	return nil
 }
 
 func generateAuthKeyPair(keyType string) (map[string]string, error) {
@@ -87,6 +236,127 @@ func generateRSA2048() (string, string, error) {
 	privatePEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
 	publicPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: publicDER})
 	return string(privatePEM), string(publicPEM), nil
+}
+
+func parsePublicKeyPEM(value string) (any, error) {
+	block, _ := pem.Decode([]byte(value))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM public key")
+	}
+	if key, err := x509.ParsePKIXPublicKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	privateKey, err := parsePrivateKeyBlock(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key PEM block type %q", block.Type)
+	}
+	switch k := privateKey.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey, nil
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey, nil
+	default:
+		return nil, fmt.Errorf("unsupported private key type %T", privateKey)
+	}
+}
+
+func parsePrivateKeyPEM(value string) (any, error) {
+	block, _ := pem.Decode([]byte(value))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM private key")
+	}
+	return parsePrivateKeyBlock(block)
+}
+
+func parsePrivateKeyBlock(block *pem.Block) (any, error) {
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("failed to parse private key PEM block type %q", block.Type)
+}
+
+func buildCertificateSubject(r CertificateRequest) pkix.Name {
+	return pkix.Name{
+		CommonName:         r.CN,
+		Organization:       append([]string(nil), r.O...),
+		OrganizationalUnit: append([]string(nil), r.OU...),
+		Locality:           append([]string(nil), r.L...),
+		Province:           append([]string(nil), r.ST...),
+		Country:            append([]string(nil), r.C...),
+	}
+}
+
+func applyCertificateNames(template *x509.Certificate, r CertificateRequest) {
+	template.DNSNames = append(template.DNSNames, r.DNS...)
+	for _, uriText := range r.URI {
+		if uriText == "" {
+			continue
+		}
+		if parsed, err := url.Parse(uriText); err == nil && parsed.Scheme != "" {
+			template.URIs = append(template.URIs, parsed)
+		}
+	}
+	for _, san := range r.SAN {
+		addGeneralName(template, san)
+	}
+}
+
+func addGeneralName(template *x509.Certificate, name string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	key, value, hasPrefix := strings.Cut(name, ":")
+	if hasPrefix {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "dns":
+			template.DNSNames = append(template.DNSNames, strings.TrimSpace(value))
+			return
+		case "ip":
+			if ip := net.ParseIP(strings.TrimSpace(value)); ip != nil {
+				template.IPAddresses = append(template.IPAddresses, ip)
+			}
+			return
+		case "uri":
+			if parsed, err := url.Parse(strings.TrimSpace(value)); err == nil && parsed.Scheme != "" {
+				template.URIs = append(template.URIs, parsed)
+			}
+			return
+		case "email":
+			if strings.TrimSpace(value) != "" {
+				template.EmailAddresses = append(template.EmailAddresses, strings.TrimSpace(value))
+			}
+			return
+		}
+	}
+	if ip := net.ParseIP(name); ip != nil {
+		template.IPAddresses = append(template.IPAddresses, ip)
+		return
+	}
+	if parsed, err := url.Parse(name); err == nil && parsed.Scheme != "" {
+		template.URIs = append(template.URIs, parsed)
+		return
+	}
+	if strings.Contains(name, "@") {
+		template.EmailAddresses = append(template.EmailAddresses, name)
+		return
+	}
+	template.DNSNames = append(template.DNSNames, name)
+}
+
+func mustSerialNumber() *big.Int {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		return big.NewInt(time.Now().UnixNano())
+	}
+	return serialNumber
 }
 
 func writeHostFile(path string, content string, perm int64) error {

--- a/jsh/lib/crypto/crypto.js
+++ b/jsh/lib/crypto/crypto.js
@@ -14,7 +14,18 @@ function generateAuthKeyPair(type = 'ecdsa') {
 
 /**
  * Generate an X.509 certificate.
- * @param {{newKey?: string, days: number, cn?: string, o?: string[], ou?: string[], l?: string[], st?: string[], c?: string[], dns?: string[], uri?: string[], san?: string[]}} request
+ * @param {{
+ *   days: number,
+ *   cn?: string,
+ *   o?: string[],
+ *   ou?: string[],
+ *   l?: string[],
+ *   st?: string[],
+ *   c?: string[],
+ *   dns?: string[],
+ *   uri?: string[],
+ *   san?: string[]
+ * }} request certificate request: validity days, subject fields, DNS names, URIs, and SAN values
  * @param {string} publicKey PEM-encoded public key
  * @param {string} signerPrivateKey PEM-encoded private key used to sign the certificate
  * @returns {string} PEM-encoded certificate

--- a/jsh/lib/crypto/crypto.js
+++ b/jsh/lib/crypto/crypto.js
@@ -13,6 +13,17 @@ function generateAuthKeyPair(type = 'ecdsa') {
 }
 
 /**
+ * Generate an X.509 certificate.
+ * @param {{newKey?: string, days: number, cn?: string, o?: string[], ou?: string[], l?: string[], st?: string[], c?: string[], dns?: string[], uri?: string[], san?: string[]}} request
+ * @param {string} publicKey PEM-encoded public key
+ * @param {string} signerPrivateKey PEM-encoded private key used to sign the certificate
+ * @returns {string} PEM-encoded certificate
+ */
+function generateX509Certificate(request, publicKey, signerPrivateKey) {
+    return nativeCrypto.generateX509Certificate(request, publicKey, signerPrivateKey);
+}
+
+/**
  * Write file to host OS filesystem.
  * This helper is intended for paths prefixed with `@` in commands.
  * @param {string} path host path without `@`
@@ -25,5 +36,6 @@ function writeHostFile(path, content, mode = 0o600) {
 
 module.exports = {
     generateAuthKeyPair,
+    generateX509Certificate,
     writeHostFile,
 };

--- a/jsh/lib/crypto/crypto_internal_test.go
+++ b/jsh/lib/crypto/crypto_internal_test.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"crypto/ecdh"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -220,7 +221,7 @@ func TestGenerateX509CertificateErrors(t *testing.T) {
 	})
 
 	t.Run("signer does not match public key algorithm", func(t *testing.T) {
-		x25519Key, err := ecdh.X25519().GenerateKey(nil)
+		x25519Key, err := ecdh.X25519().GenerateKey(rand.Reader)
 		if err != nil {
 			t.Fatalf("generate X25519 key: %v", err)
 		}

--- a/jsh/lib/crypto/crypto_internal_test.go
+++ b/jsh/lib/crypto/crypto_internal_test.go
@@ -1,0 +1,238 @@
+package crypto
+
+import (
+	"crypto/ecdh"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestIntField(t *testing.T) {
+	request := map[string]any{
+		"int":         int(7),
+		"int32":       int32(8),
+		"int64":       int64(9),
+		"float32":     float32(10),
+		"float64":     float64(11),
+		"uint":        uint(12),
+		"uint32":      uint32(13),
+		"uint64":      uint64(14),
+		"trimmed":     " 15 ",
+		"bad":         "not-a-number",
+		"fallback":    "16",
+		"unsupported": true,
+	}
+
+	tests := []struct {
+		name string
+		keys []string
+		want int
+	}{
+		{name: "int", keys: []string{"int"}, want: 7},
+		{name: "int32", keys: []string{"int32"}, want: 8},
+		{name: "int64", keys: []string{"int64"}, want: 9},
+		{name: "float32", keys: []string{"float32"}, want: 10},
+		{name: "float64", keys: []string{"float64"}, want: 11},
+		{name: "uint", keys: []string{"uint"}, want: 12},
+		{name: "uint32", keys: []string{"uint32"}, want: 13},
+		{name: "uint64", keys: []string{"uint64"}, want: 14},
+		{name: "trimmed string", keys: []string{"trimmed"}, want: 15},
+		{name: "fallback key after bad string", keys: []string{"bad", "fallback"}, want: 16},
+		{name: "unsupported type", keys: []string{"unsupported"}, want: 0},
+		{name: "missing", keys: []string{"missing"}, want: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := intField(request, tc.keys...); got != tc.want {
+				t.Fatalf("intField(%v) = %d, want %d", tc.keys, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStringSliceField(t *testing.T) {
+	request := map[string]any{
+		"strings":     []string{"alpha", "beta"},
+		"interfaces":  []interface{}{"alpha", 42, true},
+		"single":      "value",
+		"empty":       "",
+		"scalar":      3.14,
+		"nilFirst":    nil,
+		"nilFallback": []string{"gamma"},
+	}
+
+	tests := []struct {
+		name string
+		keys []string
+		want []string
+	}{
+		{name: "string slice", keys: []string{"strings"}, want: []string{"alpha", "beta"}},
+		{name: "interface slice", keys: []string{"interfaces"}, want: []string{"alpha", "42", "true"}},
+		{name: "single string", keys: []string{"single"}, want: []string{"value"}},
+		{name: "empty string", keys: []string{"empty"}, want: nil},
+		{name: "scalar fallback", keys: []string{"scalar"}, want: []string{"3.14"}},
+		{name: "skip nil key", keys: []string{"nilFirst", "nilFallback"}, want: []string{"gamma"}},
+		{name: "missing", keys: []string{"missing"}, want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stringSliceField(request, tc.keys...)
+			if len(got) != len(tc.want) {
+				t.Fatalf("stringSliceField(%v) length = %d, want %d (%v)", tc.keys, len(got), len(tc.want), got)
+			}
+			for idx := range tc.want {
+				if got[idx] != tc.want[idx] {
+					t.Fatalf("stringSliceField(%v)[%d] = %q, want %q", tc.keys, idx, got[idx], tc.want[idx])
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateAuthKeyPair(t *testing.T) {
+	tests := []struct {
+		name            string
+		keyType         string
+		wantPrivateType string
+		assertPublicKey func(*testing.T, any)
+	}{
+		{
+			name:            "default ecdsa",
+			keyType:         "",
+			wantPrivateType: "EC PRIVATE KEY",
+			assertPublicKey: func(t *testing.T, key any) {
+				t.Helper()
+				if _, ok := key.(*ecdsa.PublicKey); !ok {
+					t.Fatalf("expected ECDSA public key, got %T", key)
+				}
+			},
+		},
+		{
+			name:            "trimmed rsa",
+			keyType:         " RSA ",
+			wantPrivateType: "RSA PRIVATE KEY",
+			assertPublicKey: func(t *testing.T, key any) {
+				t.Helper()
+				if _, ok := key.(*rsa.PublicKey); !ok {
+					t.Fatalf("expected RSA public key, got %T", key)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pair, err := generateAuthKeyPair(tc.keyType)
+			if err != nil {
+				t.Fatalf("generateAuthKeyPair(%q) error = %v", tc.keyType, err)
+			}
+
+			privateBlock, _ := pem.Decode([]byte(pair["privateKey"]))
+			if privateBlock == nil {
+				t.Fatalf("failed to decode private key PEM")
+			}
+			if privateBlock.Type != tc.wantPrivateType {
+				t.Fatalf("private PEM type = %q, want %q", privateBlock.Type, tc.wantPrivateType)
+			}
+
+			publicBlock, _ := pem.Decode([]byte(pair["publicKey"]))
+			if publicBlock == nil {
+				t.Fatalf("failed to decode public key PEM")
+			}
+			if publicBlock.Type != "PUBLIC KEY" {
+				t.Fatalf("public PEM type = %q, want PUBLIC KEY", publicBlock.Type)
+			}
+
+			publicKey, err := x509.ParsePKIXPublicKey(publicBlock.Bytes)
+			if err != nil {
+				t.Fatalf("parse public key: %v", err)
+			}
+			tc.assertPublicKey(t, publicKey)
+		})
+	}
+
+	t.Run("invalid type", func(t *testing.T) {
+		if _, err := generateAuthKeyPair("invalid"); err == nil {
+			t.Fatal("expected error for invalid key type")
+		}
+	})
+}
+
+func TestAddGeneralName(t *testing.T) {
+	template := &x509.Certificate{}
+
+	addGeneralName(template, "")
+	addGeneralName(template, " dns:example.com ")
+	addGeneralName(template, "ip:127.0.0.1")
+	addGeneralName(template, "uri:spiffe://machbase/neo")
+	addGeneralName(template, "email:ops@example.com")
+	addGeneralName(template, "10.0.0.8")
+	addGeneralName(template, "https://example.com/service")
+	addGeneralName(template, "admin@example.com")
+	addGeneralName(template, "localhost")
+	addGeneralName(template, "ip:not-an-ip")
+
+	if got := template.DNSNames; len(got) != 2 || got[0] != "example.com" || got[1] != "localhost" {
+		t.Fatalf("unexpected DNS names: %#v", got)
+	}
+	if got := template.IPAddresses; len(got) != 2 || !got[0].Equal(net.ParseIP("127.0.0.1")) || !got[1].Equal(net.ParseIP("10.0.0.8")) {
+		t.Fatalf("unexpected IP addresses: %#v", got)
+	}
+	if got := template.URIs; len(got) != 2 || got[0].String() != "spiffe://machbase/neo" || got[1].String() != "https://example.com/service" {
+		t.Fatalf("unexpected URIs: %#v", got)
+	}
+	if got := template.EmailAddresses; len(got) != 2 || got[0] != "ops@example.com" || got[1] != "admin@example.com" {
+		t.Fatalf("unexpected email addresses: %#v", got)
+	}
+}
+
+func TestGenerateX509CertificateErrors(t *testing.T) {
+	pair, err := generateAuthKeyPair("ecdsa")
+	if err != nil {
+		t.Fatalf("generateAuthKeyPair(ecdsa) error = %v", err)
+	}
+
+	t.Run("invalid days", func(t *testing.T) {
+		_, err := generateX509Certificate(map[string]any{"days": 0}, pair["publicKey"], pair["privateKey"])
+		if err == nil || !strings.Contains(err.Error(), "invalid certificate validity days") {
+			t.Fatalf("expected invalid days error, got %v", err)
+		}
+	})
+
+	t.Run("invalid public key pem", func(t *testing.T) {
+		_, err := generateX509Certificate(map[string]any{"days": 1}, "not a pem", pair["privateKey"])
+		if err == nil || !strings.Contains(err.Error(), "failed to decode PEM public key") {
+			t.Fatalf("expected public key PEM error, got %v", err)
+		}
+	})
+
+	t.Run("invalid private key pem", func(t *testing.T) {
+		_, err := generateX509Certificate(map[string]any{"days": 1}, pair["publicKey"], "not a pem")
+		if err == nil || !strings.Contains(err.Error(), "failed to decode PEM private key") {
+			t.Fatalf("expected private key PEM error, got %v", err)
+		}
+	})
+
+	t.Run("signer does not match public key algorithm", func(t *testing.T) {
+		x25519Key, err := ecdh.X25519().GenerateKey(nil)
+		if err != nil {
+			t.Fatalf("generate X25519 key: %v", err)
+		}
+		x25519DER, err := x509.MarshalPKCS8PrivateKey(x25519Key)
+		if err != nil {
+			t.Fatalf("marshal X25519 key: %v", err)
+		}
+		x25519PEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x25519DER}))
+
+		_, err = generateX509Certificate(map[string]any{"days": 1}, pair["publicKey"], x25519PEM)
+		if err == nil || !strings.Contains(err.Error(), "create certificate:") {
+			t.Fatalf("expected create certificate error, got %v", err)
+		}
+	})
+}

--- a/jsh/lib/crypto/crypto_test.go
+++ b/jsh/lib/crypto/crypto_test.go
@@ -1,7 +1,11 @@
 package crypto_test
 
 import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/machbase/neo-server/v8/jsh/test_engine"
@@ -72,5 +76,117 @@ func TestWriteHostFile(t *testing.T) {
 	}
 	if string(b) != "hello" {
 		t.Fatalf("unexpected host file content: %q", string(b))
+	}
+}
+
+func TestGenerateX509Certificate(t *testing.T) {
+	tests := []test_engine.TestCase{
+		{
+			Name: "ecdsa",
+			Script: `
+				const crypto = require('crypto');
+				const process = require('process');
+				const pair = crypto.generateAuthKeyPair(process.env.get('KEY_TYPE'));
+				const cert = crypto.generateX509Certificate({
+					days: 30,
+					cn: 'example.local',
+					o: ['Machbase'],
+					ou: ['JSH'],
+					l: ['Seoul'],
+					st: ['Seoul'],
+					c: ['KR'],
+					dns: ['example.local', 'localhost'],
+					uri: ['spiffe://machbase/neo'],
+					san: ['ip:127.0.0.1', 'email:ops@example.com'],
+				}, pair.publicKey, pair.privateKey);
+				console.println(JSON.stringify(cert));
+			`,
+			Vars: map[string]any{"KEY_TYPE": "ecdsa"},
+			ExpectFunc: func(t *testing.T, result string) {
+				t.Helper()
+				assertCertificate(t, result)
+			},
+		},
+		{
+			Name: "rsa",
+			Script: `
+				const crypto = require('crypto');
+				const process = require('process');
+				const pair = crypto.generateAuthKeyPair(process.env.get('KEY_TYPE'));
+				const cert = crypto.generateX509Certificate({
+					days: 30,
+					cn: 'example.local',
+					o: ['Machbase'],
+					ou: ['JSH'],
+					l: ['Seoul'],
+					st: ['Seoul'],
+					c: ['KR'],
+					dns: ['example.local', 'localhost'],
+					uri: ['spiffe://machbase/neo'],
+					san: ['ip:127.0.0.1', 'email:ops@example.com'],
+				}, pair.publicKey, pair.privateKey);
+				console.println(JSON.stringify(cert));
+			`,
+			Vars: map[string]any{"KEY_TYPE": "rsa"},
+			ExpectFunc: func(t *testing.T, result string) {
+				t.Helper()
+				assertCertificate(t, result)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			test_engine.RunTest(t, tc)
+		})
+	}
+}
+
+func assertCertificate(t *testing.T, result string) {
+	t.Helper()
+	var certPEM string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(result)), &certPEM); err != nil {
+		t.Fatalf("unmarshal certificate PEM: %v", err)
+	}
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil || block.Type != "CERTIFICATE" {
+		t.Fatalf("expected CERTIFICATE PEM block, got %q", certPEM)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	if cert.Subject.CommonName != "example.local" {
+		t.Fatalf("unexpected common name: %q", cert.Subject.CommonName)
+	}
+	if got := cert.Subject.Organization; len(got) != 1 || got[0] != "Machbase" {
+		t.Fatalf("unexpected organization: %#v", got)
+	}
+	if got := cert.Subject.OrganizationalUnit; len(got) != 1 || got[0] != "JSH" {
+		t.Fatalf("unexpected organizational unit: %#v", got)
+	}
+	if got := cert.Subject.Locality; len(got) != 1 || got[0] != "Seoul" {
+		t.Fatalf("unexpected locality: %#v", got)
+	}
+	if got := cert.Subject.Province; len(got) != 1 || got[0] != "Seoul" {
+		t.Fatalf("unexpected province: %#v", got)
+	}
+	if got := cert.Subject.Country; len(got) != 1 || got[0] != "KR" {
+		t.Fatalf("unexpected country: %#v", got)
+	}
+	if len(cert.DNSNames) != 2 || cert.DNSNames[0] != "example.local" || cert.DNSNames[1] != "localhost" {
+		t.Fatalf("unexpected dns names: %#v", cert.DNSNames)
+	}
+	if len(cert.URIs) != 1 || cert.URIs[0].String() != "spiffe://machbase/neo" {
+		t.Fatalf("unexpected uris: %#v", cert.URIs)
+	}
+	if len(cert.IPAddresses) != 1 || cert.IPAddresses[0].String() != "127.0.0.1" {
+		t.Fatalf("unexpected ip addresses: %#v", cert.IPAddresses)
+	}
+	if len(cert.EmailAddresses) != 1 || cert.EmailAddresses[0] != "ops@example.com" {
+		t.Fatalf("unexpected email addresses: %#v", cert.EmailAddresses)
+	}
+	if !cert.NotAfter.After(cert.NotBefore) {
+		t.Fatalf("expected certificate validity window, got notBefore=%v notAfter=%v", cert.NotBefore, cert.NotAfter)
 	}
 }


### PR DESCRIPTION
This pull request adds comprehensive support for generating X.509 certificates in the `crypto` module, including both the Go backend and the JavaScript interface. It introduces a new function for certificate creation, robust parsing and normalization utilities, and thorough test coverage to ensure correctness across key types and certificate fields.

**X.509 Certificate Generation Feature:**

* Added a new `generateX509Certificate` function to the Go backend (`crypto.go`) that creates PEM-encoded X.509 certificates from a flexible request object, a public key, and a signer private key. This includes:
  * Parsing and normalization of input fields (subject, SANs, validity, etc.)
  * Support for various key types (ECDSA, RSA)
  * Handling of all standard X.509 subject and SAN fields (DNS, IP, URI, email)
* Implemented helper functions in Go for parsing PEM-encoded keys, building certificate subjects, and applying SANs and other extensions to the certificate template.

**JavaScript API Enhancements:**

* Exposed the new `generateX509Certificate` function in the JavaScript `crypto` module, allowing scripts to generate certificates directly from JS using the same flexible request format. [[1]](diffhunk://#diff-1b5f9b379d742547fccd9796681af5d33727fc9305a7c387fbfa81eac6e49b40R15-R25) [[2]](diffhunk://#diff-1b5f9b379d742547fccd9796681af5d33727fc9305a7c387fbfa81eac6e49b40R39)

**Testing Improvements:**

* Added comprehensive tests in `crypto_test.go` that:
  * Create certificates using both ECDSA and RSA keys
  * Validate all subject and SAN fields in the resulting certificate
  * Ensure correct certificate validity and encoding
* Included utility imports for certificate parsing and validation in tests.

These changes significantly extend the crypto module's capabilities, enabling dynamic certificate generation for secure communications and automation workflows.