### PR TITLE
Enhance D2ext extension and update Goldmark dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -163,6 +163,7 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
@@ -180,6 +181,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.37.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.19.0
 	github.com/wroge/wgs84 v1.1.7
-	github.com/yuin/goldmark v1.8.2
+	github.com/yuin/goldmark v1.8.4
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
 	github.com/zclconf/go-cty v1.17.0
 	go.abhg.dev/goldmark/mermaid v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.4.15/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
-github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.8.4 h1:oat/nd3U6NeQqFEL3xpEJq7d7c86NI+DbSNGAs4xnjA=
+github.com/yuin/goldmark v1.8.4/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc h1:+IAOyRda+RLrxa1WC7umKOZRsGq4QrFFMYApOeHzQwQ=
 github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc/go.mod h1:ovIvrum6DQJA4QsJSovrkC4saKHQVs7TvcaeO8AIl5I=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/sony/sonyflake v1.3.0 h1:tiB4Dlp0lnmKp/h6BLXA14P8Qi+LYS9+0QRpcrKHvg4=
 github.com/sony/sonyflake v1.3.0/go.mod h1:LORtCywH/cq10ZbyfhKrHYgAUGH7mOBa76enV9txy/Y=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/mods/codec/internal/markdown/md_test.go
+++ b/mods/codec/internal/markdown/md_test.go
@@ -233,6 +233,48 @@ func TestMarkdownTemplatePathText(t *testing.T) {
 	require.Equal(t, expected, buffer.String())
 }
 
+func TestMarkdownTemplatePathTextHtml(t *testing.T) {
+	buffer := &bytes.Buffer{}
+
+	md := markdown.NewEncoder()
+	md.SetOutputStream(buffer)
+	md.SetColumns("name", "value")
+	md.SetTemplate(`{{- if .IsFirst -}}|name|value|{{"\n"}}|:-----|:-----|{{"\n"}}{{- end -}}|{{ .Value 0 }}|{{ .Value 1 }}|{{"\n"}}{{- if .IsLast -}}> *Total* {{ .Num }} *records*{{"\n"}}{{- end -}}`)
+	md.SetHtml(true)
+
+	require.NoError(t, md.Open())
+	require.NoError(t, md.AddRow([]any{"alpha", 1}))
+	require.NoError(t, md.AddRow([]any{"beta", 2}))
+	md.Close()
+
+	expected := strings.Join([]string{
+		"<div>",
+		"<table>",
+		"<thead>",
+		"<tr>",
+		"<th align=\"left\">name</th>",
+		"<th align=\"left\">value</th>",
+		"</tr>",
+		"</thead>",
+		"<tbody>",
+		"<tr>",
+		"<td align=\"left\">alpha</td>",
+		"<td align=\"left\">1</td>",
+		"</tr>",
+		"<tr>",
+		"<td align=\"left\">beta</td>",
+		"<td align=\"left\">2</td>",
+		"</tr>",
+		"</tbody>",
+		"</table>",
+		"<blockquote>",
+		"<p><em>Total</em> 2 <em>records</em></p>",
+		"</blockquote>",
+		"</div>",
+	}, "\n")
+	require.Equal(t, expected, buffer.String())
+}
+
 func TestMarkdownTemplatePathHtml(t *testing.T) {
 	buffer := &bytes.Buffer{}
 

--- a/mods/tql/expression/parse.go
+++ b/mods/tql/expression/parse.go
@@ -540,20 +540,9 @@ func matchTaggedBlockCloser(source []rune, lineStart int, lineEnd int, tag strin
 		return 0, false
 	}
 	bracePos := i
-	i++
-	if i >= lineEnd || source[i] != ')' {
-		return 0, false
-	}
-	i++
 
-	for i < lineEnd && (source[i] == ' ' || source[i] == '\t') {
-		i++
-	}
-	if i != lineEnd {
-		return 0, false
-	}
-
-	// Keep ')' unread so the caller can lex it as CLAUSE_CLOSE token.
+	// Close on TAG} and leave the following characters unread so callers can
+	// continue lexing ", ..." arguments or ")" naturally.
 	return bracePos + 1, true
 }
 

--- a/mods/tql/expression/parse_test.go
+++ b/mods/tql/expression/parse_test.go
@@ -398,6 +398,25 @@ func TestScriptBlock(test *testing.T) {
 				{Kind: CLAUSE_CLOSE},
 			},
 		},
+		{
+			Name:  "Tagged block with trailing option function",
+			Input: "markdown({<<EOF\n{{ if .IsFirst }}\n```d2\n{{ end }}\nEOF}, html(true))",
+			Functions: map[string]Function{
+				"markdown": noop,
+				"html":     argNoop,
+			},
+			Expected: []Token{
+				{Kind: FUNCTION, Value: noop},
+				{Kind: CLAUSE},
+				{Kind: STRING, Value: "{{ if .IsFirst }}\n```d2\n{{ end }}\n"},
+				{Kind: SEPARATOR},
+				{Kind: FUNCTION, Value: argNoop},
+				{Kind: CLAUSE},
+				{Kind: BOOLEAN, Value: true},
+				{Kind: CLAUSE_CLOSE},
+				{Kind: CLAUSE_CLOSE},
+			},
+		},
 	}
 	runTokenParsingTest(tokenParsingTests, test)
 }

--- a/mods/tql/tqlreader.go
+++ b/mods/tql/tqlreader.go
@@ -91,7 +91,8 @@ func scanLines(codeReader io.Reader, functions map[string]expression.Function) (
 			}
 			continue
 		}
