### PR TITLE
Enhance server.certificate.get to support multiple formats

### DIFF
--- a/docs/jsonrpc.gen.md
+++ b/docs/jsonrpc.gen.md
@@ -399,17 +399,16 @@ statzKeys lists available metric keys with optional patterns.
 
 #### server.certificate.get
 
-getServerCertificate returns the server certificate in PEM format.
+getServerCertificate returns the server certificate in the specified format.
 
-`server.certificate.get()`
+`server.certificate.get(format)`
 
 *Params*
-
-- none
+- `format` *string* - certificate format, either "pem" or "der" (default is "pem")
 
 *Return*
 
-- `string|error - server certificate PEM text`
+- `string|error - server certificate text in PEM format, or base64 encoded binary DER format if requested`
 
 <details>
 <summary>Request/Response JSON</summary>
@@ -424,7 +423,9 @@ getServerCertificate returns the server certificate in PEM format.
         "jsonrpc": "2.0",
         "id": 20,
         "method": "server.certificate.get",
-        "params": []
+        "params": [
+            "string"
+        ]
     }
 }
 ```

--- a/mods/server/http_facility.go
+++ b/mods/server/http_facility.go
@@ -580,7 +580,7 @@ func (svr *httpd) handleKeysGen(ctx *gin.Context) {
 		return
 	}
 
-	serverRsp, err := svr.authServer.ServerKey(ctx)
+	serverRsp, err := svr.authServer.ServerKey(ctx, nil)
 	if err != nil {
 		rsp["reason"] = err.Error()
 		rsp["elapse"] = time.Since(tick).String()

--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -1765,7 +1765,7 @@ func (s *Server) genKey(ctx context.Context, id string, typ string, notBefore in
 		"token":       rsp.Token,
 	}
 	if store {
-		serverKey, err := s.ServerKey(ctx)
+		serverKey, err := s.ServerKey(ctx, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1834,13 +1834,14 @@ func (s *Server) deleteKey(ctx context.Context, id string) error {
 	return nil
 }
 
-// getServerCertificate returns the server certificate in PEM format.
+// getServerCertificate returns the server certificate in the specified format.
 //
 // params:
+//   - format: certificate format, either "pem" or "der" (default is "pem")
 //
-// return: server certificate PEM text
-func (s *Server) getServerCertificate(ctx context.Context) (string, error) {
-	rsp, err := s.ServerKey(ctx)
+// return: server certificate text in PEM format, or base64 encoded binary DER format if requested
+func (s *Server) getServerCertificate(ctx context.Context, format string) (string, error) {
+	rsp, err := s.ServerKey(ctx, &ServerKeyRequest{Format: format})
 	if err != nil {
 		return "", err
 	}

--- a/mods/server/svrmgmt.go
+++ b/mods/server/svrmgmt.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"crypto"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -199,27 +200,63 @@ func (s *Server) DelKey(ctx context.Context, req *DelKeyRequest) (*DelKeyRespons
 	return rsp, nil
 }
 
+type ServerKeyRequest struct {
+	Format string `json:"format,omitempty"` // PEM, DER, CER
+}
+
 type ServerKeyResponse struct {
 	Success     bool   `json:"success"`
 	Reason      string `json:"reason"`
 	Elapse      string `json:"elapse"`
+	Format      string `json:"format,omitempty"`
 	Certificate string `json:"certificate"`
 }
 
-func (s *Server) ServerKey(ctx context.Context) (*ServerKeyResponse, error) {
+func (s *Server) ServerKey(ctx context.Context, req *ServerKeyRequest) (*ServerKeyResponse, error) {
 	tick := time.Now()
 	rsp := &ServerKeyResponse{Reason: "unspecified"}
 	defer func() {
 		rsp.Elapse = time.Since(tick).String()
 	}()
+
+	if req == nil {
+		req = &ServerKeyRequest{Format: "pem"}
+	}
+
+	format := strings.ToLower(strings.TrimSpace(req.Format))
+	if format == "" {
+		format = "pem"
+	}
+	rsp.Format = strings.ToUpper(format)
+
 	path := s.ServerCertificatePath()
 	b, err := os.ReadFile(path)
 	if err != nil {
 		rsp.Reason = err.Error()
-	} else {
+		return rsp, nil
+	}
+
+	if format == "pem" {
 		rsp.Success = true
 		rsp.Reason = "success"
 		rsp.Certificate = string(b)
+		return rsp, nil
+	}
+
+	block, _ := pem.Decode(b)
+	if block == nil {
+		rsp.Reason = "invalid PEM certificate"
+		return rsp, nil
+	}
+
+	switch format {
+	case "der", "cer":
+		// DER/CER are binary encodings; return base64 for JSON-safe transport.
+		rsp.Success = true
+		rsp.Reason = "success"
+		rsp.Certificate = base64.StdEncoding.EncodeToString(block.Bytes)
+	default:
+		rsp.Reason = "unsupported format, use PEM, DER, or CER"
 	}
 	return rsp, nil
 }

--- a/mods/server/svrmgmt_test.go
+++ b/mods/server/svrmgmt_test.go
@@ -8,10 +8,13 @@ import (
 	crand "crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -285,4 +288,54 @@ func TestSessionRPCDefaultDatabaseBranches(t *testing.T) {
 	require.NotNil(t, limitRsp)
 	require.False(t, limitRsp.Success)
 	require.Contains(t, limitRsp.Reason, "not supported")
+}
+
+func TestServerKeyFormatCases(t *testing.T) {
+	tmpDir := t.TempDir()
+	svr := &Server{certDirPath: tmpDir}
+
+	ec := NewEllipticCurveP256()
+	pri, pub, err := ec.GenerateKeys()
+	require.NoError(t, err)
+
+	certPEM, err := GenerateServerCertificate(pri, pub)
+	require.NoError(t, err)
+
+	certPath := filepath.Join(tmpDir, "machbase_cert.pem")
+	err = os.WriteFile(certPath, certPEM, 0o644)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	expectedDERBase64 := base64.StdEncoding.EncodeToString(block.Bytes)
+
+	t.Run("pem", func(t *testing.T) {
+		rsp, err := svr.ServerKey(context.Background(), &ServerKeyRequest{Format: "pem"})
+		require.NoError(t, err)
+		require.NotNil(t, rsp)
+		require.True(t, rsp.Success)
+		require.Equal(t, "success", rsp.Reason)
+		require.Equal(t, "PEM", rsp.Format)
+		require.Equal(t, string(certPEM), rsp.Certificate)
+	})
+
+	t.Run("der", func(t *testing.T) {
+		rsp, err := svr.ServerKey(context.Background(), &ServerKeyRequest{Format: "der"})
+		require.NoError(t, err)
+		require.NotNil(t, rsp)
+		require.True(t, rsp.Success)
+		require.Equal(t, "success", rsp.Reason)
+		require.Equal(t, "DER", rsp.Format)
+		require.Equal(t, expectedDERBase64, rsp.Certificate)
+	})
+
+	t.Run("wrong format", func(t *testing.T) {
+		rsp, err := svr.ServerKey(context.Background(), &ServerKeyRequest{Format: "xxx"})
+		require.NoError(t, err)
+		require.NotNil(t, rsp)
+		require.False(t, rsp.Success)
+		require.Equal(t, "XXX", rsp.Format)
+		require.Contains(t, rsp.Reason, "unsupported format")
+		require.Empty(t, rsp.Certificate)
+	})
 }


### PR DESCRIPTION
This pull request updates the server certificate retrieval functionality to support multiple output formats (PEM and DER), improves API documentation, and refactors related code to handle the new format parameter. The most important changes are grouped below:

**API and Documentation Improvements:**

* The `getServerCertificate` method now accepts a `format` parameter, allowing clients to specify the certificate format as either "pem" or "der" (default is "pem"). The documentation and example JSON-RPC requests have been updated to reflect this change. [[1]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L402-R411) [[2]](diffhunk://#diff-4b68718ec5b611c710b896e86c52e1f8841ab244bf74fa15d93071af5444daa1L427-R428)

**Backend Support for Format Selection:**

* Added a new `ServerKeyRequest` struct to specify the desired certificate format, and updated the `ServerKey` method to accept this parameter. The response now includes the format used.
* The `ServerKey` method now returns the certificate in PEM format as plain text or in DER/CER format as a base64-encoded string, depending on the requested format. It also validates the format and handles errors for unsupported formats.

**Refactoring and Consistency Updates:**

* Updated all internal calls to `ServerKey` and `getServerCertificate` to pass the new `format` parameter, ensuring consistent usage throughout the codebase. [[1]](diffhunk://#diff-d42739bba26e313f079835969059e2f99d397edabfd43337090b676e6d05aa7dL583-R583) [[2]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL1768-R1768) [[3]](diffhunk://#diff-3ff5833e74b22fee657e40bf7341cedcff437e8ef172837e3e450e14cf312ffdL1837-R1844)
* Added necessary imports (such as `encoding/base64`) to support new encoding requirements.