### PR TITLE
Markdown template

### DIFF
--- a/mods/codec/internal/markdown/md_encode.go
+++ b/mods/codec/internal/markdown/md_encode.go
@@ -3,12 +3,14 @@ package markdown
 import (
 	"errors"
 	"fmt"
+	htmlTemplate "html/template"
 	"io"
 	"net"
 	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
+	txtTemplate "text/template"
 	"time"
 
 	"github.com/machbase/neo-client/api"
@@ -31,6 +33,9 @@ type Exporter struct {
 	precision       int
 	timeformatter   *util.TimeFormatter
 	binaryFormatter *util.BinaryFormatter
+	templates       []string
+	tmpl            *txtTemplate.Template
+	record          *Record
 
 	headerNames []string
 	closeOnce   sync.Once
@@ -86,6 +91,10 @@ func (ex *Exporter) SetRownum(show bool) {
 	ex.showRownum = show
 }
 
+func (ex *Exporter) SetTemplate(templates ...string) {
+	ex.templates = append(ex.templates, templates...)
+}
+
 func (ex *Exporter) SetHtml(flag bool) {
 	ex.htmlRender = flag
 }
@@ -106,11 +115,28 @@ func (ex *Exporter) Open() error {
 	if ex.output == nil {
 		return errors.New("no output is assigned")
 	}
+	if len(ex.templates) > 0 {
+		tmpl := txtTemplate.New("markdown_layout").Funcs(templateFuncs())
+		for _, content := range ex.templates {
+			if _, err := tmpl.Parse(content); err != nil {
+				return err
+			}
+		}
+		ex.tmpl = tmpl
+	}
 	return nil
 }
 
 func (ex *Exporter) Close() {
 	ex.closeOnce.Do(func() {
+		if ex.tmpl != nil {
+			ex.closeTemplatePath()
+			if closer, ok := ex.output.(io.Closer); ok {
+				closer.Close()
+			}
+			return
+		}
+
 		if ex.showRownum && len(ex.headerNames) > 0 {
 			ex.headerNames = append([]string{"ROWNUM"}, ex.headerNames...)
 		}
@@ -150,6 +176,47 @@ func (ex *Exporter) Close() {
 	})
 }
 
+func (ex *Exporter) closeTemplatePath() {
+	if ex.record != nil {
+		ex.record.IsLast = true
+		ex.executeTemplate(ex.record)
+	} else if ex.rownum == 0 {
+		executeRecord := &Record{
+			Num:        0,
+			IsFirst:    true,
+			IsLast:     true,
+			IsEmpty:    true,
+			columns:    ex.headerNames,
+			showRownum: ex.showRownum,
+		}
+		ex.executeTemplate(executeRecord)
+	}
+
+	content := strings.Join(ex.mdLines, "")
+	if ex.htmlRender {
+		conv := mdconv.New(mdconv.WithDarkMode(false))
+		ex.output.Write([]byte("<div>\n"))
+		conv.ConvertString(content, ex.output)
+		ex.output.Write([]byte("</div>"))
+		return
+	}
+	ex.output.Write([]byte(content))
+}
+
+func (ex *Exporter) executeTemplate(record *Record) {
+	if ex.tmpl == nil {
+		return
+	}
+	b := &strings.Builder{}
+	if err := ex.tmpl.Execute(b, record); err != nil {
+		if ex.logger != nil {
+			ex.logger.LogError("markdown template execute", err)
+		}
+		return
+	}
+	ex.mdLines = append(ex.mdLines, b.String())
+}
+
 func (ex *Exporter) Flush(heading bool) {
 	if flusher, ok := ex.output.(api.Flusher); ok {
 		flusher.Flush()
@@ -185,6 +252,24 @@ func (ex *Exporter) AddRow(values []any) error {
 		for i := range ex.headerNames {
 			ex.headerNames[i] = fmt.Sprintf("column%d", i)
 		}
+	}
+
+	if ex.tmpl != nil {
+		if ex.record != nil {
+			ex.executeTemplate(ex.record)
+		}
+		for i, val := range values {
+			values[i] = api.Unbox(val)
+		}
+		ex.record = &Record{
+			values:     values,
+			Num:        int(ex.rownum),
+			IsFirst:    ex.rownum == 1,
+			IsEmpty:    len(values) == 0,
+			columns:    ex.headerNames,
+			showRownum: ex.showRownum,
+		}
+		return nil
 	}
 	var cols = make([]string, len(values))
 
@@ -241,4 +326,118 @@ func (ex *Exporter) AddRow(values []any) error {
 	ex.mdLines = append(ex.mdLines, line)
 
 	return nil
+}
+
+type Record struct {
+	Num        int
+	IsFirst    bool
+	IsLast     bool
+	IsEmpty    bool
+	columns    []string
+	values     []any
+	showRownum bool
+	v          map[string]any
+}
+
+func (to *Record) Value(idx int) any {
+	if idx < 0 || idx >= len(to.values) {
+		return nil
+	}
+	return to.values[idx]
+}
+
+func (to *Record) ValueString(idx int) string {
+	return fmt.Sprint(to.Value(idx))
+}
+
+func (to *Record) ValueHTML(idx int) htmlTemplate.HTML {
+	return htmlTemplate.HTML(to.ValueString(idx))
+}
+
+func (to *Record) ValueHTMLAttr(idx int) htmlTemplate.HTMLAttr {
+	return htmlTemplate.HTMLAttr(to.ValueString(idx))
+}
+
+func (to *Record) ValueCSS(idx int) htmlTemplate.CSS {
+	return htmlTemplate.CSS(to.ValueString(idx))
+}
+
+func (to *Record) ValueJS(idx int) htmlTemplate.JS {
+	return htmlTemplate.JS(to.ValueString(idx))
+}
+
+func (to *Record) ValueURL(idx int) htmlTemplate.URL {
+	return htmlTemplate.URL(to.ValueString(idx))
+}
+
+func (to *Record) Values() []any {
+	if !to.showRownum {
+		return to.values
+	}
+	vals := make([]any, 0, len(to.values)+1)
+	vals = append(vals, to.Num)
+	vals = append(vals, to.values...)
+	return vals
+}
+
+func (to *Record) V() map[string]any {
+	if to.v == nil {
+		to.v = make(map[string]any)
+		if to.showRownum {
+			to.v["ROWNUM"] = to.Num
+		}
+		for i := 0; i < len(to.values) && i < len(to.columns); i++ {
+			to.v[to.columns[i]] = to.values[i]
+		}
+	}
+	return to.v
+}
+
+func (to *Record) Columns() []string {
+	if to.columns == nil {
+		return nil
+	}
+	if !to.showRownum {
+		cols := make([]string, len(to.columns))
+		copy(cols, to.columns)
+		return cols
+	}
+	cols := make([]string, 0, len(to.columns)+1)
+	cols = append(cols, "ROWNUM")
+	cols = append(cols, to.columns...)
+	return cols
+}
+
+func (to *Record) Column(idx int) string {
+	cols := to.Columns()
+	if cols == nil || idx < 0 || idx >= len(cols) {
+		return ""
+	}
+	return cols[idx]
+}
+
+func templateFuncs() txtTemplate.FuncMap {
+	return txtTemplate.FuncMap{
+		"timeformat": func(s any, z any, v any) string {
+			tz, err := util.ParseTimeLocation(fmt.Sprint(z), time.Local)
+			if err != nil {
+				return fmt.Sprintf("Invalid timezone: %v", err)
+			}
+			ts, err := util.ToTime(v)
+			if err != nil {
+				return fmt.Sprintf("Invalid time: %v", err)
+			}
+			tf := util.NewTimeFormatter(util.Timeformat(fmt.Sprint(s)), util.TimeLocation(tz))
+			return tf.Format(ts)
+		},
+		"format": func(format string, v any) string {
+			return fmt.Sprintf(format, v)
+		},
+		"toUpper": func(s string) string {
+			return strings.ToUpper(s)
+		},
+		"toLower": func(s string) string {
+			return strings.ToLower(s)
+		},
+	}
 }

--- a/mods/codec/internal/markdown/md_encode_internal_test.go
+++ b/mods/codec/internal/markdown/md_encode_internal_test.go
@@ -1,0 +1,181 @@
+package markdown
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/machbase/neo-client/api"
+	"github.com/stretchr/testify/require"
+)
+
+type spyLogger struct {
+	errorCount int
+}
+
+func (l *spyLogger) Logf(format string, args ...any)      {}
+func (l *spyLogger) Log(args ...any)                      {}
+func (l *spyLogger) LogDebugf(format string, args ...any) {}
+func (l *spyLogger) LogDebug(args ...any)                 {}
+func (l *spyLogger) LogWarnf(format string, args ...any)  {}
+func (l *spyLogger) LogWarn(args ...any)                  {}
+func (l *spyLogger) LogErrorf(format string, args ...any) {}
+func (l *spyLogger) LogError(args ...any)                 { l.errorCount++ }
+
+type flushCloseBuffer struct {
+	bytes.Buffer
+	flushCount int
+	closeCount int
+}
+
+func (b *flushCloseBuffer) Flush() error {
+	b.flushCount++
+	return nil
+}
+
+func (b *flushCloseBuffer) Close() error {
+	b.closeCount++
+	return nil
+}
+
+func TestExporterOpenErrorPaths(t *testing.T) {
+	ex := NewEncoder()
+	err := ex.Open()
+	require.EqualError(t, err, "no output is assigned")
+
+	ex.SetOutputStream(&bytes.Buffer{})
+	ex.SetTemplate("{{")
+	err = ex.Open()
+	require.Error(t, err)
+}
+
+func TestExporterFlushAndCloseOnce(t *testing.T) {
+	out := &flushCloseBuffer{}
+	ex := NewEncoder()
+	ex.SetOutputStream(out)
+	ex.SetColumns("v")
+	require.NoError(t, ex.Open())
+	ex.Flush(false)
+	ex.Close()
+	ex.Close()
+
+	require.Equal(t, 1, out.flushCount)
+	require.Equal(t, 1, out.closeCount)
+}
+
+func TestExporterSetBriefAndPrecision(t *testing.T) {
+	out := &bytes.Buffer{}
+	ex := NewEncoder()
+	ex.SetOutputStream(out)
+	ex.SetColumns("f")
+	ex.SetPrecision(2)
+	ex.SetBrief(true)
+	require.NoError(t, ex.Open())
+
+	for i := 0; i < 7; i++ {
+		require.NoError(t, ex.AddRow([]any{1.2345}))
+	}
+	ex.Close()
+
+	result := out.String()
+	require.Contains(t, result, "|1.23|")
+	require.Contains(t, result, "Total")
+}
+
+func TestExporterTemplateNoRowsAndTemplateExecuteError(t *testing.T) {
+	t.Run("no rows template path", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		ex := NewEncoder()
+		ex.SetOutputStream(out)
+		ex.SetColumns("name")
+		ex.SetTemplate(`{{if .IsEmpty}}EMPTY{{end}}`)
+		require.NoError(t, ex.Open())
+		ex.Close()
+		require.Equal(t, "EMPTY", out.String())
+	})
+
+	t.Run("template execute error logs", func(t *testing.T) {
+		out := &bytes.Buffer{}
+		logger := &spyLogger{}
+		ex := NewEncoder()
+		ex.SetOutputStream(out)
+		ex.SetLogger(logger)
+		ex.SetTemplate(`{{index .Values 3}}`)
+		require.NoError(t, ex.Open())
+		require.NoError(t, ex.AddRow([]any{"only-one"}))
+		ex.Close()
+		require.Greater(t, logger.errorCount, 0)
+	})
+}
+
+func TestExporterAdditionalAddRowTypes(t *testing.T) {
+	out := &bytes.Buffer{}
+	ex := NewEncoder()
+	ex.SetOutputStream(out)
+	ex.SetColumns("u16", "u32", "u64", "json")
+	require.NoError(t, ex.Open())
+
+	require.NoError(t, ex.AddRow([]any{uint16(16), uint32(32), uint64(64), api.JSONString(`{"k":1}`)}))
+	ex.Close()
+
+	result := out.String()
+	require.Contains(t, result, "|16|32|64|{\"k\":1}|")
+}
+
+func TestRecordHelpers(t *testing.T) {
+	rec := &Record{
+		Num:        7,
+		columns:    []string{"c1", "c2"},
+		values:     []any{"x", 10},
+		showRownum: true,
+	}
+
+	require.Equal(t, "x", rec.Value(0))
+	require.Nil(t, rec.Value(-1))
+	require.Nil(t, rec.Value(9))
+	require.Equal(t, "10", rec.ValueString(1))
+	require.Equal(t, "x", string(rec.ValueHTML(0)))
+	require.Equal(t, "x", string(rec.ValueHTMLAttr(0)))
+	require.Equal(t, "x", string(rec.ValueCSS(0)))
+	require.Equal(t, "x", string(rec.ValueJS(0)))
+	require.Equal(t, "x", string(rec.ValueURL(0)))
+	require.Equal(t, []any{7, "x", 10}, rec.Values())
+	require.Equal(t, []string{"ROWNUM", "c1", "c2"}, rec.Columns())
+	require.Equal(t, "ROWNUM", rec.Column(0))
+	require.Equal(t, "", rec.Column(10))
+
+	m := rec.V()
+	require.Equal(t, 7, m["ROWNUM"])
+	require.Equal(t, "x", m["c1"])
+	require.Equal(t, 10, m["c2"])
+
+	recNoRow := &Record{columns: []string{"a"}, values: []any{1}, showRownum: false}
+	require.Equal(t, []any{1}, recNoRow.Values())
+	require.Equal(t, []string{"a"}, recNoRow.Columns())
+}
+
+func TestTemplateFuncs(t *testing.T) {
+	fm := templateFuncs()
+
+	toUpper, ok := fm["toUpper"].(func(string) string)
+	require.True(t, ok)
+	require.Equal(t, "ABC", toUpper("Abc"))
+
+	toLower, ok := fm["toLower"].(func(string) string)
+	require.True(t, ok)
+	require.Equal(t, "abc", toLower("AbC"))
+
+	formatFn, ok := fm["format"].(func(string, any) string)
+	require.True(t, ok)
+	require.Equal(t, "v=3", formatFn("v=%d", 3))
+
+	timeformatFn, ok := fm["timeformat"].(func(any, any, any) string)
+	require.True(t, ok)
+
+	require.Contains(t, timeformatFn("2006", "Invalid/TZ", time.Now()), "Invalid timezone")
+	require.Contains(t, timeformatFn("2006", "UTC", errors.New("not time")), "Invalid time")
+	valid := timeformatFn("2006-01-02", "UTC", time.Date(2023, 8, 22, 0, 0, 0, 0, time.UTC))
+	require.Equal(t, "2023-08-22", strings.TrimSpace(valid))
+}

--- a/mods/codec/internal/markdown/md_test.go
+++ b/mods/codec/internal/markdown/md_test.go
@@ -215,3 +215,45 @@ func TestBinaryFormat(t *testing.T) {
 		require.Contains(t, result, tt.expect)
 	}
 }
+
+func TestMarkdownTemplatePathText(t *testing.T) {
+	buffer := &bytes.Buffer{}
+
+	md := markdown.NewEncoder()
+	md.SetOutputStream(buffer)
+	md.SetColumns("name", "value")
+	md.SetTemplate(`{{- if .IsFirst -}}|name|value|{{"\n"}}|:-----|:-----|{{"\n"}}{{- end -}}|{{ .Value 0 }}|{{ .Value 1 }}|{{"\n"}}{{- if .IsLast -}}> *Total* {{ .Num }} *records*{{"\n"}}{{- end -}}`)
+
+	require.NoError(t, md.Open())
+	require.NoError(t, md.AddRow([]any{"alpha", 1}))
+	require.NoError(t, md.AddRow([]any{"beta", 2}))
+	md.Close()
+
+	expected := "|name|value|\n|:-----|:-----|\n|alpha|1|\n|beta|2|\n> *Total* 2 *records*\n"
+	require.Equal(t, expected, buffer.String())
+}
+
+func TestMarkdownTemplatePathHtml(t *testing.T) {
+	buffer := &bytes.Buffer{}
+
+	md := markdown.NewEncoder()
+	md.SetOutputStream(buffer)
+	md.SetHtml(true)
+	md.SetTemplate(`# Title
+
+|name|value|
+|:-----|:-----|
+|{{ .Value 0 }}|{{ .Value 1 }}|
+`)
+
+	require.NoError(t, md.Open())
+	require.NoError(t, md.AddRow([]any{"alpha", 1}))
+	md.Close()
+
+	result := buffer.String()
+	require.Equal(t, "application/xhtml+xml", md.ContentType())
+	require.Contains(t, result, "<div>")
+	require.Contains(t, result, "<h1>Title</h1>")
+	require.Contains(t, result, "<table>")
+	require.Contains(t, result, "<td align=\"left\">alpha</td>")
+}

--- a/mods/tql/expression/parse.go
+++ b/mods/tql/expression/parse.go
@@ -150,7 +150,7 @@ func readToken(stream *lexerStream, state lexerState, functions map[string]Funct
 		}
 		if character == '`' {
 			kind = STRING
-			tokenValue = readStringUntilBacktick(stream)
+			tokenValue = readBacktickString(stream)
 			break
 		}
 
@@ -320,6 +320,79 @@ func readStringUntilBacktick(stream *lexerStream) string {
 	return tokenBuffer.String()
 }
 
+func readBacktickString(stream *lexerStream) string {
+	if tagged, ok := readTaggedBacktickString(stream); ok {
+		return tagged
+	}
+	return readStringUntilBacktick(stream)
+}
+
+func readTaggedBacktickString(stream *lexerStream) (string, bool) {
+	originalPos := stream.position
+	if stream.position+1 >= stream.length {
+		return "", false
+	}
+	if stream.source[stream.position] != '<' || stream.source[stream.position+1] != '<' {
+		return "", false
+	}
+
+	// consume "<<"
+	stream.position += 2
+	tagLineStart := stream.position
+	for stream.canRead() {
+		if stream.readCharacter() == '\n' {
+			break
+		}
+	}
+	if stream.position <= tagLineStart || stream.source[stream.position-1] != '\n' {
+		stream.position = originalPos
+		return "", false
+	}
+	tagLineEnd := stream.position - 1
+	if tagLineEnd > tagLineStart && stream.source[tagLineEnd-1] == '\r' {
+		tagLineEnd--
+	}
+	tag := strings.TrimSpace(string(stream.source[tagLineStart:tagLineEnd]))
+	if !isTaggedBlockTag(tag) {
+		stream.position = originalPos
+		return "", false
+	}
+
+	var body bytes.Buffer
+	for stream.canRead() {
+		lineStart := stream.position
+		for stream.canRead() {
+			if stream.readCharacter() == '\n' {
+				break
+			}
+		}
+
+		lineEnd := stream.position
+		hasNewline := false
+		if lineEnd > lineStart && stream.source[lineEnd-1] == '\n' {
+			hasNewline = true
+			lineEnd--
+		}
+		if lineEnd > lineStart && stream.source[lineEnd-1] == '\r' {
+			lineEnd--
+		}
+
+		if closeAfterBacktick, ok := matchTaggedBacktickCloser(stream.source, lineStart, lineEnd, tag); ok {
+			stream.position = closeAfterBacktick
+			return body.String(), true
+		}
+
+		body.WriteString(string(stream.source[lineStart:lineEnd]))
+		if hasNewline {
+			body.WriteRune('\n')
+		}
+	}
+
+	// Keep tagged mode even when closer is not yet present so multi-line
+	// callers can continue accumulating input without premature token errors.
+	return body.String(), true
+}
+
 func readStringUntilEndOfLine(stream *lexerStream) {
 	for stream.canRead() {
 		character := stream.readCharacter()
@@ -330,6 +403,14 @@ func readStringUntilEndOfLine(stream *lexerStream) {
 }
 
 func readBlock(stream *lexerStream) string {
+	if tagged, ok := readTaggedBlock(stream); ok {
+		return tagged
+	}
+
+	return readNestedBraceBlock(stream)
+}
+
+func readNestedBraceBlock(stream *lexerStream) string {
 	var tokenBuffer bytes.Buffer
 	var character rune
 	var depth = 1
@@ -350,6 +431,159 @@ func readBlock(stream *lexerStream) string {
 		}
 	}
 	return tokenBuffer.String()
+}
+
+func readTaggedBlock(stream *lexerStream) (string, bool) {
+	originalPos := stream.position
+	if stream.position+1 >= stream.length {
+		return "", false
+	}
+	if stream.source[stream.position] != '<' || stream.source[stream.position+1] != '<' {
+		return "", false
+	}
+
+	// consume "<<"
+	stream.position += 2
+	tagLineStart := stream.position
+	for stream.canRead() {
+		if stream.readCharacter() == '\n' {
+			break
+		}
+	}
+	if stream.position <= tagLineStart || stream.source[stream.position-1] != '\n' {
+		stream.position = originalPos
+		return "", false
+	}
+	tagLineEnd := stream.position - 1
+	if tagLineEnd > tagLineStart && stream.source[tagLineEnd-1] == '\r' {
+		tagLineEnd--
+	}
+	tag := strings.TrimSpace(string(stream.source[tagLineStart:tagLineEnd]))
+	if !isTaggedBlockTag(tag) {
+		stream.position = originalPos
+		return "", false
+	}
+
+	var body bytes.Buffer
+	for stream.canRead() {
+		lineStart := stream.position
+		for stream.canRead() {
+			if stream.readCharacter() == '\n' {
+				break
+			}
+		}
+
+		lineEnd := stream.position
+		hasNewline := false
+		if lineEnd > lineStart && stream.source[lineEnd-1] == '\n' {
+			hasNewline = true
+			lineEnd--
+		}
+		if lineEnd > lineStart && stream.source[lineEnd-1] == '\r' {
+			lineEnd--
+		}
+
+		if closeAfterBrace, ok := matchTaggedBlockCloser(stream.source, lineStart, lineEnd, tag); ok {
+			stream.position = closeAfterBrace
+			return body.String(), true
+		}
+
+		body.WriteString(string(stream.source[lineStart:lineEnd]))
+		if hasNewline {
+			body.WriteRune('\n')
+		}
+	}
+
+	stream.position = originalPos
+	return "", false
+}
+
+func isTaggedBlockTag(tag string) bool {
+	if len(tag) == 0 {
+		return false
+	}
+	for i, r := range tag {
+		if i == 0 {
+			if !(unicode.IsLetter(r) || r == '_') {
+				return false
+			}
+			continue
+		}
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+func matchTaggedBlockCloser(source []rune, lineStart int, lineEnd int, tag string) (int, bool) {
+	i := lineStart
+	for i < lineEnd && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+
+	tagRunes := []rune(tag)
+	if i+len(tagRunes) > lineEnd {
+		return 0, false
+	}
+	for _, r := range tagRunes {
+		if source[i] != r {
+			return 0, false
+		}
+		i++
+	}
+
+	for i < lineEnd && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+	if i >= lineEnd || source[i] != '}' {
+		return 0, false
+	}
+	bracePos := i
+	i++
+	if i >= lineEnd || source[i] != ')' {
+		return 0, false
+	}
+	i++
+
+	for i < lineEnd && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+	if i != lineEnd {
+		return 0, false
+	}
+
+	// Keep ')' unread so the caller can lex it as CLAUSE_CLOSE token.
+	return bracePos + 1, true
+}
+
+func matchTaggedBacktickCloser(source []rune, lineStart int, lineEnd int, tag string) (int, bool) {
+	i := lineStart
+	for i < lineEnd && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+
+	tagRunes := []rune(tag)
+	if i+len(tagRunes) > lineEnd {
+		return 0, false
+	}
+	for _, r := range tagRunes {
+		if source[i] != r {
+			return 0, false
+		}
+		i++
+	}
+
+	for i < lineEnd && (source[i] == ' ' || source[i] == '\t') {
+		i++
+	}
+	if i >= lineEnd || source[i] != '`' {
+		return 0, false
+	}
+	backtickPos := i
+
+	// Consume closing backtick to finish string token.
+	return backtickPos + 1, true
 }
 
 func readTokenUntilFalse(stream *lexerStream, condition func(rune) bool) string {

--- a/mods/tql/expression/parse_test.go
+++ b/mods/tql/expression/parse_test.go
@@ -365,6 +365,39 @@ func TestScriptBlock(test *testing.T) {
 				{Kind: CLAUSE_CLOSE},
 			},
 		},
+		{
+			Name:      "Tagged block with script literal brace",
+			Input:     "script({<<JS\n// this is a function return '{'\nfunction a () { return '{' };\nJS})",
+			Functions: map[string]Function{"script": noop},
+			Expected: []Token{
+				{Kind: FUNCTION, Value: noop},
+				{Kind: CLAUSE},
+				{Kind: STRING, Value: "// this is a function return '{'\nfunction a () { return '{' };\n"},
+				{Kind: CLAUSE_CLOSE},
+			},
+		},
+		{
+			Name:      "Tagged block with mermaid brace",
+			Input:     "script({<<MD\n```mermaid\nerDiagram\n    CUSTOMER ||--o{ ORDER :places\n```\nMD})",
+			Functions: map[string]Function{"script": noop},
+			Expected: []Token{
+				{Kind: FUNCTION, Value: noop},
+				{Kind: CLAUSE},
+				{Kind: STRING, Value: "```mermaid\nerDiagram\n    CUSTOMER ||--o{ ORDER :places\n```\n"},
+				{Kind: CLAUSE_CLOSE},
+			},
+		},
+		{
+			Name:      "Tagged backtick string with nested backticks",
+			Input:     "script(`<<MD\n```mermaid\nerDiagram\n    CUSTOMER ||--o{ ORDER :places\n    NOTE : `inline` text\n```\nMD`)",
+			Functions: map[string]Function{"script": noop},
+			Expected: []Token{
+				{Kind: FUNCTION, Value: noop},
+				{Kind: CLAUSE},
+				{Kind: STRING, Value: "```mermaid\nerDiagram\n    CUSTOMER ||--o{ ORDER :places\n    NOTE : `inline` text\n```\n"},
+				{Kind: CLAUSE_CLOSE},
+			},
+		},
 	}
 	runTokenParsingTest(tokenParsingTests, test)
 }

--- a/mods/tql/fm_encoder.go
+++ b/mods/tql/fm_encoder.go
@@ -81,6 +81,13 @@ func (node *Node) fmBox(args ...any) (*Encoder, error) {
 }
 
 func (node *Node) fmMarkdown(args ...any) (*Encoder, error) {
+	for i := range args {
+		if o, err := toTemplateOption(args[i]); err != nil {
+			return nil, err
+		} else if o != nil {
+			args[i] = o
+		}
+	}
 	return newEncoder("markdown", args...)
 }
 

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -1032,6 +1032,36 @@ func TestTql(t *testing.T) {
 			},
 		},
 		{
+			Name: "CSV_payload_MAPVALUE_MARKDOWN_TEMPLATE",
+			Script: `
+				CSV(payload(), header(false))
+				MAPVALUE(2, value(2) != "VALUE" ? parseFloat(value(2))*10 : value(2))
+				MARKDOWN({
+{{ if .IsFirst }}## demo
+{{ end }}{{ .Value 0 }},{{ .Value 2 }}
+{{ if .IsLast }}--------
+{{ end }}
+				})
+				`,
+			Payload: strings.Join([]string{
+				`NAME,TIME,VALUE,BOOL`,
+				`wave.sin,1676432361,0.000000,true`,
+				`wave.cos,1676432361,1.0000000,false`,
+				`wave.sin,1676432362,0.406736,true`,
+				`wave.cos,1676432362,0.913546,false`,
+				`wave.sin,1676432363,0.743144,true`,
+			}, "\n") + "\n",
+			ExpectFunc: func(t *testing.T, result string) {
+				require.Contains(t, result, "## demo")
+				require.Contains(t, result, "NAME,VALUE")
+				require.Contains(t, result, "wave.sin,0")
+				require.Contains(t, result, "wave.cos,10")
+				require.Contains(t, result, "wave.sin,4.067")
+				require.Contains(t, result, "wave.cos,9.135")
+				require.Contains(t, result, "--------")
+			},
+		},
+		{
 			Name: "CSV_MARKDOWN",
 			Script: `
 				CSV(payload(), header(true))

--- a/mods/tql/tql_test.go
+++ b/mods/tql/tql_test.go
@@ -720,6 +720,7 @@ func TestDatabaseTql(t *testing.T) {
 				// FIXME: 'create-table' test is failing randomly on Windows
 				return runtime.GOOS != "windows"
 			},
+			CtxTimeout: 15 * time.Second, // increase timeout for slow CI/CD environment
 			ExpectFunc: func(t *testing.T, result string) {
 				require.Empty(t, result)
 			},

--- a/mods/tql/tqlreader_test.go
+++ b/mods/tql/tqlreader_test.go
@@ -190,6 +190,33 @@ func TestReadLine(t *testing.T) {
 				{text: "TEXT()", line: 9},
 			},
 		},
+		{
+			`SCRIPT({<<JS
+			|  // this is a function return '{'
+			|  function a () { return '{' };
+			|JS})
+			|CSV()
+			`,
+			[]Line{
+				{text: " this is a function return '{'", isComment: true, line: 2},
+				{text: "SCRIPT({<<JS\n\n  function a () { return '{' };\nJS})", line: 1},
+				{text: "CSV()", line: 5},
+			},
+		},
+		{
+			"MARKDOWN({<<MD\n```mermaid\nerDiagram\n    CUSTOMER ||--o{ ORDER :places\n```\nMD})\nCSV()\n",
+			[]Line{
+				{text: "MARKDOWN({<<MD\n```mermaid\nerDiagram\nCUSTOMER ||--o{ ORDER :places\n```\nMD})", line: 1},
+				{text: "CSV()", line: 7},
+			},
+		},
+		{
+			"MARKDOWN(`<<MD\n```mermaid\nerDiagram\n    CUSTOMER ||--o{ ORDER :places\n    NOTE : `inline` text\n```\nMD`)\nCSV()\n",
+			[]Line{
+				{text: "MARKDOWN(`<<MD\n```mermaid\nerDiagram\nCUSTOMER ||--o{ ORDER :places\nNOTE : `inline` text\n```\nMD`)", line: 1},
+				{text: "CSV()", line: 8},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request introduces two major features: support for tagged block and backtick string literals in the TQL parser, and the addition of customizable text/template-based rendering for the Markdown exporter. It also includes comprehensive tests for these features and necessary integration with the TQL function pipeline. These changes allow for more flexible and robust handling of multi-line and embedded content, such as scripts and markdown, especially when they contain characters that would otherwise interfere with parsing.

**TQL Parser Enhancements:**

* Added support for tagged block and tagged backtick string literals, allowing the parser to correctly handle multi-line strings with custom delimiters (e.g., `<<TAG ... TAG})` or `` `<<TAG ... TAG` ``), which is particularly useful for embedding scripts or markdown with nested braces or backticks. [[1]](diffhunk://#diff-52bef38eadede5e0b4e8b37686823b2169461dcc8c629cf9acf552278f090063L153-R153) [[2]](diffhunk://#diff-52bef38eadede5e0b4e8b37686823b2169461dcc8c629cf9acf552278f090063R323-R395) [[3]](diffhunk://#diff-52bef38eadede5e0b4e8b37686823b2169461dcc8c629cf9acf552278f090063R406-R413) [[4]](diffhunk://#diff-52bef38eadede5e0b4e8b37686823b2169461dcc8c629cf9acf552278f090063R436-R588)
* Implemented robust tag validation and closer matching logic, ensuring only valid tags are accepted and that the parser correctly identifies the end of tagged blocks/strings.
* Added and updated tests for the new tagged literal syntax in both the expression parser and TQL reader, covering various edge cases and ensuring correct tokenization and line reading. [[1]](diffhunk://#diff-7a5d37d6a6a7de49d4508e7029ba4cb0af03cc02ea6fc860c07b79a3e3a1ba21R368-R400) [[2]](diffhunk://#diff-58eaee311c8753aeb121b523f29935e657c358c4001441744e9d7664d8cb9c9eR193-R219)

**Markdown Exporter Template Support:**

* Added the ability to set and use Go `text/template` templates for rendering Markdown output, introducing the `SetTemplate` method and associated logic in the `Exporter` struct. This enables highly customizable Markdown generation based on row data and record state (first/last row, etc.). [[1]](diffhunk://#diff-61eca6e97948c79e47db8e09773a838a54b3abd59d702e2582f5da3c89c4046fR36-R38) [[2]](diffhunk://#diff-61eca6e97948c79e47db8e09773a838a54b3abd59d702e2582f5da3c89c4046fR94-R97) [[3]](diffhunk://#diff-61eca6e97948c79e47db8e09773a838a54b3abd59d702e2582f5da3c89c4046fR118-R139) [[4]](diffhunk://#diff-61eca6e97948c79e47db8e09773a838a54b3abd59d702e2582f5da3c89c4046fR179-R219) [[5]](diffhunk://#diff-61eca6e97948c79e47db8e09773a838a54b3abd59d702e2582f5da3c89c4046fR256-R273)
* Implemented the `Record` struct and related template functions, exposing row data and helpers to templates for flexible formatting, including functions for time formatting, string casing, and HTML-safe output.
* Added unit tests demonstrating template-based rendering for both plain text and HTML modes, verifying correct output and HTML conversion.

**Integration and Pipeline Updates:**

* Updated the TQL function pipeline to support template options for Markdown output, ensuring that template arguments are correctly recognized and passed through the encoder.
* Added a TQL integration test to verify that template-based Markdown rendering works as expected in end-to-end scripts.