### PR TITLE
Refactor query handling and enhance QueryRequest decoding

### DIFF
--- a/mods/server/http_query.go
+++ b/mods/server/http_query.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,8 +14,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gofrs/uuid/v5"
 	"github.com/machbase/neo-client/api"
-	"github.com/machbase/neo-server/v8/mods/codec"
-	"github.com/machbase/neo-server/v8/mods/codec/opts"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/mods/tql"
 	"github.com/machbase/neo-server/v8/mods/util"
@@ -24,65 +21,29 @@ import (
 	"github.com/machbase/neo-server/v8/spi"
 )
 
-// Execute machbase SQL query
-//
-// @Summary     Execute query
-// @Description execute query
-// @Param       q           query   string true "sql query text" default(select * from example limit 3)
-// @Param       p           query   string false "sql bind parameters as JSON array"
-// @Success     200  {object}  msg.QueryResponse
-// @Failure     400  {object}  msg.QueryResponse
-// @Failure     500  {object}  msg.QueryResponse
-// @Router      /db/query [get]
 func (svr *httpd) handleQuery(ctx *gin.Context) {
-	rsp := &QueryResponse{Success: false, Reason: "not specified"}
 	tick := time.Now()
+	req := NewQueryRequest()
+	rsp := &QueryResponse{Success: false, Reason: "not specified"}
 
-	var err error
-	req := &QueryRequest{Precision: -1}
 	switch ctx.Request.Method {
 	case http.MethodPost:
 		contentType := ctx.ContentType()
 		switch contentType {
 		case "application/json":
-			req.Timeformat = "ns"
-			req.TimeLocation = "UTC"
-			req.Format = "json"
-			req.BinaryFormat = "base64"
-			req.Rownum = false
-			req.Heading = true
-			req.Precision = -1
-			if err = decodeQueryRequestJSON(ctx.Request.Body, req); err != nil {
+			if err := req.DecodeJSON(ctx.Request.Body); err != nil {
 				rsp.Reason = err.Error()
 				rsp.Elapse = time.Since(tick).String()
 				ctx.JSON(http.StatusBadRequest, rsp)
 				return
-			}
-			if req.Header == "skip" {
-				req.Heading = false
 			}
 		case "application/x-www-form-urlencoded":
-			req.SqlText = ctx.PostForm("q")
-			if req.Params, err = parseQueryParams(ctx.PostForm("p")); err != nil {
+			if err := req.DecodePostForm(ctx); err != nil {
 				rsp.Reason = err.Error()
 				rsp.Elapse = time.Since(tick).String()
 				ctx.JSON(http.StatusBadRequest, rsp)
 				return
 			}
-			req.Timeformat = strString(ctx.PostForm("timeformat"), "ns")
-			req.TimeLocation = strString(ctx.PostForm("tz"), "UTC")
-			req.Format = strString(ctx.PostForm("format"), "json")
-			req.BinaryFormat = strString(ctx.PostForm("binaryformat"), "base64")
-			req.Compress = ctx.PostForm("compress")
-			req.Rownum = strBool(ctx.PostForm("rownum"), false)
-			req.Heading = strBool(ctx.PostForm("heading"), true)
-			if h := ctx.PostForm("header"); h == "skip" {
-				req.Heading = false
-			}
-			req.Precision = strInt(ctx.PostForm("precision"), -1)
-			req.Transpose = strBool(ctx.PostForm("transpose"), false)
-			req.RowsFlatten = strBool(ctx.PostForm("rowsFlatten"), false)
-			req.RowsArray = strBool(ctx.PostForm("rowsArray"), false)
 		default:
 			rsp.Reason = fmt.Sprintf("unsupported content-type: %s", contentType)
 			rsp.Elapse = time.Since(tick).String()
@@ -90,140 +51,60 @@ func (svr *httpd) handleQuery(ctx *gin.Context) {
 			return
 		}
 	case http.MethodGet:
-		req.SqlText = ctx.Query("q")
-		if req.Params, err = parseQueryParams(ctx.Query("p")); err != nil {
+		if err := req.DecodeQuery(ctx); err != nil {
 			rsp.Reason = err.Error()
 			rsp.Elapse = time.Since(tick).String()
 			ctx.JSON(http.StatusBadRequest, rsp)
 			return
 		}
-		req.Timeformat = strString(ctx.Query("timeformat"), "ns")
-		req.TimeLocation = strString(ctx.Query("tz"), "UTC")
-		req.Format = strString(ctx.Query("format"), "json")
-		req.BinaryFormat = ctx.Query("binaryformat")
-		req.Compress = ctx.Query("compress")
-		req.Rownum = strBool(ctx.Query("rownum"), false)
-		req.Heading = strBool(ctx.Query("heading"), true)
-		if h := ctx.Query("header"); h == "skip" {
-			req.Heading = false
-		}
-		req.Precision = strInt(ctx.Query("precision"), -1)
-		req.Transpose = strBool(ctx.Query("transpose"), false)
-		req.RowsFlatten = strBool(ctx.Query("rowsFlatten"), false)
-		req.RowsArray = strBool(ctx.Query("rowsArray"), false)
 	}
 
 	// golang json decoder case-insensitive for struct field names,
 	// as result, it accepts both "q" and "Q" into req.SqlText
 	if svr.cypherAlg != "" && svr.cypherKey != "" && strings.HasPrefix(req.SqlText, "ENC:") {
 		cypherQ := strings.TrimPrefix(req.SqlText, "ENC:")
-		req.SqlText, err = util.DecryptString(cypherQ, svr.cypherAlg, svr.cypherKey, svr.cypherPad)
-		if err != nil {
+		if sqlText, err := util.DecryptString(cypherQ, svr.cypherAlg, svr.cypherKey, svr.cypherPad); err != nil {
 			rsp.Reason = "decrypt sql fail, " + err.Error()
 			rsp.Elapse = time.Since(tick).String()
 			ctx.JSON(http.StatusBadRequest, rsp)
 			return
+		} else {
+			req.SqlText = sqlText
 		}
 	}
-	if len(req.SqlText) == 0 {
-		rsp.Reason = "empty sql"
-		rsp.Elapse = time.Since(tick).String()
-		ctx.JSON(http.StatusBadRequest, rsp)
-		return
+
+	statusCode := http.StatusOK
+	hook := &QueryHook{
+		SetContentType: func(contentType string) {
+			ctx.Writer.Header().Set("Content-Type", contentType)
+		},
+		SetContentEncoding: func(contentEncoding string) {
+			ctx.Writer.Header().Set("Content-Encoding", contentEncoding)
+		},
+		SetStatusCode: func(code int) {
+			statusCode = code
+		},
+		SetUserMessage: func(message string) {
+			rsp.Reason = message
+		},
 	}
 
-	timeLocation, err := util.ParseTimeLocation(req.TimeLocation, time.UTC)
-	if err != nil {
+	if err := req.Execute(ctx, ctx.Writer, hook); err != nil {
 		rsp.Reason = err.Error()
 		rsp.Elapse = time.Since(tick).String()
-		ctx.JSON(http.StatusBadRequest, rsp)
+		ctx.JSON(statusCode, rsp)
 		return
 	}
-
-	var output io.Writer
-	switch req.Compress {
-	case "gzip":
-		output = gzip.NewWriter(ctx.Writer)
-	default:
-		req.Compress = ""
-		output = ctx.Writer
-	}
-
-	encoder := codec.NewEncoder(req.Format,
-		opts.OutputStream(output),
-		opts.Timeformat(req.Timeformat),
-		opts.Binaryformat(req.BinaryFormat),
-		opts.Precision(req.Precision),
-		opts.Rownum(req.Rownum),
-		opts.Header(req.Heading),
-		opts.TimeLocation(timeLocation),
-		opts.Delimiter(","),
-		opts.BoxStyle("default"),
-		opts.BoxSeparateColumns(true),
-		opts.BoxDrawBorder(true),
-		opts.RowsFlatten(req.RowsFlatten),
-		opts.RowsArray(req.RowsArray),
-		opts.Transpose(req.Transpose),
-	)
-	conn, err := getPoolConn(ctx)
-	if err != nil {
-		svr.log.Warnf("query pooled connection unavailable: %s", err.Error())
-		rsp.Reason = "service unavailable"
+	// If sql is not SELECT, the response is not written,
+	// so we need to write the response here
+	// The reason has been set by hook.SetUserMessage
+	if !ctx.Writer.Written() {
+		rsp.Success = true
 		rsp.Elapse = time.Since(tick).String()
-		ctx.Header("Retry-After", "1")
-		ctx.JSON(http.StatusServiceUnavailable, rsp)
-		return
-	}
-	defer conn.Close()
-
-	query := &spi.Query{
-		Begin: func(q *spi.Query) {
-			if !q.IsFetch() {
-				return
-			}
-			cols := q.Columns()
-			ctx.Writer.Header().Set("Content-Type", encoder.ContentType())
-			if len(req.Compress) > 0 {
-				ctx.Writer.Header().Set("Content-Encoding", req.Compress)
-			}
-			codec.SetEncoderColumns(encoder, cols)
-			encoder.Open()
-		},
-		Next: func(q *spi.Query, nrow int64) bool {
-			values, err := q.Columns().MakeBuffer()
-			if err != nil {
-				svr.log.Error("buffer", err.Error())
-				return false
-			}
-			if err := q.Scan(values...); err != nil {
-				svr.log.Error("scan", err.Error())
-				return false
-			}
-			if err := encoder.AddRow(values); err != nil {
-				// report error to client?
-				svr.log.Error("render", err.Error())
-				return false
-			}
-			return true
-		},
-		End: func(q *spi.Query) {
-			if q.IsFetch() {
-				encoder.Close()
-			} else {
-				rsp.Success, rsp.Reason = true, q.UserMessage()
-				rsp.Elapse = time.Since(tick).String()
-				ctx.JSON(http.StatusOK, rsp)
-			}
-		},
-	}
-
-	if err := query.Execute(ctx, conn, req.SqlText, req.Params...); err != nil {
-		svr.log.Error("query fail", err.Error())
-		rsp.Reason = err.Error()
-		rsp.Elapse = time.Since(tick).String()
-		ctx.JSON(http.StatusInternalServerError, rsp)
+		ctx.JSON(statusCode, rsp)
 	}
 }
+
 func (svr *httpd) handleWatchQuery(ctx *gin.Context) {
 	tick := time.Now()
 	defer func() {

--- a/mods/server/http_query_test.go
+++ b/mods/server/http_query_test.go
@@ -340,7 +340,7 @@ func TestHttpQueryMutation(t *testing.T) {
 		result, _ := io.ReadAll(rsp.Body)
 		rsp.Body.Close()
 		require.Equal(t, http.StatusOK, rsp.StatusCode, "%s: %s", name, string(result))
-		require.Equal(t, "application/json; charset=utf-8", rsp.Header.Get("Content-Type"), "%s", name)
+		require.Equal(t, "application/json", rsp.Header.Get("Content-Type"), "%s", name)
 
 		resultObj := map[string]any{}
 		err = json.Unmarshal(result, &resultObj)
@@ -418,7 +418,7 @@ func TestHttpQueryEmptySqlErrors(t *testing.T) {
 	require.NoError(t, err)
 	delete(resultObj, "elapse")
 	require.EqualValues(t, map[string]any{
-		"success": false, "reason": "empty sql",
+		"success": false, "reason": "sql text is empty",
 	}, resultObj)
 }
 

--- a/mods/server/mqtt_query.go
+++ b/mods/server/mqtt_query.go
@@ -2,26 +2,20 @@ package server
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
-	"io"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/machbase/neo-server/v8/mods/codec"
-	"github.com/machbase/neo-server/v8/mods/codec/opts"
 	"github.com/machbase/neo-server/v8/mods/tql"
-	"github.com/machbase/neo-server/v8/mods/util"
-	"github.com/machbase/neo-server/v8/spi"
 	mqtt "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/packets"
 )
 
 func (s *mqttd) handleQuery(cl *mqtt.Client, pk packets.Packet) {
 	tick := time.Now()
-	req := &QueryRequest{Format: "json", Timeformat: "ns", TimeLocation: "UTC", Precision: -1, Heading: true}
+	req := NewQueryRequest()
 	rsp := &QueryResponse{Reason: "not specified"}
 	replyTopic := s.defaultReplyTopic
 	defer func() {
@@ -56,103 +50,36 @@ func (s *mqttd) handleQuery(cl *mqtt.Client, pk packets.Packet) {
 		}
 	}()
 
-	err := decodeQueryRequestJSON(bytes.NewReader(pk.Payload), req)
-	if err != nil {
+	if err := req.DecodeJSON(bytes.NewReader(pk.Payload)); err != nil {
 		rsp.Reason = err.Error()
 		return
 	}
 	if req.ReplyTo != "" {
 		replyTopic = req.ReplyTo
 	}
-	timeLocation, err := util.ParseTimeLocation(req.TimeLocation, time.UTC)
-	if err != nil {
-		rsp.Reason = err.Error()
-		return
-	}
-	if req.Header == "skip" {
-		req.Heading = false
-	}
 
+	hook := &QueryHook{
+		SetContentType: func(contentType string) {
+			rsp.ContentType = contentType
+		},
+		SetContentEncoding: func(contentEncoding string) {
+			rsp.ContentEncoding = contentEncoding
+		},
+		SetStatusCode: func(code int) {
+			if code == 200 {
+				rsp.Success = true
+			}
+		},
+		SetUserMessage: func(msg string) {
+			rsp.Reason = msg
+		},
+	}
 	var buffer = &bytes.Buffer{}
-	var output io.Writer
-	switch req.Compress {
-	case "gzip":
-		output = gzip.NewWriter(buffer)
-	default:
-		req.Compress = ""
-		output = buffer
-	}
-
-	encoder := codec.NewEncoder(req.Format,
-		opts.OutputStream(output),
-		opts.Timeformat(req.Timeformat),
-		opts.Precision(req.Precision),
-		opts.Rownum(req.Rownum),
-		opts.Heading(req.Heading),
-		opts.TimeLocation(timeLocation),
-		opts.Delimiter(","),
-		opts.BoxStyle("default"),
-		opts.BoxSeparateColumns(true),
-		opts.BoxDrawBorder(true),
-		opts.RowsFlatten(req.RowsFlatten),
-		opts.RowsArray(req.RowsArray),
-		opts.Transpose(req.Transpose),
-	)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	conn, err := getPoolConn(ctx)
-	if err != nil {
+	if err := req.Execute(context.Background(), buffer, hook); err != nil {
 		rsp.Reason = err.Error()
 		return
 	}
-	defer conn.Close()
-
-	query := &spi.Query{
-		Begin: func(q *spi.Query) {
-			if !q.IsFetch() {
-				return
-			}
-			cols := q.Columns()
-			rsp.ContentType = encoder.ContentType()
-			codec.SetEncoderColumns(encoder, cols)
-			encoder.Open()
-		},
-		Next: func(q *spi.Query, nrow int64) bool {
-			values, err := q.Columns().MakeBuffer()
-			if err != nil {
-				s.log.Error("buffer", err.Error())
-				return false
-			}
-			if err = q.Scan(values...); err != nil {
-				s.log.Error("scan", err.Error())
-				return false
-			}
-			if err = encoder.AddRow(values); err != nil {
-				// report error to client?
-				s.log.Error("render", err.Error())
-				return false
-			}
-			return true
-		},
-		End: func(q *spi.Query) {
-			if q.IsFetch() {
-				encoder.Close()
-				rsp.Success, rsp.Reason = true, "success"
-				rsp.Content = buffer.Bytes()
-			} else {
-				rsp.Success, rsp.Reason = true, q.UserMessage()
-				rsp.Elapse = time.Since(tick).String()
-			}
-		},
-	}
-
-	if err := query.Execute(ctx, conn, req.SqlText, req.Params...); err != nil {
-		s.log.Error("query fail", err.Error())
-		rsp.Reason = err.Error()
-		rsp.Elapse = time.Since(tick).String()
-	}
+	rsp.Content = buffer.Bytes()
 }
 
 func (s *mqttd) handleTql(cl *mqtt.Client, pk packets.Packet) {

--- a/mods/server/svrmsg.go
+++ b/mods/server/svrmsg.go
@@ -1,33 +1,69 @@
 package server
 
 import (
+	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
+	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/machbase/neo-client/api"
+	"github.com/machbase/neo-server/v8/mods/codec"
+	"github.com/machbase/neo-server/v8/mods/codec/opts"
+	"github.com/machbase/neo-server/v8/mods/util"
 )
 
 type QueryRequest struct {
-	SqlText      string `json:"q"`
-	Params       []any  `json:"p,omitempty"`
-	ReplyTo      string `json:"reply,omitempty"`        // for mqtt query only
-	RowsFlatten  bool   `json:"rowsFlatten,omitempty"`  // json output only for http, mqtt
-	RowsArray    bool   `json:"rowsArray,omitempty"`    // json output only for http, mqtt
-	Transpose    bool   `json:"transpose,omitempty"`    // json output only for http, mqtt
-	Timeformat   string `json:"timeformat,omitempty"`   //
-	TimeLocation string `json:"tz,omitempty"`           //
-	Format       string `json:"format,omitempty"`       //
-	BinaryFormat string `json:"binaryformat,omitempty"` //
-	Compress     string `json:"compress,omitempty"`     //
-	Precision    int    `json:"precision,omitempty"`    //
-	Rownum       bool   `json:"rownum,omitempty"`       //
-	Heading      bool   `json:"heading,omitempty"`      // deprecated, use Header
-	Header       string `json:"header,omitempty"`       //
+	SqlText            string `json:"q"`
+	Params             []any  `json:"p,omitempty"`
+	ReplyTo            string `json:"reply,omitempty"`              // for mqtt query only
+	RowsFlatten        bool   `json:"rowsFlatten,omitempty"`        // json output only for http, mqtt
+	RowsArray          bool   `json:"rowsArray,omitempty"`          // json output only for http, mqtt
+	Transpose          bool   `json:"transpose,omitempty"`          // json output only for http, mqtt
+	Timeformat         string `json:"timeformat,omitempty"`         //
+	TimeLocation       string `json:"tz,omitempty"`                 //
+	Format             string `json:"format,omitempty"`             //
+	BinaryFormat       string `json:"binaryformat,omitempty"`       //
+	Compress           string `json:"compress,omitempty"`           //
+	Precision          int    `json:"precision,omitempty"`          //
+	Rownum             bool   `json:"rownum,omitempty"`             //
+	Heading            bool   `json:"heading,omitempty"`            // deprecated, use Header
+	Header             string `json:"header,omitempty"`             //
+	Delimiter          string `json:"delimiter,omitempty"`          // csv output only for http, mqtt
+	BoxStyle           string `json:"boxStyle,omitempty"`           // box output only for http, mqtt
+	BoxSeparateColumns bool   `json:"boxSeparateColumns,omitempty"` // box output only for http, mqtt
+	BoxDrawBorder      bool   `json:"boxDrawBorder,omitempty"`      // box output only for http, mqtt
 }
 
-func decodeQueryRequestJSON(r io.Reader, req *QueryRequest) error {
+func NewQueryRequest() *QueryRequest {
+	return &QueryRequest{
+		SqlText:            "",
+		Params:             nil,
+		ReplyTo:            "",
+		RowsFlatten:        false,
+		RowsArray:          false,
+		Transpose:          false,
+		Timeformat:         "ns",
+		TimeLocation:       "UTC",
+		Format:             "json",
+		BinaryFormat:       "hex",
+		Compress:           "",
+		Precision:          -1,
+		Rownum:             false,
+		Heading:            true,
+		Header:             "",
+		Delimiter:          ",",
+		BoxStyle:           "default",
+		BoxSeparateColumns: true,
+		BoxDrawBorder:      true,
+	}
+}
+
+func (req *QueryRequest) DecodeJSON(r io.Reader) error {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
 	if err := dec.Decode(req); err != nil {
@@ -38,6 +74,188 @@ func decodeQueryRequestJSON(r io.Reader, req *QueryRequest) error {
 		return fmt.Errorf("invalid p, %w", err)
 	}
 	req.Params = params
+	if req.Header == "skip" {
+		req.Heading = false
+	}
+	return nil
+}
+
+func (req *QueryRequest) DecodeQuery(ctx *gin.Context) error {
+	req.SqlText = ctx.Query("q")
+	if p, err := parseQueryParams(ctx.Query("p")); err != nil {
+		return err
+	} else {
+		req.Params = p
+	}
+	req.Timeformat = strString(ctx.Query("timeformat"), req.Timeformat)
+	req.TimeLocation = strString(ctx.Query("tz"), req.TimeLocation)
+	req.Format = strString(ctx.Query("format"), req.Format)
+	req.BinaryFormat = strString(ctx.Query("binaryformat"), req.BinaryFormat)
+	req.Compress = ctx.Query("compress")
+	req.Rownum = strBool(ctx.Query("rownum"), req.Rownum)
+	req.Heading = strBool(ctx.Query("heading"), req.Heading)
+	if h := ctx.Query("header"); h == "skip" {
+		req.Heading = false
+	}
+	req.Precision = strInt(ctx.Query("precision"), req.Precision)
+	req.Transpose = strBool(ctx.Query("transpose"), req.Transpose)
+	req.RowsFlatten = strBool(ctx.Query("rowsFlatten"), req.RowsFlatten)
+	req.RowsArray = strBool(ctx.Query("rowsArray"), req.RowsArray)
+	return nil
+}
+
+func (req *QueryRequest) DecodePostForm(ctx *gin.Context) error {
+	req.SqlText = ctx.PostForm("q")
+	if p, err := parseQueryParams(ctx.PostForm("p")); err != nil {
+		return err
+	} else {
+		req.Params = p
+	}
+	req.Timeformat = strString(ctx.PostForm("timeformat"), req.Timeformat)
+	req.TimeLocation = strString(ctx.PostForm("tz"), req.TimeLocation)
+	req.Format = strString(ctx.PostForm("format"), req.Format)
+	req.BinaryFormat = strString(ctx.PostForm("binaryformat"), req.BinaryFormat)
+	req.Compress = ctx.PostForm("compress")
+	req.Rownum = strBool(ctx.PostForm("rownum"), req.Rownum)
+	req.Heading = strBool(ctx.PostForm("heading"), req.Heading)
+	if h := ctx.PostForm("header"); h == "skip" {
+		req.Heading = false
+	}
+	req.Precision = strInt(ctx.PostForm("precision"), req.Precision)
+	req.Transpose = strBool(ctx.PostForm("transpose"), req.Transpose)
+	req.RowsFlatten = strBool(ctx.PostForm("rowsFlatten"), req.RowsFlatten)
+	req.RowsArray = strBool(ctx.PostForm("rowsArray"), req.RowsArray)
+	return nil
+}
+
+type QueryHook struct {
+	SetStatusCode      func(int)
+	SetContentType     func(string)
+	SetContentEncoding func(string)
+	SetUserMessage     func(string)
+}
+
+func (req *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHook) error {
+	if hook == nil {
+		hook = &QueryHook{}
+	}
+
+	if len(req.SqlText) == 0 {
+		if hook.SetStatusCode != nil {
+			hook.SetStatusCode(400)
+		}
+		return fmt.Errorf("sql text is empty")
+	}
+
+	timeLocation, err := util.ParseTimeLocation(req.TimeLocation, time.UTC)
+	if err != nil {
+		if hook.SetStatusCode != nil {
+			hook.SetStatusCode(400)
+		}
+		return err
+	}
+
+	var output io.Writer
+	switch req.Compress {
+	case "gzip":
+		output = gzip.NewWriter(w)
+	default:
+		req.Compress = ""
+		output = w
+	}
+
+	encoder := codec.NewEncoder(req.Format,
+		opts.OutputStream(output),
+		opts.Timeformat(req.Timeformat),
+		opts.Binaryformat(req.BinaryFormat),
+		opts.Precision(req.Precision),
+		opts.Rownum(req.Rownum),
+		opts.Header(req.Heading),
+		opts.TimeLocation(timeLocation),
+		opts.Delimiter(req.Delimiter),
+		opts.BoxStyle(req.BoxStyle),
+		opts.BoxSeparateColumns(req.BoxSeparateColumns),
+		opts.BoxDrawBorder(req.BoxDrawBorder),
+		opts.RowsFlatten(req.RowsFlatten),
+		opts.RowsArray(req.RowsArray),
+		opts.Transpose(req.Transpose),
+	)
+	conn, err := getPoolConn(ctx)
+	if err != nil {
+		if hook.SetStatusCode != nil {
+			hook.SetStatusCode(http.StatusServiceUnavailable)
+		}
+		return err
+	}
+	defer conn.Close()
+
+	rows, err := conn.Query(ctx, req.SqlText, req.Params...)
+	if err != nil {
+		if hook.SetStatusCode != nil {
+			hook.SetStatusCode(http.StatusInternalServerError)
+		}
+		return err
+	}
+	defer rows.Close()
+
+	if hook.SetContentType != nil {
+		hook.SetContentType(encoder.ContentType())
+	}
+	if hook.SetContentEncoding != nil && len(req.Compress) > 0 {
+		hook.SetContentEncoding(req.Compress)
+	}
+
+	if !rows.IsFetchable() {
+		if hook.SetStatusCode != nil {
+			hook.SetStatusCode(http.StatusOK)
+		}
+		if hook.SetUserMessage != nil {
+			hook.SetUserMessage(rows.Message())
+		}
+		return nil
+	}
+
+	var columns api.Columns
+	if cols, err := rows.Columns(); err != nil {
+		if hook.SetStatusCode != nil {
+			hook.SetStatusCode(http.StatusInternalServerError)
+		}
+		return err
+	} else {
+		columns = cols
+		codec.SetEncoderColumns(encoder, cols)
+	}
+
+	encoder.Open()
+	defer encoder.Close()
+
+	for rows.Next() {
+		values, err := columns.MakeBuffer()
+		if err != nil {
+			if hook.SetStatusCode != nil {
+				hook.SetStatusCode(http.StatusInternalServerError)
+			}
+			return err
+		}
+		if err := rows.Scan(values...); err != nil {
+			if hook.SetStatusCode != nil {
+				hook.SetStatusCode(http.StatusInternalServerError)
+			}
+			return err
+		}
+		if err := encoder.AddRow(values); err != nil {
+			if hook.SetStatusCode != nil {
+				hook.SetStatusCode(http.StatusInternalServerError)
+			}
+			return err
+		}
+	}
+	if hook.SetStatusCode != nil {
+		hook.SetStatusCode(http.StatusOK)
+	}
+	if hook.SetUserMessage != nil {
+		hook.SetUserMessage(rows.Message())
+	}
 	return nil
 }
 

--- a/mods/server/svrmsg.go
+++ b/mods/server/svrmsg.go
@@ -101,6 +101,9 @@ func (req *QueryRequest) DecodeQuery(ctx *gin.Context) error {
 	req.Transpose = strBool(ctx.Query("transpose"), req.Transpose)
 	req.RowsFlatten = strBool(ctx.Query("rowsFlatten"), req.RowsFlatten)
 	req.RowsArray = strBool(ctx.Query("rowsArray"), req.RowsArray)
+	req.BoxStyle = strString(ctx.Query("boxStyle"), req.BoxStyle)
+	req.BoxSeparateColumns = strBool(ctx.Query("boxSeparateColumns"), req.BoxSeparateColumns)
+	req.BoxDrawBorder = strBool(ctx.Query("boxDrawBorder"), req.BoxDrawBorder)
 	return nil
 }
 
@@ -125,6 +128,9 @@ func (req *QueryRequest) DecodePostForm(ctx *gin.Context) error {
 	req.Transpose = strBool(ctx.PostForm("transpose"), req.Transpose)
 	req.RowsFlatten = strBool(ctx.PostForm("rowsFlatten"), req.RowsFlatten)
 	req.RowsArray = strBool(ctx.PostForm("rowsArray"), req.RowsArray)
+	req.BoxStyle = strString(ctx.PostForm("boxStyle"), req.BoxStyle)
+	req.BoxSeparateColumns = strBool(ctx.PostForm("boxSeparateColumns"), req.BoxSeparateColumns)
+	req.BoxDrawBorder = strBool(ctx.PostForm("boxDrawBorder"), req.BoxDrawBorder)
 	return nil
 }
 

--- a/mods/server/svrmsg_test.go
+++ b/mods/server/svrmsg_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDecodeQueryRequestJSONNormalizesParams(t *testing.T) {
 	req := &QueryRequest{}
-	err := decodeQueryRequestJSON(strings.NewReader(`{"q":"select * from t where a = ?","p":[1,1.5,true,"neo"],"binaryformat":"base64"}`), req)
+	err := req.DecodeJSON(strings.NewReader(`{"q":"select * from t where a = ?","p":[1,1.5,true,"neo"],"binaryformat":"base64"}`))
 	require.NoError(t, err)
 	require.Equal(t, "select * from t where a = ?", req.SqlText)
 	require.Equal(t, []any{int64(1), 1.5, true, "neo"}, req.Params)
@@ -19,7 +19,7 @@ func TestDecodeQueryRequestJSONNormalizesParams(t *testing.T) {
 
 func TestDecodeQueryRequestJSONRejectsCompositeParam(t *testing.T) {
 	req := &QueryRequest{}
-	err := decodeQueryRequestJSON(strings.NewReader(`{"q":"select * from t","p":[{"nested":1}]}`), req)
+	err := req.DecodeJSON(strings.NewReader(`{"q":"select * from t","p":[{"nested":1}]}`))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid p")
 	require.Contains(t, err.Error(), "scalar")


### PR DESCRIPTION
This pull request refactors and centralizes the handling of SQL query requests for both HTTP and MQTT endpoints. The main improvements include consolidating request parsing and query execution logic into the `QueryRequest` struct, introducing unified decoding and execution methods, and simplifying the handler code. This change enhances maintainability, reduces code duplication, and adds support for more flexible query options.

The most important changes are:

**Core refactoring and unification:**

* Introduced a new `QueryRequest` struct with default values and methods for decoding from JSON, query parameters, and form data, as well as a unified `Execute` method for running queries and handling output formatting and errors. (`mods/server/svrmsg.go`) [[1]](diffhunk://#diff-f78a555c6c1b930e267f2706d9dc6cb480eab5da709363a8a525a49ea111a87eR36-R66) [[2]](diffhunk://#diff-f78a555c6c1b930e267f2706d9dc6cb480eab5da709363a8a525a49ea111a87eR77-R264)
* Replaced duplicated request parsing and query execution logic in both HTTP (`handleQuery`) and MQTT (`handleQuery`) handlers with calls to the new `QueryRequest` methods, significantly simplifying those handlers. (`mods/server/http_query.go`, `mods/server/mqtt_query.go`) [[1]](diffhunk://#diff-7dbcb2816ab1b320be3db5cde03ad796cf3583ce6eb8375f49310162305408c0L18-R107) [[2]](diffhunk://#diff-7c7b320f0d0d89e0d85ac6c75bf62f280a1c4053ff506e2fe4bd14101ef104eeL59-R82)

**Extensibility and options:**

* Added new output formatting options to `QueryRequest` (such as `Delimiter`, `BoxStyle`, `BoxSeparateColumns`, `BoxDrawBorder`) to support more flexible CSV and box output for HTTP and MQTT queries. (`mods/server/svrmsg.go`)

**Error handling and consistency:**

* Improved error messages and status code handling, including returning `"sql text is empty"` for empty queries and ensuring the correct HTTP status is set via hooks. (`mods/server/svrmsg.go`, `mods/server/http_query.go`, `mods/server/http_query_test.go`) [[1]](diffhunk://#diff-f78a555c6c1b930e267f2706d9dc6cb480eab5da709363a8a525a49ea111a87eR77-R264) [[2]](diffhunk://#diff-7dbcb2816ab1b320be3db5cde03ad796cf3583ce6eb8375f49310162305408c0L18-R107) [[3]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L421-R421)

**Testing and compatibility:**

* Updated tests to match new error messages and content type headers (removing charset from the expected `Content-Type`). (`mods/server/http_query_test.go`) [[1]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L343-R343) [[2]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L421-R421)
* Updated tests to use the new decoding methods. (`mods/server/svrmsg_test.go`) [[1]](diffhunk://#diff-a0a062c45d2766460bba89a367cd84636c5c8374aeac7cdb4dcaca37a3a5b930L13-R13) [[2]](diffhunk://#diff-a0a062c45d2766460bba89a367cd84636c5c8374aeac7cdb4dcaca37a3a5b930L22-R22)