-		if strings.HasPrefix(trimLineText, "#pragma") {
+		inMultilineStmt := lineFrom != 0
+		if strings.HasPrefix(trimLineText, "#pragma") && !inMultilineStmt {
 			pragmaText := trimLineText[7:]
 			start := lineStartOffset + strings.Index(lineText, pragmaText)
 			if start < lineStartOffset {
@@ -100,7 +101,7 @@ func scanLines(codeReader io.Reader, functions map[string]expression.Function) (
 			expressions = append(expressions, &Line{text: pragmaText, line: lineNo, isComment: true, isPragma: true, start: start, end: start + utf8.RuneCountInString(pragmaText)})
 			continue
 		}
-		if strings.HasPrefix(trimLineText, "//+") {
+		if strings.HasPrefix(trimLineText, "//+") && !inMultilineStmt {
 			pragmaText := trimLineText[3:]
 			start := lineStartOffset + strings.Index(lineText, pragmaText)
 			if start < lineStartOffset {
@@ -109,7 +110,7 @@ func scanLines(codeReader io.Reader, functions map[string]expression.Function) (
 			expressions = append(expressions, &Line{text: pragmaText, line: lineNo, isComment: true, isPragma: true, start: start, end: start + utf8.RuneCountInString(pragmaText)})
 			continue
 		}
-		if strings.HasPrefix(trimLineText, "//") {
+		if strings.HasPrefix(trimLineText, "//") && !inMultilineStmt {
 			stmt = append(stmt, "")
 			commentText := trimLineText[2:]
 			start := lineStartOffset + strings.Index(lineText, commentText)
@@ -119,7 +120,7 @@ func scanLines(codeReader io.Reader, functions map[string]expression.Function) (
 			expressions = append(expressions, &Line{text: commentText, line: lineNo, isComment: true, start: start, end: start + utf8.RuneCountInString(commentText)})
 			continue
 		}
-		if strings.HasPrefix(trimLineText, "#") {
+		if strings.HasPrefix(trimLineText, "#") && !inMultilineStmt {
 			commentText := trimLineText[1:]
 			start := lineStartOffset + strings.Index(lineText, commentText)
 			if start < lineStartOffset {

--- a/mods/tql/tqlreader_test.go
+++ b/mods/tql/tqlreader_test.go
@@ -217,6 +217,13 @@ func TestReadLine(t *testing.T) {
 				{text: "CSV()", line: 8},
 			},
 		},
+		{
+			"MARKDOWN({<<EOF\n{{ if .IsFirst }}\n```d2\n{{ end }}\nEOF}, html(true))\nCSV()\n",
+			[]Line{
+				{text: "MARKDOWN({<<EOF\n{{ if .IsFirst }}\n```d2\n{{ end }}\nEOF}, html(true))", line: 1},
+				{text: "CSV()", line: 6},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/mods/tql/tqlreader_test.go
+++ b/mods/tql/tqlreader_test.go
@@ -161,9 +161,7 @@ func TestReadLine(t *testing.T) {
 			|CSV()
 			`,
 			[]Line{
-				{text: " comment-first", isComment: true, line: 3},
-				{text: " comment-second", isComment: true, line: 5},
-				{text: "SCRIPT({\n\n\n  line2;\n\n  line4;\n\n})", line: 1},
+				{text: "SCRIPT({\n\n  // comment-first\n  line2;\n  // comment-second\n  line4;\n\n})", line: 1},
 				{text: "CSV()", line: 9},
 			},
 		},
@@ -198,8 +196,7 @@ func TestReadLine(t *testing.T) {
 			|CSV()
 			`,
 			[]Line{
-				{text: " this is a function return '{'", isComment: true, line: 2},
-				{text: "SCRIPT({<<JS\n\n  function a () { return '{' };\nJS})", line: 1},
+				{text: "SCRIPT({<<JS\n  // this is a function return '{'\n  function a () { return '{' };\nJS})", line: 1},
 				{text: "CSV()", line: 5},
 			},
 		},
@@ -221,6 +218,13 @@ func TestReadLine(t *testing.T) {
 			"MARKDOWN({<<EOF\n{{ if .IsFirst }}\n```d2\n{{ end }}\nEOF}, html(true))\nCSV()\n",
 			[]Line{
 				{text: "MARKDOWN({<<EOF\n{{ if .IsFirst }}\n```d2\n{{ end }}\nEOF}, html(true))", line: 1},
+				{text: "CSV()", line: 6},
+			},
+		},
+		{
+			"MARKDOWN({<<EOF\nsome text\n# this is not a comment but a title\n// this is not a comment either\nEOF})\nCSV()\n",
+			[]Line{
+				{text: "MARKDOWN({<<EOF\nsome text\n# this is not a comment but a title\n// this is not a comment either\nEOF})", line: 1},
 				{text: "CSV()", line: 6},
 			},
 		},

--- a/mods/util/mdconv/d2ext/README.md
+++ b/mods/util/mdconv/d2ext/README.md
@@ -1,0 +1,90 @@
+# d2ext
+
+`d2ext` is a Goldmark extension for rendering D2 fenced code blocks into SVG.
+
+## Fence Option Syntax
+
+Use Hugo-style fence options:
+
+```markdown
+```d2 {layout=dagre,theme="Cool Classics",sketch=true,nodesep=120,edgesep=45}
+a -> b: connect
+```
+```
+
+Option values follow `key=value` form.
+
+- Strings: `theme="Cool Classics"`
+- Booleans: `sketch=true`
+- Integers: `nodesep=120`
+- Floats: `scale=1.25`
+- Arrays: `hl_lines=[2,3,"10-20"]` (parsed by the option parser; currently not consumed by D2 renderer)
+
+## Supported d2ext Options
+
+The following options are currently applied by `d2ext`:
+
+- `theme` (string): D2 theme name. Must match one of the `d2themescatalog` `Theme.Name` values.
+- `layout` (string): D2 layout engine name. Common values are `dagre` and `elk`.
+- `algorithm` (string): ELK layout algorithm. Only valid when `layout=elk`.
+- `sketch` (bool): Enables/disables sketch rendering.
+- `nodesep` (int): Dagre node separation. Only valid when `layout=dagre`.
+- `edgesep` (int): Dagre edge separation. Only valid when `layout=dagre`.
+- `themeID` (int, optional): Directly sets D2 theme id. If both `theme` and `themeID` are set, `themeID` wins.
+- `pad` (int, optional): SVG padding.
+- `scale` (float, optional): SVG render scale.
+
+### ELK `algorithm` List
+
+When `layout=elk`, `d2ext` currently supports the following algorithms:
+
+- `layered` (default)
+- `mrtree`
+- `random`
+
+Example:
+
+```markdown
+```d2 {layout=elk,algorithm="mrtree"}
+a -> b: connect
+```
+```
+
+Note: Other ELK algorithms are rejected by `d2ext` to avoid runtime instability in the current Goja execution path.
+
+## Theme Names (from d2themescatalog)
+
+Use these exact `Theme.Name` values.
+
+### Light Catalog
+
+- Neutral Default
+- Neutral Grey
+- Flagship Terrastruct
+- Cool Classics
+- Mixed Berry Blue
+- Grape Soda
+- Aubergine
+- Colorblind Clear
+- Vanilla Nitro Cola
+- Orange Creamsicle
+- Shirley Temple
+- Earth Tones
+- Everglade Green
+- Buttered Toast
+- Terminal
+- Terminal Grayscale
+- Origami
+- C4
+
+### Dark Catalog
+
+- Dark Mauve
+- Dark Flagship Terrastruct
+
+## Notes
+
+- `theme` matching is case-insensitive.
+- `layout` matching is case-insensitive.
+- `algorithm` is only applied when `layout=elk` (for example: `algorithm="layered"`, `algorithm="mrtree"`).
+- Unknown `theme` values return an error during rendering.

--- a/mods/util/mdconv/d2ext/README.md
+++ b/mods/util/mdconv/d2ext/README.md
@@ -6,11 +6,11 @@
 
 Use Hugo-style fence options:
 
-```markdown
+~~~markdown
 ```d2 {layout=dagre,theme="Cool Classics",sketch=true,nodesep=120,edgesep=45}
 a -> b: connect
 ```
-```
+~~~
 
 Option values follow `key=value` form.
 
@@ -44,11 +44,11 @@ When `layout=elk`, `d2ext` currently supports the following algorithms:
 
 Example:
 
-```markdown
+~~~markdown
 ```d2 {layout=elk,algorithm="mrtree"}
 a -> b: connect
 ```
-```
+~~~
 
 Note: Other ELK algorithms are rejected by `d2ext` to avoid runtime instability in the current Goja execution path.
 

--- a/mods/util/mdconv/d2ext/ast.go
+++ b/mods/util/mdconv/d2ext/ast.go
@@ -7,6 +7,7 @@ import (
 
 type Block struct {
 	ast.BaseBlock
+	Options map[string]any
 }
 
 func (n *Block) IsBlank(source []byte) bool {

--- a/mods/util/mdconv/d2ext/extender.go
+++ b/mods/util/mdconv/d2ext/extender.go
@@ -5,16 +5,24 @@ import (
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/util"
+	"oss.terrastruct.com/d2/d2graph"
 )
 
-// waiting for PR merged in "github.com/FurqanSoftware/goldmark-d2"
-type Extender struct{}
+type Extender struct {
+	Layout  d2graph.LayoutGraph
+	ThemeID *int64
+	Sketch  bool
+}
 
 func (e *Extender) Extend(m goldmark.Markdown) {
 	m.Parser().AddOptions(parser.WithASTTransformers(
 		util.Prioritized(&Transformer{}, 100),
 	))
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
-		util.Prioritized(&HTMLRenderer{}, 0),
+		util.Prioritized(&HTMLRenderer{
+			Layout:  e.Layout,
+			ThemeID: e.ThemeID,
+			Sketch:  e.Sketch,
+		}, 0),
 	))
 }

--- a/mods/util/mdconv/d2ext/extender.go
+++ b/mods/util/mdconv/d2ext/extender.go
@@ -9,9 +9,10 @@ import (
 )
 
 type Extender struct {
-	Layout  d2graph.LayoutGraph
-	ThemeID *int64
-	Sketch  bool
+	Layout          d2graph.LayoutGraph
+	ThemeID         *int64
+	Sketch          bool
+	OptionApplierFn FenceOptionApplier
 }
 
 func (e *Extender) Extend(m goldmark.Markdown) {
@@ -20,9 +21,10 @@ func (e *Extender) Extend(m goldmark.Markdown) {
 	))
 	m.Renderer().AddOptions(renderer.WithNodeRenderers(
 		util.Prioritized(&HTMLRenderer{
-			Layout:  e.Layout,
-			ThemeID: e.ThemeID,
-			Sketch:  e.Sketch,
+			Layout:          e.Layout,
+			ThemeID:         e.ThemeID,
+			Sketch:          e.Sketch,
+			OptionApplierFn: e.OptionApplierFn,
 		}, 0),
 	))
 }

--- a/mods/util/mdconv/d2ext/options.go
+++ b/mods/util/mdconv/d2ext/options.go
@@ -1,0 +1,194 @@
+package d2ext
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func parseInlineOptions(raw string) (map[string]any, error) {
+	out := map[string]any{}
+	parts, err := splitTopLevel(raw, ',')
+	if err != nil {
+		return nil, fmt.Errorf("invalid d2 fence options: %w", err)
+	}
+	for _, p := range parts {
+		entry := strings.TrimSpace(p)
+		if entry == "" {
+			continue
+		}
+		eq := strings.Index(entry, "=")
+		if eq <= 0 || eq == len(entry)-1 {
+			return nil, fmt.Errorf("invalid d2 fence option entry: %q", entry)
+		}
+		key := strings.TrimSpace(entry[:eq])
+		if key == "" {
+			return nil, fmt.Errorf("invalid d2 fence option key: %q", entry)
+		}
+		val, err := parseOptionValue(strings.TrimSpace(entry[eq+1:]))
+		if err != nil {
+			return nil, err
+		}
+		out[key] = val
+	}
+
+	return out, nil
+}
+
+func splitTopLevel(s string, sep rune) ([]string, error) {
+	var parts []string
+	start := 0
+	depthBrace := 0
+	depthBracket := 0
+	inQuote := false
+	escaped := false
+
+	for i, r := range s {
+		if inQuote {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if r == '\\' {
+				escaped = true
+				continue
+			}
+			if r == '"' {
+				inQuote = false
+			}
+			continue
+		}
+
+		switch r {
+		case '"':
+			inQuote = true
+		case '{':
+			depthBrace++
+		case '}':
+			depthBrace--
+			if depthBrace < 0 {
+				return nil, fmt.Errorf("unexpected closing brace")
+			}
+		case '[':
+			depthBracket++
+		case ']':
+			depthBracket--
+			if depthBracket < 0 {
+				return nil, fmt.Errorf("unexpected closing bracket")
+			}
+		default:
+			if r == sep && depthBrace == 0 && depthBracket == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+
+	if inQuote {
+		return nil, fmt.Errorf("unterminated quote")
+	}
+	if depthBrace != 0 || depthBracket != 0 {
+		return nil, fmt.Errorf("unbalanced option delimiters")
+	}
+
+	parts = append(parts, s[start:])
+	return parts, nil
+}
+
+func parseOptionValue(raw string) (any, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("empty option value")
+	}
+
+	if strings.HasPrefix(raw, "\"") {
+		v, err := strconv.Unquote(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid quoted value %q: %w", raw, err)
+		}
+		return v, nil
+	}
+
+	if strings.HasPrefix(raw, "[") {
+		if !strings.HasSuffix(raw, "]") {
+			return nil, fmt.Errorf("invalid array value %q", raw)
+		}
+		inner := strings.TrimSpace(raw[1 : len(raw)-1])
+		if inner == "" {
+			return []any{}, nil
+		}
+		items, err := splitTopLevel(inner, ',')
+		if err != nil {
+			return nil, fmt.Errorf("invalid array value %q: %w", raw, err)
+		}
+		ret := make([]any, 0, len(items))
+		for _, item := range items {
+			parsed, err := parseOptionValue(item)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, parsed)
+		}
+		return ret, nil
+	}
+
+	if raw == "true" || raw == "false" {
+		return raw == "true", nil
+	}
+	if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		return i, nil
+	}
+	if f, err := strconv.ParseFloat(raw, 64); err == nil {
+		return f, nil
+	}
+
+	// Hugo style allows unquoted bare words (for example: linenos=table).
+	return raw, nil
+}
+
+func optionBool(v any) (bool, bool) {
+	switch val := v.(type) {
+	case bool:
+		return val, true
+	case string:
+		parsed, err := strconv.ParseBool(val)
+		if err == nil {
+			return parsed, true
+		}
+	}
+	return false, false
+}
+
+func optionInt64(v any) (int64, bool) {
+	switch val := v.(type) {
+	case int64:
+		return val, true
+	case int:
+		return int64(val), true
+	case float64:
+		return int64(val), true
+	case string:
+		if i, err := strconv.ParseInt(val, 10, 64); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func optionFloat64(v any) (float64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case float32:
+		return float64(val), true
+	case int:
+		return float64(val), true
+	case int64:
+		return float64(val), true
+	case string:
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}

--- a/mods/util/mdconv/d2ext/options_test.go
+++ b/mods/util/mdconv/d2ext/options_test.go
@@ -156,7 +156,7 @@ func TestApplyDefaultFenceOptionsRejectsUnsupportedElkAlgorithm(t *testing.T) {
 	}, compileOpts, renderOpts)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unsupported elk algorithm: spore")
-	require.Contains(t, err.Error(), "supported: layered, mrtree, radial")
+	require.Contains(t, err.Error(), "supported: layered, mrtree, random")
 }
 
 func TestDefaultLayoutResolverUnknownLayoutMessage(t *testing.T) {

--- a/mods/util/mdconv/d2ext/options_test.go
+++ b/mods/util/mdconv/d2ext/options_test.go
@@ -1,0 +1,196 @@
+package d2ext
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"oss.terrastruct.com/d2/d2graph"
+	"oss.terrastruct.com/d2/d2lib"
+	"oss.terrastruct.com/d2/d2plugin"
+	"oss.terrastruct.com/d2/d2renderers/d2svg"
+	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
+)
+
+func TestParseFenceOptions(t *testing.T) {
+	t.Run("parse hugo style options", func(t *testing.T) {
+		opts, err := parseFenceOptions("d2 {layout=elk,linenos=table,linenostart=1,hl_lines=[2,3,\"10-20\"],include_space=\"a b\"}")
+		require.NoError(t, err)
+		require.Equal(t, "elk", opts["layout"])
+		require.Equal(t, "table", opts["linenos"])
+		require.Equal(t, int64(1), opts["linenostart"])
+		require.Equal(t, "a b", opts["include_space"])
+
+		hl, ok := opts["hl_lines"].([]any)
+		require.True(t, ok)
+		require.Len(t, hl, 3)
+		require.Equal(t, int64(2), hl[0])
+		require.Equal(t, int64(3), hl[1])
+		require.Equal(t, "10-20", hl[2])
+	})
+
+	t.Run("old double brace syntax is ignored", func(t *testing.T) {
+		opts, err := parseFenceOptions("d2 {{opt1:true}}")
+		require.NoError(t, err)
+		require.Nil(t, opts)
+	})
+
+	t.Run("no meta", func(t *testing.T) {
+		opts, err := parseFenceOptions("d2")
+		require.NoError(t, err)
+		require.Nil(t, opts)
+	})
+
+	t.Run("invalid meta", func(t *testing.T) {
+		opts, err := parseFenceOptions("d2 {opt1=true")
+		require.NoError(t, err)
+		require.Nil(t, opts)
+	})
+}
+
+func TestApplyDefaultFenceOptions(t *testing.T) {
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptions(map[string]any{
+		"themeID": "7",
+		"sketch":  true,
+		"pad":     32,
+		"scale":   1.5,
+	}, nil, renderOpts)
+	require.NoError(t, err)
+	require.NotNil(t, renderOpts.ThemeID)
+	require.Equal(t, int64(7), *renderOpts.ThemeID)
+	require.NotNil(t, renderOpts.Sketch)
+	require.Equal(t, true, *renderOpts.Sketch)
+	require.NotNil(t, renderOpts.Pad)
+	require.Equal(t, int64(32), *renderOpts.Pad)
+	require.NotNil(t, renderOpts.Scale)
+	require.Equal(t, 1.5, *renderOpts.Scale)
+}
+
+func TestApplyDefaultFenceOptionsWithThemeName(t *testing.T) {
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptions(map[string]any{
+		"theme":  "Cool Classics",
+		"sketch": false,
+	}, nil, renderOpts)
+	require.NoError(t, err)
+	require.NotNil(t, renderOpts.ThemeID)
+	require.Equal(t, d2themescatalog.CoolClassics.ID, *renderOpts.ThemeID)
+}
+
+func TestApplyDefaultFenceOptionsWithLayoutOverride(t *testing.T) {
+	compileOpts := &d2lib.CompileOptions{}
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptionsWithCompile(map[string]any{
+		"layout":  "dagre",
+		"nodesep": int64(120),
+		"edgesep": int64(45),
+	}, compileOpts, renderOpts)
+	require.NoError(t, err)
+	require.NotNil(t, compileOpts.Layout)
+	require.Equal(t, "dagre", *compileOpts.Layout)
+	require.NotNil(t, compileOpts.LayoutResolver)
+
+	layout, err := compileOpts.LayoutResolver("dagre")
+	require.NoError(t, err)
+	require.NotNil(t, layout)
+}
+
+func TestApplyDefaultFenceOptionsWithLayoutOnly(t *testing.T) {
+	compileOpts := &d2lib.CompileOptions{}
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptionsWithCompile(map[string]any{
+		"layout": "elk",
+	}, compileOpts, renderOpts)
+	require.NoError(t, err)
+	require.NotNil(t, compileOpts.Layout)
+	require.Equal(t, "elk", *compileOpts.Layout)
+}
+
+func TestApplyDefaultFenceOptionsRejectsNodeSepWithNonDagreLayout(t *testing.T) {
+	compileOpts := &d2lib.CompileOptions{}
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptionsWithCompile(map[string]any{
+		"layout":  "elk",
+		"nodesep": int64(120),
+	}, compileOpts, renderOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only supported when layout is dagre")
+}
+
+func TestApplyDefaultFenceOptionsWithElkAlgorithm(t *testing.T) {
+	compileOpts := &d2lib.CompileOptions{}
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptionsWithCompile(map[string]any{
+		"layout":    "elk",
+		"algorithm": "mrtree",
+	}, compileOpts, renderOpts)
+	require.NoError(t, err)
+	require.NotNil(t, compileOpts.Layout)
+	require.Equal(t, "elk", *compileOpts.Layout)
+	require.NotNil(t, compileOpts.LayoutResolver)
+
+	layout, err := compileOpts.LayoutResolver("elk")
+	require.NoError(t, err)
+	require.NotNil(t, layout)
+}
+
+func TestApplyDefaultFenceOptionsRejectsAlgorithmWithNonElkLayout(t *testing.T) {
+	compileOpts := &d2lib.CompileOptions{}
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptionsWithCompile(map[string]any{
+		"layout":    "dagre",
+		"algorithm": "layered",
+	}, compileOpts, renderOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "algorithm is only supported when layout is elk")
+}
+
+func TestApplyDefaultFenceOptionsRejectsUnsupportedElkAlgorithm(t *testing.T) {
+	compileOpts := &d2lib.CompileOptions{}
+	renderOpts := &d2svg.RenderOpts{}
+	err := applyDefaultFenceOptionsWithCompile(map[string]any{
+		"layout":    "elk",
+		"algorithm": "spore",
+	}, compileOpts, renderOpts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported elk algorithm: spore")
+	require.Contains(t, err.Error(), "supported: layered, mrtree, radial")
+}
+
+func TestDefaultLayoutResolverUnknownLayoutMessage(t *testing.T) {
+	d2PluginListOnce = sync.Once{}
+	d2PluginListErr = nil
+	d2PluginList = []d2plugin.Plugin{&stubPlugin{name: "dagre"}, &stubPlugin{name: "elk"}}
+
+	r := &HTMLRenderer{}
+	_, err := r.defaultLayoutResolver("not-exists")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown layout engine: not-exists")
+	require.Contains(t, err.Error(), "available: dagre, elk")
+}
+
+type stubPlugin struct {
+	name string
+}
+
+func (p *stubPlugin) Info(context.Context) (*d2plugin.PluginInfo, error) {
+	return &d2plugin.PluginInfo{Name: p.name}, nil
+}
+
+func (p *stubPlugin) Flags(context.Context) ([]d2plugin.PluginSpecificFlag, error) {
+	return nil, nil
+}
+
+func (p *stubPlugin) HydrateOpts([]byte) error {
+	return nil
+}
+
+func (p *stubPlugin) Layout(context.Context, *d2graph.Graph) error {
+	return nil
+}
+
+func (p *stubPlugin) PostProcess(context.Context, []byte) ([]byte, error) {
+	return nil, nil
+}

--- a/mods/util/mdconv/d2ext/renderer.go
+++ b/mods/util/mdconv/d2ext/renderer.go
@@ -3,28 +3,56 @@ package d2ext
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/util"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
+	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
 	"oss.terrastruct.com/d2/d2lib"
+	"oss.terrastruct.com/d2/d2plugin"
 	"oss.terrastruct.com/d2/d2renderers/d2svg"
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 	d2log "oss.terrastruct.com/d2/lib/log"
 	"oss.terrastruct.com/d2/lib/textmeasure"
 )
 
+var (
+	d2PluginListOnce sync.Once
+	d2PluginList     []d2plugin.Plugin
+	d2PluginListErr  error
+)
+
+var supportedElkAlgorithms = map[string]struct{}{
+	"layered": {},
+	"mrtree":  {},
+	//	"radial":      {},
+	//	"rectpacking": {},
+	//	"spore":       {},
+	//	"box":    {},
+	//	"fixed":  {},
+	"random": {},
+}
+
 func ptr[T any](v T) *T {
 	return &v
 }
 
 type HTMLRenderer struct {
-	Layout  d2graph.LayoutGraph
-	ThemeID *int64
-	Sketch  bool
+	Layout          d2graph.LayoutGraph
+	ThemeID         *int64
+	Sketch          bool
+	OptionApplierFn FenceOptionApplier
 }
+
+type FenceOptionApplier func(opts map[string]any, compileOpts *d2lib.CompileOptions, renderOpts *d2svg.RenderOpts) error
 
 func (r *HTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(KindBlock, r.Render)
@@ -55,13 +83,8 @@ func (r *HTMLRenderer) Render(w util.BufWriter, src []byte, node ast.Node, enter
 	}
 
 	compileOpts := &d2lib.CompileOptions{
-		Ruler: ruler,
-		LayoutResolver: func(engine string) (d2graph.LayoutGraph, error) {
-			if r.Layout != nil {
-				return r.Layout, nil
-			}
-			return d2dagrelayout.DefaultLayout, nil
-		},
+		Ruler:          ruler,
+		LayoutResolver: r.defaultLayoutResolver,
 	}
 
 	renderOpts := &d2svg.RenderOpts{
@@ -73,6 +96,17 @@ func (r *HTMLRenderer) Render(w util.BufWriter, src []byte, node ast.Node, enter
 		renderOpts.ThemeID = r.ThemeID
 	} else {
 		renderOpts.ThemeID = &d2themescatalog.CoolClassics.ID
+	}
+
+	if len(n.Options) > 0 {
+		applier := r.OptionApplierFn
+		if applier == nil {
+			applier = applyDefaultFenceOptionsWithCompile
+		}
+		if err := applier(n.Options, compileOpts, renderOpts); err != nil {
+			_, _ = w.Write(b.Bytes())
+			return ast.WalkContinue, err
+		}
 	}
 
 	ctx := d2log.WithDefault(context.Background())
@@ -99,4 +133,242 @@ func (r *HTMLRenderer) Render(w util.BufWriter, src []byte, node ast.Node, enter
 
 func Pointer[T any](v T) *T {
 	return &v
+}
+
+func applyDefaultFenceOptions(opts map[string]any, _ *d2lib.CompileOptions, renderOpts *d2svg.RenderOpts) error {
+	return applyDefaultFenceOptionsWithCompile(opts, nil, renderOpts)
+}
+
+func applyDefaultFenceOptionsWithCompile(opts map[string]any, compileOpts *d2lib.CompileOptions, renderOpts *d2svg.RenderOpts) error {
+	layoutName := ""
+	if v, ok := opts["layout"]; ok {
+		layoutValue, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("layout must be a string")
+		}
+		layoutName = strings.ToLower(strings.TrimSpace(layoutValue))
+		if layoutName == "" {
+			return fmt.Errorf("layout must not be empty")
+		}
+		if compileOpts != nil {
+			compileOpts.Layout = Pointer(layoutName)
+		}
+	}
+
+	if v, ok := opts["sketch"]; ok {
+		if b, parsed := optionBool(v); parsed {
+			renderOpts.Sketch = Pointer(b)
+		}
+	}
+
+	if v, ok := opts["theme"]; ok {
+		themeName, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("theme must be a string")
+		}
+		themeID, found := resolveThemeIDByName(themeName)
+		if !found {
+			return fmt.Errorf("unknown d2 theme name: %q", themeName)
+		}
+		renderOpts.ThemeID = Pointer(themeID)
+	}
+
+	if v, ok := opts["themeID"]; ok {
+		if themeID, parsed := optionInt64(v); parsed {
+			renderOpts.ThemeID = Pointer(themeID)
+		}
+	}
+
+	if v, ok := opts["pad"]; ok {
+		if pad, parsed := optionInt64(v); parsed {
+			renderOpts.Pad = Pointer(pad)
+		}
+	}
+
+	if v, ok := opts["scale"]; ok {
+		if scale, parsed := optionFloat64(v); parsed {
+			renderOpts.Scale = Pointer(scale)
+		}
+	}
+
+	if compileOpts != nil {
+		requestedLayout := "dagre"
+		if compileOpts.Layout != nil && strings.TrimSpace(*compileOpts.Layout) != "" {
+			requestedLayout = strings.ToLower(strings.TrimSpace(*compileOpts.Layout))
+		}
+
+		if v, ok := opts["algorithm"]; ok {
+			if requestedLayout != "elk" {
+				return fmt.Errorf("algorithm is only supported when layout is elk")
+			}
+			algorithm, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("algorithm must be a string")
+			}
+			algorithm = strings.ToLower(strings.TrimSpace(algorithm))
+			if algorithm == "" {
+				return fmt.Errorf("algorithm must not be empty")
+			}
+			if _, supported := supportedElkAlgorithms[algorithm]; !supported {
+				return fmt.Errorf("unsupported elk algorithm: %s (supported: %s)", algorithm, strings.Join(supportedElkAlgorithmNames(), ", "))
+			}
+
+			baseResolver := compileOpts.LayoutResolver
+			compileOpts.LayoutResolver = func(engine string) (d2graph.LayoutGraph, error) {
+				normalized := strings.ToLower(strings.TrimSpace(engine))
+				if normalized == "" || normalized == "elk" {
+					return func(ctx context.Context, g *d2graph.Graph) error {
+						return d2elklayout.Layout(ctx, g, &d2elklayout.ConfigurableOpts{
+							Algorithm:       algorithm,
+							NodeSpacing:     d2elklayout.DefaultOpts.NodeSpacing,
+							Padding:         d2elklayout.DefaultOpts.Padding,
+							EdgeNodeSpacing: d2elklayout.DefaultOpts.EdgeNodeSpacing,
+							SelfLoopSpacing: d2elklayout.DefaultOpts.SelfLoopSpacing,
+						})
+					}, nil
+				}
+				if baseResolver != nil {
+					return baseResolver(engine)
+				}
+				return nil, fmt.Errorf("unsupported layout engine: %s", engine)
+			}
+		}
+
+		nodeSep, hasNodeSep := parseIntOption(opts, "nodesep")
+		edgeSep, hasEdgeSep := parseIntOption(opts, "edgesep")
+		if hasNodeSep || hasEdgeSep {
+			if requestedLayout != "dagre" {
+				return fmt.Errorf("nodesep/edgesep are only supported when layout is dagre")
+			}
+
+			if !hasNodeSep {
+				nodeSep = d2dagrelayout.DefaultOpts.NodeSep
+			}
+			if !hasEdgeSep {
+				edgeSep = d2dagrelayout.DefaultOpts.EdgeSep
+			}
+
+			baseResolver := compileOpts.LayoutResolver
+			compileOpts.LayoutResolver = func(engine string) (d2graph.LayoutGraph, error) {
+				normalized := strings.ToLower(strings.TrimSpace(engine))
+				if normalized == "" || normalized == "dagre" {
+					return func(ctx context.Context, g *d2graph.Graph) error {
+						return d2dagrelayout.Layout(ctx, g, &d2dagrelayout.ConfigurableOpts{
+							NodeSep: nodeSep,
+							EdgeSep: edgeSep,
+						})
+					}, nil
+				}
+				if baseResolver != nil {
+					return baseResolver(engine)
+				}
+				return nil, fmt.Errorf("unsupported layout engine: %s", engine)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *HTMLRenderer) defaultLayoutResolver(engine string) (d2graph.LayoutGraph, error) {
+	normalized := strings.ToLower(strings.TrimSpace(engine))
+	if normalized == "" || normalized == "dagre" {
+		if r.Layout != nil {
+			return r.Layout, nil
+		}
+		return d2dagrelayout.DefaultLayout, nil
+	}
+
+	plugins, err := listD2Plugins()
+	if err != nil {
+		return nil, err
+	}
+
+	plugin, err := d2plugin.FindPlugin(context.Background(), plugins, normalized)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, fmt.Errorf("unknown layout engine: %s (available: %s)", normalized, strings.Join(availableLayoutNames(plugins), ", "))
+		}
+		return nil, err
+	}
+
+	return plugin.Layout, nil
+}
+
+func listD2Plugins() ([]d2plugin.Plugin, error) {
+	d2PluginListOnce.Do(func() {
+		d2PluginList, d2PluginListErr = d2plugin.ListPlugins(context.Background())
+	})
+	if d2PluginListErr != nil {
+		return nil, d2PluginListErr
+	}
+	return d2PluginList, nil
+}
+
+func availableLayoutNames(plugins []d2plugin.Plugin) []string {
+	names := make([]string, 0, len(plugins))
+	for _, p := range plugins {
+		info, err := p.Info(context.Background())
+		if err != nil {
+			continue
+		}
+		if info == nil || strings.TrimSpace(info.Name) == "" {
+			continue
+		}
+		names = append(names, strings.ToLower(strings.TrimSpace(info.Name)))
+	}
+
+	if len(names) == 0 {
+		return []string{"dagre"}
+	}
+
+	sort.Strings(names)
+	unique := names[:0]
+	for i, name := range names {
+		if i == 0 || name != names[i-1] {
+			unique = append(unique, name)
+		}
+	}
+	return unique
+}
+
+func parseIntOption(opts map[string]any, key string) (int, bool) {
+	v, ok := opts[key]
+	if !ok {
+		return 0, false
+	}
+	i, parsed := optionInt64(v)
+	if !parsed {
+		return 0, false
+	}
+	return int(i), true
+}
+
+func supportedElkAlgorithmNames() []string {
+	names := make([]string, 0, len(supportedElkAlgorithms))
+	for name := range supportedElkAlgorithms {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func resolveThemeIDByName(name string) (int64, bool) {
+	query := strings.TrimSpace(name)
+	if query == "" {
+		return 0, false
+	}
+
+	for _, t := range d2themescatalog.LightCatalog {
+		if strings.EqualFold(t.Name, query) {
+			return t.ID, true
+		}
+	}
+	for _, t := range d2themescatalog.DarkCatalog {
+		if strings.EqualFold(t.Name, query) {
+			return t.ID, true
+		}
+	}
+
+	return 0, false
 }

--- a/mods/util/mdconv/d2ext/renderer.go
+++ b/mods/util/mdconv/d2ext/renderer.go
@@ -93,9 +93,9 @@ func (r *HTMLRenderer) Render(w util.BufWriter, src []byte, node ast.Node, enter
 	}
 
 	if r.ThemeID != nil {
-		renderOpts.ThemeID = r.ThemeID
+		renderOpts.ThemeID = ptr(int64(*r.ThemeID))
 	} else {
-		renderOpts.ThemeID = &d2themescatalog.CoolClassics.ID
+		renderOpts.ThemeID = ptr(int64(d2themescatalog.CoolClassics.ID))
 	}
 
 	if len(n.Options) > 0 {

--- a/mods/util/mdconv/d2ext/renderer.go
+++ b/mods/util/mdconv/d2ext/renderer.go
@@ -9,8 +9,6 @@ import (
 	"github.com/yuin/goldmark/util"
 	"oss.terrastruct.com/d2/d2graph"
 	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
-	"oss.terrastruct.com/d2/d2layouts/d2elklayout"
-	"oss.terrastruct.com/d2/d2layouts/d2grid"
 	"oss.terrastruct.com/d2/d2lib"
 	"oss.terrastruct.com/d2/d2renderers/d2svg"
 	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
@@ -18,12 +16,14 @@ import (
 	"oss.terrastruct.com/d2/lib/textmeasure"
 )
 
-var (
-	defaultLayout  = d2dagrelayout.DefaultLayout
-	defaultThemeID = d2themescatalog.CoolClassics.ID
-)
+func ptr[T any](v T) *T {
+	return &v
+}
 
 type HTMLRenderer struct {
+	Layout  d2graph.LayoutGraph
+	ThemeID *int64
+	Sketch  bool
 }
 
 func (r *HTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
@@ -54,25 +54,26 @@ func (r *HTMLRenderer) Render(w util.BufWriter, src []byte, node ast.Node, enter
 		return ast.WalkStop, err
 	}
 
-	layoutResolver := func(engine string) (d2graph.LayoutGraph, error) {
-		switch engine {
-		case "elk":
-			return d2elklayout.DefaultLayout, nil
-		case "dagre":
-			return d2dagrelayout.DefaultLayout, nil
-		case "grid":
-			return d2grid.Layout, nil
-		default:
-			return d2dagrelayout.DefaultLayout, nil
-		}
-	}
-
 	compileOpts := &d2lib.CompileOptions{
-		LayoutResolver: layoutResolver,
-		Ruler:          ruler,
+		Ruler: ruler,
+		LayoutResolver: func(engine string) (d2graph.LayoutGraph, error) {
+			if r.Layout != nil {
+				return r.Layout, nil
+			}
+			return d2dagrelayout.DefaultLayout, nil
+		},
 	}
 
-	renderOpts := &d2svg.RenderOpts{}
+	renderOpts := &d2svg.RenderOpts{
+		Pad:    ptr(int64(d2svg.DEFAULT_PADDING)),
+		Sketch: &r.Sketch,
+	}
+
+	if r.ThemeID != nil {
+		renderOpts.ThemeID = r.ThemeID
+	} else {
+		renderOpts.ThemeID = &d2themescatalog.CoolClassics.ID
+	}
 
 	ctx := d2log.WithDefault(context.Background())
 
@@ -85,9 +86,6 @@ func (r *HTMLRenderer) Render(w util.BufWriter, src []byte, node ast.Node, enter
 	if renderOpts.Scale == nil {
 		renderOpts.Scale = Pointer(1.0)
 	}
-
-	// renderOpts.ThemeID = go2.Pointer(d2themescatalog.NeutralDefault.ID)
-	// renderOpts.ThemeID = go2.Pointer(d2themescatalog.DarkMauve.ID)
 
 	out, err := d2svg.Render(diagram, renderOpts)
 	if err != nil {

--- a/mods/util/mdconv/d2ext/transformer.go
+++ b/mods/util/mdconv/d2ext/transformer.go
@@ -2,6 +2,7 @@ package d2ext
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/parser"
@@ -45,9 +46,44 @@ func (s *Transformer) Transform(doc *ast.Document, reader text.Reader, pctx pars
 		b := new(Block)
 		b.SetLines(cb.Lines())
 
+		if cb.Info != nil {
+			info := string(cb.Info.Segment.Value(reader.Source()))
+			if opts, err := parseFenceOptions(info); err == nil && len(opts) > 0 {
+				b.Options = opts
+			}
+		}
+
 		parent := cb.Parent()
 		if parent != nil {
 			parent.ReplaceChild(parent, cb, b)
 		}
 	}
+}
+
+func parseFenceOptions(info string) (map[string]any, error) {
+	trimmed := strings.TrimSpace(info)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	space := strings.IndexAny(trimmed, " \t")
+	if space < 0 {
+		return nil, nil
+	}
+
+	meta := strings.TrimSpace(trimmed[space+1:])
+	if strings.HasPrefix(meta, "{{") && strings.HasSuffix(meta, "}}") {
+		// Legacy format is intentionally ignored after switching to Hugo-style options.
+		return nil, nil
+	}
+	if !strings.HasPrefix(meta, "{") || !strings.HasSuffix(meta, "}") {
+		return nil, nil
+	}
+
+	body := strings.TrimSpace(meta[1 : len(meta)-1])
+	if body == "" {
+		return map[string]any{}, nil
+	}
+
+	return parseInlineOptions(body)
 }

--- a/mods/util/mdconv/mdconv.go
+++ b/mods/util/mdconv/mdconv.go
@@ -1,6 +1,7 @@
 package mdconv
 
 import (
+	"context"
 	"io"
 	"regexp"
 
@@ -12,6 +13,9 @@ import (
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/renderer/html"
 	"go.abhg.dev/goldmark/mermaid"
+	"oss.terrastruct.com/d2/d2graph"
+	"oss.terrastruct.com/d2/d2layouts/d2dagrelayout"
+	"oss.terrastruct.com/d2/d2themes/d2themescatalog"
 )
 
 type Converter struct {
@@ -59,7 +63,16 @@ func (c *Converter) Convert(src []byte, w io.Writer) error {
 					chromahtml.WrapLongLines(true),
 				),
 			),
-			&d2ext.Extender{},
+			&d2ext.Extender{
+				Layout: func(ctx context.Context, g *d2graph.Graph) error {
+					return d2dagrelayout.Layout(ctx, g, &d2dagrelayout.ConfigurableOpts{
+						NodeSep: 20,
+						EdgeSep: 20,
+					})
+				},
+				ThemeID: &d2themescatalog.CoolClassics.ID,
+				Sketch:  false,
+			},
 		),
 		goldmark.WithRendererOptions(
 			html.WithXHTML(),

--- a/mods/util/mdconv/mdconv.go
+++ b/mods/util/mdconv/mdconv.go
@@ -2,6 +2,7 @@ package mdconv
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"regexp"
 
@@ -42,7 +43,17 @@ func (c *Converter) ConvertString(src string, w io.Writer) error {
 	return c.Convert([]byte(src), w)
 }
 
-func (c *Converter) Convert(src []byte, w io.Writer) error {
+func (c *Converter) Convert(src []byte, w io.Writer) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Handle the panic and return an error instead of crashing the program
+			err, ok := r.(error)
+			if !ok {
+				err = fmt.Errorf("panic: %v", r)
+			}
+			retErr = err
+		}
+	}()
 	highlightingStyle := "onesenterprise"
 	if c.darkMode {
 		highlightingStyle = "catppuccin-macchiato"


### PR DESCRIPTION
This pull request introduces a new, robust D2 fenced code block extension (`d2ext`) for Goldmark, enabling advanced D2 diagram rendering with Hugo-style fence options. It includes a comprehensive option parser, improved layout/theme handling, and extensive tests. Additionally, it updates dependencies and enhances TQL parsing to support trailing function arguments after tagged blocks.

**D2 Fenced Code Block Extension and Option Parsing**

* Added the new `d2ext` Goldmark extension, which parses Hugo-style fence options for D2 code blocks and renders them as SVG diagrams. The extension supports a wide range of options (theme, layout, algorithm, sketch, padding, scale, etc.) and provides a detailed README documenting usage and supported options. (`mods/util/mdconv/d2ext/README.md`, `mods/util/mdconv/d2ext/ast.go`, `mods/util/mdconv/d2ext/extender.go`, `mods/util/mdconv/d2ext/renderer.go`) [[1]](diffhunk://#diff-b68bae6d1eefc7f87ab15d80ec1cb93ce4ba2ec4f81ee1abdafc6f5de8e19a2fR1-R90) [[2]](diffhunk://#diff-17ae3b5d690d12f9db89b485b7d83a4973482a57a1c82e334d17f718c1e9cd51R10) [[3]](diffhunk://#diff-61f08de3231bf056de7997f54149508d2e907165d4abe1e4bd24e923a86829ffR8-R28) [[4]](diffhunk://#diff-a647a7817502277c076d932e39fde145229d87ff1c7c1b7a200f4834e75dfdf3R6-R56) [[5]](diffhunk://#diff-a647a7817502277c076d932e39fde145229d87ff1c7c1b7a200f4834e75dfdf3L57-R110) [[6]](diffhunk://#diff-a647a7817502277c076d932e39fde145229d87ff1c7c1b7a200f4834e75dfdf3L89-L91)
* Implemented a robust parser for Hugo-style inline options, supporting strings, booleans, numbers, and arrays, with helpers for type conversion. (`mods/util/mdconv/d2ext/options.go`, `mods/util/mdconv/d2ext/options_test.go`) [[1]](diffhunk://#diff-d9217d94f5bc27ca104484cf61266857e071be897f8265b8143628e711bbfc0eR1-R194) [[2]](diffhunk://#diff-a839576451955ce9186d46a878c8dfe77961e461317d6d5bc094b5424f040fa9R1-R196)
* Improved layout and theme resolution, including support for custom layouts, theme names, and algorithm selection with error handling for unsupported values. (`mods/util/mdconv/d2ext/renderer.go`)

**TQL Parsing Improvements**

* Enhanced the TQL parser to allow trailing function arguments after tagged blocks, so expressions like `MARKDOWN({<<EOF ... EOF}, html(true))` are now correctly tokenized and parsed. (`mods/tql/expression/parse.go`, `mods/tql/expression/parse_test.go`, `mods/tql/tqlreader_test.go`) [[1]](diffhunk://#diff-52bef38eadede5e0b4e8b37686823b2169461dcc8c629cf9acf552278f090063L543-R545) [[2]](diffhunk://#diff-7a5d37d6a6a7de49d4508e7029ba4cb0af03cc02ea6fc860c07b79a3e3a1ba21R401-R419) [[3]](diffhunk://#diff-58eaee311c8753aeb121b523f29935e657c358c4001441744e9d7664d8cb9c9eR220-R226)

**Testing and Dependency Updates**

* Added comprehensive tests for the new D2 fence option parsing, option application, and error cases, ensuring robust and predictable behavior. (`mods/util/mdconv/d2ext/options_test.go`)
* Updated dependencies: bumped `github.com/yuin/goldmark` to v1.8.4, added `github.com/spf13/pflag` and `go.uber.org/multierr` as indirect dependencies. (`go.mod`) [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L56-R56) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R166) [[3]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R184)
* Added a new test to verify HTML output for markdown tables with templates. (`mods/codec/internal/markdown/md_test.go`)