### PR TITLE
Add tests for SQL compatibility and refactor handleWrite

### DIFF
--- a/mods/server/mqtt_write.go
+++ b/mods/server/mqtt_write.go
@@ -133,8 +133,7 @@ func (s *mqttd) handleWrite(cl *mqtt.Client, pk packets.Packet) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, dbUser, tableName := api.TableName(wp.Table).Split()
-	conn, err := spi.Default().Connect(ctx, api.WithAuthKey("sys", spi.DefaultKey()), api.WithProxyUser(dbUser))
+	conn, err := getPoolConn(ctx)
 	if err != nil {
 		rsp.Reason = err.Error()
 		s.log.Warn(cl.Net.Remote, rsp.Reason)
@@ -235,7 +234,7 @@ func (s *mqttd) handleWrite(cl *mqtt.Client, pk packets.Packet) {
 				columnTypes = append(columnTypes, _type.DataType())
 			}
 			valueHolder := strings.Join(_hold, ",")
-			insertQuery = fmt.Sprintf("INSERT INTO %s(%s) VALUES(%s)", tableName, strings.Join(columnNames, ","), valueHolder)
+			insertQuery = fmt.Sprintf("INSERT INTO %s(%s) VALUES(%s)", wp.Table, strings.Join(columnNames, ","), valueHolder)
 		}
 		inputStream = bytes.NewBuffer(bs)
 	}
@@ -294,7 +293,7 @@ func (s *mqttd) handleWrite(cl *mqtt.Client, pk packets.Packet) {
 			for i := range _hold {
 				_hold[i] = "?"
 			}
-			insertQuery = fmt.Sprintf("INSERT INTO %s(%s) VALUES(%s)", tableName, strings.Join(cols, ","), strings.Join(_hold, ","))
+			insertQuery = fmt.Sprintf("INSERT INTO %s(%s) VALUES(%s)", wp.Table, strings.Join(cols, ","), strings.Join(_hold, ","))
 		}
 		if result := conn.Exec(ctx, insertQuery, vals...); result.Err() != nil {
 			rsp.Reason = result.Err().Error()

--- a/spi/sql_test.go
+++ b/spi/sql_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/machbase/neo-client/api"
 	_ "github.com/machbase/neo-client/machbase"
+	"github.com/machbase/neo-client/machgo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -434,4 +436,58 @@ func TestMachbaseSQLCompatibilityAdvanced(t *testing.T) {
 		require.NoError(t, conn1.Close())
 		require.Equal(t, 1, db.Stats().MaxOpenConnections)
 	})
+}
+
+func TestStatementCacheBehavior(t *testing.T) {
+	conf := &machgo.Config{
+		Host: "127.0.0.1",
+		Port: testServer.MachPort(),
+	}
+
+	mdb, err := machgo.NewDatabase(conf)
+	if err != nil {
+		panic(err)
+	}
+
+	// Connection A: statement reuse enabled
+	conn, err := mdb.Connect(
+		t.Context(),
+		api.WithPassword("sys", "manager"),
+		api.WithStatementCache(api.StatementCacheAuto),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	sqlCreateTable := "create tag table if not exists stmtcache (name varchar(80) primary key, time datetime basetime, value double)"
+	sqlInsert := "insert into stmtcache values (?, ?, ?)"
+
+	// create table
+	result := conn.Exec(t.Context(), sqlCreateTable)
+	if err := result.Err(); err != nil {
+		panic(err)
+	}
+
+	// insert data, statement cached
+	result = conn.Exec(t.Context(), sqlInsert, "Alice", "2024-06-01 00:00:00", 123.45)
+	if err := result.Err(); err != nil {
+		panic(err)
+	}
+
+	// drop table
+	result = conn.Exec(t.Context(), "drop table stmtcache")
+	if err := result.Err(); err != nil {
+		panic(err)
+	}
+
+	// re-create table
+	result = conn.Exec(t.Context(), sqlCreateTable)
+	if err := result.Err(); err != nil {
+		panic(err)
+	}
+
+	// insert data again
+	result = conn.Exec(t.Context(), sqlInsert, "Bob", "2024-06-02 00:00:00", 678.90)
+	require.Contains(t, result.Err().Error(), "structure was modified", "Expected error due to statement cache invalidation after table drop")
 }


### PR DESCRIPTION
This pull request introduces improvements to SQL statement handling and adds a new test to verify statement cache behavior. The main changes involve updating how SQL insert queries are constructed in the MQTT write handler to use the correct table name, simplifying connection handling, and adding a test to ensure the statement cache is properly invalidated when a table is dropped and recreated.

**SQL Insert Query Handling:**
- Updated the construction of SQL insert queries in `mqtt_write.go` to use `wp.Table` directly instead of splitting the table name, ensuring the correct table name is always used. [[1]](diffhunk://#diff-f6065007a6d642585ae4e6482c6836b2ee53e92ca9a053ba1b4925c0535c00feL238-R237) [[2]](diffhunk://#diff-f6065007a6d642585ae4e6482c6836b2ee53e92ca9a053ba1b4925c0535c00feL297-R296)
- Simplified database connection acquisition in `handleWrite` by replacing manual connection setup with a call to `getPoolConn(ctx)`.

**Testing and Validation:**
- Added a new test, `TestStatementCacheBehavior`, in `spi/sql_test.go` to verify that the SQL statement cache is invalidated when a table is dropped and recreated, ensuring that cached statements do not cause inconsistent behavior.
- Updated imports in `spi/sql_test.go` to include necessary packages for the new test.