### PR TITLE
Add jshext and SQL extensions with execution support and tests

### DIFF
--- a/mods/util/mdconv/chartext/options_test.go
+++ b/mods/util/mdconv/chartext/options_test.go
@@ -92,3 +92,70 @@ func TestApplyFenceOptionsRejectsInvalidLoader(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "none, local or auto")
 }
+
+func TestParseInlineOptionsCoversErrorBranches(t *testing.T) {
+	t.Run("invalid entry", func(t *testing.T) {
+		_, err := parseInlineOptions("width=600px,=bad")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid chart fence option entry")
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		_, err := parseInlineOptions("width=")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid chart fence option entry")
+	})
+
+	t.Run("split errors", func(t *testing.T) {
+		_, err := parseInlineOptions(`width=[1,2`)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unbalanced option delimiters")
+	})
+}
+
+func TestParseOptionValueCoversAdditionalBranches(t *testing.T) {
+	t.Run("quoted and array values", func(t *testing.T) {
+		val, err := parseOptionValue(`"hello"`)
+		require.NoError(t, err)
+		require.Equal(t, "hello", val)
+
+		array, err := parseOptionValue(`["a", true, 3]`)
+		require.NoError(t, err)
+		require.Equal(t, []any{"a", true, int64(3)}, array)
+	})
+
+	t.Run("invalid quoted value", func(t *testing.T) {
+		_, err := parseOptionValue(`"unterminated`)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid quoted value")
+	})
+
+	t.Run("invalid array delimiters", func(t *testing.T) {
+		_, err := parseOptionValue(`[1,2`)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid array value")
+	})
+}
+
+func TestOptionStringHelpers(t *testing.T) {
+	t.Run("convertibles", func(t *testing.T) {
+		v, ok := optionStringConvertible(true)
+		require.True(t, ok)
+		require.Equal(t, "true", v)
+
+		v, ok = optionStringConvertible(int32(7))
+		require.True(t, ok)
+		require.Equal(t, "7", v)
+	})
+
+	t.Run("string list", func(t *testing.T) {
+		items, ok := optionStringList([]any{"gl", int64(42), "wordcloud"})
+		require.True(t, ok)
+		require.Equal(t, []string{"gl", "42", "wordcloud"}, items)
+	})
+
+	t.Run("invalid list entry", func(t *testing.T) {
+		_, ok := optionStringList([]any{map[string]string{"bad": "value"}})
+		require.False(t, ok)
+	})
+}

--- a/mods/util/mdconv/jshext/README.md
+++ b/mods/util/mdconv/jshext/README.md
@@ -1,0 +1,71 @@
+# jshext
+
+`jshext` is a markdown extension for `jsh` fenced code blocks that can execute the block and render the result alongside the source.
+
+## Overview
+
+By default, a `jsh` fence is rendered as a normal syntax-highlighted code block.
+When `execute=true` is specified, the block is executed through the JSH engine and the rendered output includes:
+
+- the source preview
+- the execution result
+- `exitCode` metadata
+
+## Options
+
+The extension currently supports the following options:
+
+- `execute` (`true|false`, default: `false`)
+  - `true`: execute the block
+  - `false`: render as a normal code fence
+- `source` (`hide|all` or a line selection string/array-like value)
+  - `hide`: default for `execute=true`; hide the source preview
+  - `all`: show the full source
+  - `"2-3"` or `["2-3"]`: show only the selected lines
+- `result` (`default|json|none`, default: `default`)
+  - `default`: render a human-readable result box
+  - `json`: reserved for structured machine-readable payloads
+  - `none`: hide the result area
+- `timeout` (Go duration string)
+  - examples: `1s`, `100ms`, `1000us`
+  - apply a timeout to execution
+
+## Examples
+
+### Default behavior
+
+~~~markdown
+```jsh
+console.log("hello");
+```
+~~~
+
+This renders as a normal syntax-highlighted code fence.
+
+### Execute and show the result
+
+~~~markdown
+```jsh {execute=true}
+console.log("hello from jsh");
+```
+~~~
+
+The fence is executed and rendered with the result box. The source preview is hidden by default for `execute=true`; specify `source=all` or a line selection to show it.
+
+### Select source lines
+
+~~~markdown
+```jsh {execute=true,source=["2-3"]}
+console.log("line1");
+console.log("line2");
+console.log("line3");
+```
+~~~
+
+Only the requested lines are shown in the source preview.
+
+## Notes
+
+- `execute=false` remains the safe default.
+- The current implementation is a first pass and focuses on rendering and basic execution integration.
+- `timeout` is supported as the initial execution limit policy.

--- a/mods/util/mdconv/jshext/ast.go
+++ b/mods/util/mdconv/jshext/ast.go
@@ -1,0 +1,25 @@
+package jshext
+
+import "github.com/yuin/goldmark/ast"
+
+type NodeKind int
+
+const (
+	KindBlock ast.NodeKind = ast.NodeKind(1000)
+)
+
+type Block struct {
+	ast.BaseBlock
+	Source   string
+	Options  Options
+	Output   string
+	ExitCode int
+	TimedOut bool
+	Err      string
+}
+
+func (b *Block) Kind() ast.NodeKind { return ast.NodeKind(KindBlock) }
+
+func (b *Block) Dump(source []byte, level int) {
+	ast.DumpHelper(b, source, level, nil, nil)
+}

--- a/mods/util/mdconv/jshext/engine_runner.go
+++ b/mods/util/mdconv/jshext/engine_runner.go
@@ -1,0 +1,127 @@
+package jshext
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/machbase/neo-server/v8/jsh/engine"
+	"github.com/machbase/neo-server/v8/jsh/lib"
+	"github.com/machbase/neo-server/v8/jsh/root"
+)
+
+type ExecResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	Elapsed  time.Duration
+	TimedOut bool
+	Err      string
+}
+
+func runJSHCode(code string, opts Options) ExecResult {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var ctx context.Context = context.Background()
+	var cancel context.CancelFunc
+	if opts.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), opts.Timeout)
+		defer cancel()
+	}
+
+	jr, err := engine.New(engine.Config{
+		Name:    "jshext",
+		Code:    code,
+		Context: ctx,
+		Env: map[string]any{
+			"PATH":         "/sbin:/work",
+			"HOME":         "/work",
+			"PWD":          "/work",
+			"LIBRARY_PATH": "./node_modules:/lib",
+		},
+		Aliases: map[string]string{
+			"ll": "ls -l",
+		},
+		FSTabs: []engine.FSTab{
+			root.RootFSTab(),
+			lib.LibFSTab(),
+			// TODO: add /work fstab
+		},
+	})
+	if err != nil {
+		return ExecResult{Err: err.Error()}
+	}
+	lib.Enable(jr)
+
+	jr.Env = engine.NewEnv(
+		engine.WithWriter(&stdout),
+		engine.WithErrorWriter(&stderr),
+		engine.WithReader(strings.NewReader("")),
+	)
+
+	start := time.Now()
+	err = jr.RunContext(ctx)
+	elapsed := time.Since(start)
+	res := ExecResult{Stdout: stdout.String(), Stderr: stderr.String(), ExitCode: jr.ExitCode(), Elapsed: elapsed}
+	if err != nil {
+		if ctx.Err() != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			res.TimedOut = true
+			res.Err = fmt.Sprintf("timed out after %s", opts.Timeout)
+			res.ExitCode = -1
+		} else {
+			res.Err = err.Error()
+		}
+	}
+	return res
+}
+
+func formatExecOutput(res ExecResult) string {
+	var b strings.Builder
+	if res.Stdout != "" {
+		b.WriteString(res.Stdout)
+	}
+	if res.Stderr != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(res.Stderr)
+	}
+	if res.Err != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(res.Err)
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func renderExecResultJSON(res ExecResult) string {
+	type payload struct {
+		Stdout   string `json:"stdout"`
+		Stderr   string `json:"stderr"`
+		ExitCode int    `json:"exitCode"`
+		Elapsed  int64  `json:"elapsedMs"`
+		TimedOut bool   `json:"timedOut"`
+		Err      string `json:"error,omitempty"`
+	}
+	data := payload{
+		Stdout:   res.Stdout,
+		Stderr:   res.Stderr,
+		ExitCode: res.ExitCode,
+		Elapsed:  res.Elapsed.Milliseconds(),
+		TimedOut: res.TimedOut,
+		Err:      res.Err,
+	}
+	encoded, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("{\"error\": %q}", err.Error())
+	}
+	return string(encoded)
+}

--- a/mods/util/mdconv/jshext/extender.go
+++ b/mods/util/mdconv/jshext/extender.go
@@ -1,0 +1,19 @@
+package jshext
+
+import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+type Extender struct{}
+
+func (e *Extender) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(parser.WithASTTransformers(
+		util.Prioritized(&Transformer{}, 100),
+	))
+	m.Renderer().AddOptions(renderer.WithNodeRenderers(
+		util.Prioritized(&HTMLRenderer{}, 0),
+	))
+}

--- a/mods/util/mdconv/jshext/jshext_test.go
+++ b/mods/util/mdconv/jshext/jshext_test.go
@@ -1,0 +1,177 @@
+package jshext_test
+
+import (
+	"bytes"
+	"html"
+	"strings"
+	"testing"
+
+	"github.com/machbase/neo-server/v8/mods/util/mdconv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJshExecuteRendersSourceAndOutput(t *testing.T) {
+	src := strings.Join([]string{
+		"# JSH example",
+		"```jsh {execute=true}",
+		`console.log("hello from jsh");`,
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.Contains(t, result, `class="jshext"`)
+	require.Contains(t, result, `class="jshext-result"`)
+	require.Contains(t, result, "hello from jsh")
+	require.NotContains(t, result, "exitCode")
+}
+
+func TestJshExecuteFalseRendersAsCodeFence(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=false}",
+		`console.log("hello");`,
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.NotContains(t, result, `class="jshext"`)
+	require.Contains(t, result, "<pre")
+	require.Contains(t, result, "<code")
+}
+
+func TestJshSourceSelectionRendersOnlyRequestedLines(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=true,source=[\"2-3\"]}",
+		"console.log('line1');",
+		"console.log('line2');",
+		"console.log('line3');",
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.Contains(t, result, "console.log(&#39;line2&#39;);")
+	require.Contains(t, result, "console.log(&#39;line3&#39;);")
+	require.NotContains(t, result, "console.log(&#39;line1&#39;);")
+}
+
+func TestJshExecuteUsesRealJshRuntime(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=true}",
+		`console.log("runtime-ok");`,
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.Contains(t, result, "runtime-ok")
+	require.NotContains(t, result, "exitCode")
+}
+
+func TestJshSourceHideIsDefaultForExecuteTrue(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=true}",
+		`console.log("hidden-source");`,
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.NotContains(t, result, `<div class="jshext-source">`)
+	require.Contains(t, result, `class="jshext-result"`)
+}
+
+func TestJshExecuteFalseIgnoresSourceOption(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=false,source=[\"2-3\"]}",
+		"console.log('line1');",
+		"console.log('line2');",
+		"console.log('line3');",
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.NotContains(t, result, `class="jshext"`)
+	require.Contains(t, result, "line1")
+	require.Contains(t, result, "line2")
+	require.Contains(t, result, "line3")
+}
+
+func TestJshSourceRenderUsesCodeBlockStyle(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=true,source=[\"2\"]}",
+		`console.log("first line");`,
+		`console.log("styled-source");`,
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.Contains(t, result, `<pre class="chroma"`)
+	require.Contains(t, result, `<code class="language-javascript">`)
+}
+
+func TestJshResultJsonRendersStructuredPayload(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=true,result=json}",
+		`console.log("json-ok");`,
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := html.UnescapeString(out.String())
+	require.Contains(t, result, `"stdout"`)
+	require.Contains(t, result, `"exitCode": 0`)
+	require.Contains(t, result, `"timedOut": false`)
+}
+
+func TestJshTimeoutRendersTimedOutExecution(t *testing.T) {
+	src := strings.Join([]string{
+		"```jsh {execute=true,timeout=1ms}",
+		"while (true) { }",
+		"```",
+	}, "\n")
+
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+
+	result := out.String()
+	require.Contains(t, result, "timed out")
+	require.NotContains(t, result, "timedOut=true")
+}

--- a/mods/util/mdconv/jshext/options.go
+++ b/mods/util/mdconv/jshext/options.go
@@ -1,0 +1,142 @@
+package jshext
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Options struct {
+	Execute bool
+	Source  string
+	Result  string
+	Timeout time.Duration
+}
+
+func ParseOptions(info string) Options {
+	ret := Options{Execute: false, Source: "hide", Result: "default", Timeout: 0}
+	raw := strings.TrimSpace(info)
+	if start := strings.Index(raw, "{"); start >= 0 {
+		if end := strings.LastIndex(raw, "}"); end > start {
+			raw = raw[start+1 : end]
+		}
+	}
+	for _, part := range splitTopLevelCSV(raw) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.TrimSpace(kv[1])
+		switch key {
+		case "execute":
+			ret.Execute = strings.EqualFold(val, "true")
+		case "source":
+			ret.Source = normalizeSourceValue(val)
+		case "result":
+			ret.Result = normalizeStringValue(val)
+		case "timeout":
+			if dur, err := time.ParseDuration(val); err == nil {
+				ret.Timeout = dur
+			}
+		}
+	}
+	return ret
+}
+
+func splitTopLevelCSV(raw string) []string {
+	var parts []string
+	var buf strings.Builder
+	depth := 0
+	inQuote := false
+	for _, r := range raw {
+		switch r {
+		case '[':
+			depth++
+			buf.WriteRune(r)
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+			buf.WriteRune(r)
+		case '"':
+			inQuote = !inQuote
+			buf.WriteRune(r)
+		case ',':
+			if depth == 0 && !inQuote {
+				part := strings.TrimSpace(buf.String())
+				if part != "" {
+					parts = append(parts, part)
+				}
+				buf.Reset()
+				continue
+			}
+			buf.WriteRune(r)
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	if part := strings.TrimSpace(buf.String()); part != "" {
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func normalizeSourceValue(val string) string {
+	val = strings.TrimSpace(val)
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		inner := strings.TrimSpace(val[1 : len(val)-1])
+		if inner == "" {
+			return "all"
+		}
+		parts := splitTopLevelCSV(inner)
+		for i, p := range parts {
+			parts[i] = normalizeStringValue(p)
+		}
+		return strings.Join(parts, ",")
+	}
+	return normalizeStringValue(val)
+}
+
+func normalizeStringValue(val string) string {
+	val = strings.TrimSpace(val)
+	if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
+		return val[1 : len(val)-1]
+	}
+	return val
+}
+
+func SelectSourceLines(source string, spec string) string {
+	if spec == "" || strings.EqualFold(spec, "all") {
+		return source
+	}
+	lines := strings.Split(strings.ReplaceAll(source, "\r\n", "\n"), "\n")
+	var out []string
+	for _, token := range splitTopLevelCSV(spec) {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if strings.Contains(token, "-") {
+			parts := strings.SplitN(token, "-", 2)
+			if len(parts) == 2 {
+				start, _ := strconv.Atoi(strings.TrimSpace(parts[0]))
+				end, _ := strconv.Atoi(strings.TrimSpace(parts[1]))
+				if start > 0 && end >= start {
+					for i := start - 1; i < end && i < len(lines); i++ {
+						out = append(out, lines[i])
+					}
+				}
+			}
+			continue
+		}
+		if idx, err := strconv.Atoi(token); err == nil && idx > 0 && idx <= len(lines) {
+			out = append(out, lines[idx-1])
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/mods/util/mdconv/jshext/renderer.go
+++ b/mods/util/mdconv/jshext/renderer.go
@@ -1,0 +1,42 @@
+package jshext
+
+import (
+	"html"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+type HTMLRenderer struct{}
+
+func (r *HTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindBlock, r.Render)
+}
+
+func (r *HTMLRenderer) Render(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	bn := node.(*Block)
+	var b strings.Builder
+	b.WriteString(`<div class="jshext">`)
+	if bn.Source != "" {
+		b.WriteString(`<pre class="chroma"><code class="language-javascript">`)
+		b.WriteString(html.EscapeString(bn.Source))
+		b.WriteString(`</code></pre>`)
+	}
+	if bn.Options.Execute {
+		if bn.Options.Result != "none" {
+			b.WriteString(`<div class="jshext-result">`)
+			b.WriteString(`<pre>`)
+			b.WriteString(html.EscapeString(bn.Output))
+			b.WriteString(`</pre>`)
+			b.WriteString(`</div>`)
+		}
+	}
+	b.WriteString(`</div>`)
+	_, _ = w.WriteString(b.String())
+	return ast.WalkContinue, nil
+}

--- a/mods/util/mdconv/jshext/transformer.go
+++ b/mods/util/mdconv/jshext/transformer.go
@@ -1,0 +1,81 @@
+package jshext
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+type Transformer struct{}
+
+var jshLang = []byte("jsh")
+var jsLang = []byte("javascript")
+
+func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, _ parser.Context) {
+	var blocks []*ast.FencedCodeBlock
+
+	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		cb, ok := node.(*ast.FencedCodeBlock)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		lang := cb.Language(reader.Source())
+		if !bytes.Equal(lang, jshLang) && !bytes.Equal(lang, jsLang) {
+			return ast.WalkContinue, nil
+		}
+		blocks = append(blocks, cb)
+		return ast.WalkContinue, nil
+	})
+
+	for _, cb := range blocks {
+		var buf bytes.Buffer
+		lines := cb.Lines()
+		for i := 0; i < lines.Len(); i++ {
+			segment := lines.At(i)
+			buf.Write(segment.Value(reader.Source()))
+		}
+		code := buf.String()
+		info := ""
+		if cb.Info != nil {
+			segment := cb.Info.Segment
+			info = string(segment.Value(reader.Source()))
+		}
+		opts := ParseOptions(info)
+		if !opts.Execute {
+			continue
+		}
+		res := runJSHCode(code, opts)
+		out := formatExecOutput(res)
+		switch opts.Result {
+		case "json":
+			out = renderExecResultJSON(res)
+		case "none":
+			out = ""
+		}
+		exitCode := res.ExitCode
+		preview := ""
+		if opts.Execute {
+			if opts.Source == "" || strings.EqualFold(opts.Source, "hide") {
+				preview = ""
+			} else if strings.EqualFold(opts.Source, "all") {
+				preview = code
+			} else {
+				preview = SelectSourceLines(code, opts.Source)
+			}
+		}
+		if opts.Execute && preview == "" && !strings.EqualFold(opts.Source, "hide") && !strings.EqualFold(opts.Source, "") {
+			preview = SelectSourceLines(code, opts.Source)
+		}
+		node := &Block{Source: preview, Options: opts, Output: out, ExitCode: exitCode, TimedOut: res.TimedOut}
+		parent := cb.Parent()
+		if parent != nil {
+			parent.ReplaceChild(parent, cb, node)
+		}
+	}
+}

--- a/mods/util/mdconv/mdconv.go
+++ b/mods/util/mdconv/mdconv.go
@@ -12,6 +12,7 @@ import (
 	"github.com/machbase/neo-server/v8/mods/util/mdconv/d2ext"
 	"github.com/machbase/neo-server/v8/mods/util/mdconv/geomapext"
 	"github.com/machbase/neo-server/v8/mods/util/mdconv/httpext"
+	"github.com/machbase/neo-server/v8/mods/util/mdconv/jshext"
 	"github.com/machbase/neo-server/v8/mods/util/mdconv/katex"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
@@ -98,6 +99,7 @@ func (c *Converter) Convert(src []byte, w io.Writer) (retErr error) {
 			&chartext.Extender{DarkMode: c.darkMode},
 			&geomapext.Extender{DarkMode: c.darkMode},
 			&httpext.Extender{},
+			&jshext.Extender{},
 			&katex.Extender{Options: c.katexOptions},
 		),
 		goldmark.WithRendererOptions(

--- a/mods/util/mdconv/mdconv.go
+++ b/mods/util/mdconv/mdconv.go
@@ -14,6 +14,7 @@ import (
 	"github.com/machbase/neo-server/v8/mods/util/mdconv/httpext"
 	"github.com/machbase/neo-server/v8/mods/util/mdconv/jshext"
 	"github.com/machbase/neo-server/v8/mods/util/mdconv/katex"
+	"github.com/machbase/neo-server/v8/mods/util/mdconv/sqlext"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/extension"
@@ -100,6 +101,7 @@ func (c *Converter) Convert(src []byte, w io.Writer) (retErr error) {
 			&geomapext.Extender{DarkMode: c.darkMode},
 			&httpext.Extender{},
 			&jshext.Extender{},
+			&sqlext.Extender{},
 			&katex.Extender{Options: c.katexOptions},
 		),
 		goldmark.WithRendererOptions(

--- a/mods/util/mdconv/mdconv_test.go
+++ b/mods/util/mdconv/mdconv_test.go
@@ -261,3 +261,38 @@ func TestMdWithKaTeXDisplayBlockWithBlankLines(t *testing.T) {
 	require.Contains(t, result, `annotation encoding="application/x-tex">`)
 	require.Contains(t, result, `x = y^\pi`)
 }
+
+func TestMdWithD2CodeFence(t *testing.T) {
+	code := []string{
+		`# D2 test`,
+		"```d2",
+		`graph TD`,
+		`A-->B`,
+		"```",
+	}
+
+	w := &bytes.Buffer{}
+	conv := mdconv.New(mdconv.WithDarkMode(true))
+	err := conv.ConvertString(strings.Join(code, "\n"), w)
+	require.NoError(t, err)
+
+	result := w.String()
+	require.Contains(t, result, `class="d2"`)
+	require.Contains(t, result, `graph TD`)
+}
+
+func TestMdConvRecoversFromPanic(t *testing.T) {
+	conv := mdconv.New()
+	var out bytes.Buffer
+	err := conv.Convert([]byte("# hi\n"), &out)
+	require.NoError(t, err)
+}
+
+func TestMapCodeFenceLanguage(t *testing.T) {
+	conv := mdconv.New()
+	var out bytes.Buffer
+	err := conv.Convert([]byte("```jsh\nconsole.log(1)\n```\n"), &out)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "<pre")
+	require.Contains(t, out.String(), "console")
+}

--- a/mods/util/mdconv/sqlext/README.md
+++ b/mods/util/mdconv/sqlext/README.md
@@ -1,0 +1,127 @@
+# sqlext
+
+`sqlext` is a markdown extension for `sql` fenced code blocks that can execute the block and render the result alongside the source.
+
+## Overview
+
+By default, a `sql` fence is rendered as a normal syntax-highlighted code block.
+When `execute=true` is specified, the block is executed through the shared SQL execution path and the output includes both the source preview and the execution result.
+
+## Options
+
+The extension supports the following options:
+
+- `execute` (`true|false`, default: `false`)
+  - `true`: execute the block
+  - `false`: render as a normal code fence
+- `source` (`hide|all` or a line selection string/array-like value)
+  - `hide`: default for `execute=true`; hide the source preview
+  - `all`: show the full source
+  - `"2-3"` or `["2-3"]`: show only the selected lines
+- `format` (`table|json|csv|none`, default: `table`)
+  - `table`: render a human-readable table result
+  - `json`: render a JSON object with result metadata
+  - `csv`: render CSV output
+  - `none`: hide the result area
+- `timeformat` (string)
+  - controls how time values are formatted
+- `tz` (string)
+  - controls the time zone used for formatting
+- `binaryformat` (`base64|hex|bytes|preview`, default: `hex`)
+  - controls how binary values are formatted
+- `preview` (`int` or `unlimit|none`, default: `10`)
+  - controls how many rows are shown when a result set is rendered in preview form
+  - when a query returns more rows than the preview size, the renderer shows the first and last rows with an ellipsis in the middle
+  - use `unlimit` or `none` to disable the compact preview behavior and show the full result
+- `params` / `p` (array-like value)
+  - supplies bind parameters for the SQL statement
+  - example: `params=[1,"neo"]` or `p=[1,"neo"]`
+- `header` (`skip|<other>`, default: empty)
+  - uses the same semantics as the server-side SQL request handling for header rendering
+- `delimiter` (string, default: `,`)
+  - custom delimiter for CSV-style output; applied only when `format=csv`
+- `timeout` (Go duration string)
+  - examples: `1s`, `100ms`, `1000us`
+  - apply a timeout to execution
+
+## Examples
+
+### 1. Default behavior
+
+~~~markdown
+```sql
+select 1 as v;
+```
+~~~
+
+This renders as a normal syntax-highlighted code fence.
+
+### 2. Execute and show the result
+
+~~~markdown
+```sql {execute=true}
+select 1 as v;
+```
+~~~
+
+The fence is executed and rendered with the result block. The source preview is hidden by default for `execute=true`; specify `source=all` or a line selection to show it.
+
+### 3. Format the output
+
+~~~markdown
+```sql {execute=true,format=json,timeformat=2006-01-02 15:04:05,tz=Asia/Seoul,binaryformat=hex}
+select now() as ts, x'0102' as payload;
+```
+~~~
+
+The result is rendered using the requested format and formatting options.
+
+### 4. Preview large result sets
+
+~~~markdown
+```sql {execute=true,format=table,preview=6}
+select * from generate_series(1, 20) as t(v);
+```
+~~~
+
+When the result contains more rows than the preview size, the output shows the first and last rows with an ellipsis in between.
+
+### 5. Show source preview lines
+
+~~~markdown
+```sql {execute=true,source=["2-3"]}
+select 1 as a;
+select 2 as b;
+select 3 as c;
+```
+~~~
+
+Only the requested source lines are shown in the preview block.
+
+### 6. Use bind parameters
+
+~~~markdown
+```sql {execute=true,format=csv,p=[1,"neo"]}
+select ?, ?;
+```
+~~~
+
+The fenced block can pass bind parameters through the `p` option.
+
+To show the full result instead of the compact preview, set `preview=none` or `preview=unlimit`.
+
+### 7. Render as CSV with custom header behavior
+
+~~~markdown
+```sql {execute=true,format=csv,header=skip,delimiter=|}
+select 1 as a, 2 as b;
+```
+~~~
+
+This example shows how to switch to CSV output and control the rendered header behavior.
+
+## Notes
+
+- `execute=false` remains the safe default.
+- The implementation uses the shared SQL request path, so Markdown SQL execution follows the same request semantics as the server-side SQL handling flow.
+- `timeout` is supported as the initial execution limit policy.

--- a/mods/util/mdconv/sqlext/ast.go
+++ b/mods/util/mdconv/sqlext/ast.go
@@ -1,0 +1,24 @@
+package sqlext
+
+import "github.com/yuin/goldmark/ast"
+
+type NodeKind int
+
+const (
+	KindBlock ast.NodeKind = ast.NodeKind(2000)
+)
+
+type Block struct {
+	ast.BaseBlock
+	Source   string
+	Options  Options
+	Output   string
+	Error    string
+	TimedOut bool
+}
+
+func (b *Block) Kind() ast.NodeKind { return ast.NodeKind(KindBlock) }
+
+func (b *Block) Dump(source []byte, level int) {
+	ast.DumpHelper(b, source, level, nil, nil)
+}

--- a/mods/util/mdconv/sqlext/extender.go
+++ b/mods/util/mdconv/sqlext/extender.go
@@ -1,0 +1,19 @@
+package sqlext
+
+import (
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+type Extender struct{}
+
+func (e *Extender) Extend(m goldmark.Markdown) {
+	m.Parser().AddOptions(parser.WithASTTransformers(
+		util.Prioritized(&Transformer{}, 100),
+	))
+	m.Renderer().AddOptions(renderer.WithNodeRenderers(
+		util.Prioritized(&HTMLRenderer{}, 0),
+	))
+}

--- a/mods/util/mdconv/sqlext/options.go
+++ b/mods/util/mdconv/sqlext/options.go
@@ -1,0 +1,193 @@
+package sqlext
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Options struct {
+	Execute      bool
+	Format       string
+	Output       string
+	Source       string
+	Preview      int
+	Timeout      time.Duration
+	Params       []any
+	Timeformat   string
+	TimeLocation string
+	BinaryFormat string
+	Header       string
+	Delimiter    string
+}
+
+func ParseOptions(info string) Options {
+	ret := Options{
+		Execute:      false,
+		Format:       "table",
+		Output:       "table",
+		Source:       "hide",
+		Preview:      10,
+		Timeout:      0,
+		Timeformat:   "ns",
+		TimeLocation: "UTC",
+		BinaryFormat: "hex",
+		Header:       "",
+		Delimiter:    ",",
+	}
+	raw := strings.TrimSpace(info)
+	if start := strings.Index(raw, "{"); start >= 0 {
+		if end := strings.LastIndex(raw, "}"); end > start {
+			raw = raw[start+1 : end]
+		}
+	}
+	for _, part := range splitTopLevelCSV(raw) {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		val := strings.TrimSpace(kv[1])
+		switch key {
+		case "execute":
+			ret.Execute = strings.EqualFold(val, "true")
+		case "output":
+			ret.Output = normalizeStringValue(val)
+			ret.Format = ret.Output
+		case "source":
+			ret.Source = normalizeStringValue(val)
+		case "format":
+			ret.Format = normalizeStringValue(val)
+			ret.Output = ret.Format
+		case "preview":
+			ret.Preview = parsePreviewValue(val)
+		case "timeout":
+			if dur, err := time.ParseDuration(val); err == nil {
+				ret.Timeout = dur
+			}
+		case "params", "p":
+			ret.Params = parseParamValue(val)
+		case "timeformat":
+			ret.Timeformat = normalizeStringValue(val)
+		case "tz":
+			ret.TimeLocation = normalizeStringValue(val)
+		case "binaryformat":
+			ret.BinaryFormat = normalizeStringValue(val)
+		case "header":
+			ret.Header = normalizeStringValue(val)
+		case "delimiter":
+			ret.Delimiter = normalizeStringValue(val)
+		}
+	}
+	return ret
+}
+
+func parsePreviewValue(val string) int {
+	v := strings.ToLower(strings.TrimSpace(val))
+	if v == "" || v == "unlimit" || v == "none" {
+		return 0
+	}
+	if n, err := strconv.Atoi(v); err == nil {
+		return n
+	}
+	return 10
+}
+
+func parseParamValue(val string) []any {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return nil
+	}
+	if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+		var out []any
+		if err := json.Unmarshal([]byte(val), &out); err == nil {
+			return out
+		}
+	}
+	return []any{normalizeStringValue(val)}
+}
+
+func splitTopLevelCSV(raw string) []string {
+	var parts []string
+	var buf strings.Builder
+	depth := 0
+	inQuote := false
+	for _, r := range raw {
+		switch r {
+		case '[':
+			depth++
+			buf.WriteRune(r)
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+			buf.WriteRune(r)
+		case '"':
+			inQuote = !inQuote
+			buf.WriteRune(r)
+		case ',':
+			if depth == 0 && !inQuote {
+				part := strings.TrimSpace(buf.String())
+				if part != "" {
+					parts = append(parts, part)
+				}
+				buf.Reset()
+				continue
+			}
+			buf.WriteRune(r)
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	if part := strings.TrimSpace(buf.String()); part != "" {
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func normalizeStringValue(val string) string {
+	val = strings.TrimSpace(val)
+	if len(val) >= 2 && ((val[0] == '"' && val[len(val)-1] == '"') || (val[0] == '\'' && val[len(val)-1] == '\'')) {
+		return val[1 : len(val)-1]
+	}
+	return val
+}
+
+func SelectSourceLines(source string, spec string) string {
+	if spec == "" || strings.EqualFold(spec, "hide") {
+		return ""
+	}
+	if strings.EqualFold(spec, "all") || strings.EqualFold(spec, "show") {
+		return source
+	}
+	lines := strings.Split(strings.ReplaceAll(source, "\r\n", "\n"), "\n")
+	var out []string
+	for _, token := range splitTopLevelCSV(spec) {
+		token = strings.TrimSpace(token)
+		if token == "" {
+			continue
+		}
+		if strings.Contains(token, "-") {
+			parts := strings.SplitN(token, "-", 2)
+			if len(parts) == 2 {
+				start, _ := strconv.Atoi(strings.TrimSpace(parts[0]))
+				end, _ := strconv.Atoi(strings.TrimSpace(parts[1]))
+				if start > 0 && end >= start {
+					for i := start - 1; i < end && i < len(lines); i++ {
+						out = append(out, lines[i])
+					}
+				}
+			}
+			continue
+		}
+		if idx, err := strconv.Atoi(token); err == nil && idx > 0 && idx <= len(lines) {
+			out = append(out, lines[idx-1])
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/mods/util/mdconv/sqlext/renderer.go
+++ b/mods/util/mdconv/sqlext/renderer.go
@@ -1,0 +1,137 @@
+package sqlext
+
+import (
+	"fmt"
+	"html"
+	"strconv"
+	"strings"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+type HTMLRenderer struct{}
+
+func (r *HTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(KindBlock, r.Render)
+}
+
+func renderCSVContent(body string) string {
+	const defaultDelimiter = byte(',')
+	delim := detectCSVDelimiter(body)
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	var b strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fields, _ := splitCSVFields(line, delim)
+		for idx, field := range fields {
+			className := "sqlext-csv-col-" + strconv.Itoa(idx)
+			paletteClass := "sqlext-csv-col-p" + strconv.Itoa(idx%12)
+			b.WriteString(fmt.Sprintf(`<span class="%s %s">%s</span>`, className, paletteClass, html.EscapeString(field)))
+			if idx < len(fields)-1 {
+				b.WriteString(`<span class="sqlext-csv-delim">`)
+				b.WriteString(html.EscapeString(string(delim)))
+				b.WriteString(`</span>`)
+			}
+		}
+	}
+	return b.String()
+}
+
+func detectCSVDelimiter(body string) byte {
+	const defaultDelimiter = byte(',')
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
+	var candidates []byte = []byte{',', '|', ';', '\t'}
+	best := defaultDelimiter
+	bestScore := -1
+	for _, delim := range candidates {
+		score, modeCols := scoreDelimiter(lines, delim)
+		if modeCols <= 1 {
+			continue
+		}
+		if score > bestScore {
+			bestScore = score
+			best = delim
+		}
+	}
+	return best
+}
+
+func scoreDelimiter(lines []string, delim byte) (int, int) {
+	var total int
+	var cols int
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Count(line, string(delim)) + 1
+		if fields > cols {
+			cols = fields
+		}
+		total += fields
+	}
+	return total, cols
+}
+
+func splitCSVFields(line string, delim byte) ([]string, bool) {
+	if delim == 0 {
+		return []string{line}, false
+	}
+	var fields []string
+	var buf strings.Builder
+	inQuote := false
+	for i := 0; i < len(line); i++ {
+		ch := line[i]
+		if ch == '"' {
+			if inQuote && i+1 < len(line) && line[i+1] == '"' {
+				buf.WriteByte(ch)
+				i++
+			} else {
+				inQuote = !inQuote
+			}
+			continue
+		}
+		if ch == delim && !inQuote {
+			fields = append(fields, buf.String())
+			buf.Reset()
+			continue
+		}
+		buf.WriteByte(ch)
+	}
+	fields = append(fields, buf.String())
+	return fields, true
+}
+
+func (r *HTMLRenderer) Render(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+	bn := node.(*Block)
+	var b strings.Builder
+	b.WriteString(`<div class="sqlext">`)
+	if bn.Options.Execute && bn.Source != "" {
+		b.WriteString(`<div class="sqlext-source">`)
+		b.WriteString(`<pre class="chroma"><code class="language-sql">`)
+		b.WriteString(html.EscapeString(bn.Source))
+		b.WriteString(`</code></pre>`)
+		b.WriteString(`</div>`)
+	}
+	if bn.Options.Execute && bn.Options.Format != "none" {
+		b.WriteString(`<div class="sqlext-result">`)
+		b.WriteString(`<pre>`)
+		if strings.EqualFold(bn.Options.Format, "csv") {
+			b.WriteString(renderCSVContent(bn.Output))
+		} else {
+			b.WriteString(html.EscapeString(bn.Output))
+		}
+		b.WriteString(`</pre>`)
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</div>`)
+	_, _ = w.WriteString(b.String())
+	return ast.WalkContinue, nil
+}

--- a/mods/util/mdconv/sqlext/sql_request.go
+++ b/mods/util/mdconv/sqlext/sql_request.go
@@ -1,0 +1,910 @@
+package sqlext
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/machbase/neo-server/v8/mods/util"
+	"github.com/machbase/neo-server/v8/spi"
+)
+
+// Conn is the minimal database connection abstraction used by shared SQL request helpers.
+type Conn interface {
+	PrepareContext(ctx context.Context, query string) (Stmt, error)
+	QueryContext(ctx context.Context, query string, args ...any) (Rows, error)
+	ExecContext(ctx context.Context, query string, args ...any) (Result, error)
+	Close() error
+}
+
+// Result is the minimal execution result abstraction used by shared SQL request helpers.
+type Result interface {
+	RowsAffected() (int64, error)
+}
+
+// Stmt is the minimal statement abstraction used by shared SQL request helpers.
+type Stmt interface {
+	QueryContext(ctx context.Context, args ...any) (Rows, error)
+	Close() error
+}
+
+// Rows is the minimal row set abstraction used by shared SQL request helpers.
+type Rows interface {
+	Columns() ([]string, error)
+	ColumnTypes() ([]*sql.ColumnType, error)
+	Close() error
+	Next() bool
+	Scan(dest ...any) error
+}
+
+// QueryRequest is the shared SQL request payload used by server handlers and mdconv extensions.
+type QueryRequest struct {
+	SqlText         string    `json:"q"`
+	Params          []any     `json:"p,omitempty"`
+	Preview         int       `json:"preview,omitempty"`
+	TimeFormat      string    `json:"timeformat,omitempty"`
+	Timezone        string    `json:"tz,omitempty"`
+	BinaryFormat    string    `json:"binaryformat,omitempty"`
+	RowsFlattern    bool      `json:"rowsFlattern,omitempty"`
+	RowsArray       bool      `json:"rowsArray,omitempty"`
+	Transpose       bool      `json:"transpose,omitempty"`
+	Precision       int       `json:"precision,omitempty"`
+	RowNum          bool      `json:"rownum,omitempty"`
+	Heading         bool      `json:"heading,omitempty"`
+	Header          bool      `json:"header,omitempty"`
+	Delimiter       string    `json:"delimiter,omitempty"`
+	BoxStyle        string    `json:"boxStyle,omitempty"`
+	BoxSeparateCols bool      `json:"boxSeparateColumns,omitempty"`
+	BoxDrawBorder   bool      `json:"boxDrawBorder,omitempty"`
+	Output          string    `json:"output,omitempty"`
+	Format          string    `json:"format,omitempty"`
+	ReplyTo         string    `json:"replyTo,omitempty"`
+	Database        string    `json:"database,omitempty"`
+	User            string    `json:"user,omitempty"`
+	Password        string    `json:"password,omitempty"`
+	AuthKey         string    `json:"authKey,omitempty"`
+	NoCache         bool      `json:"noCache,omitempty"`
+	NoMeta          bool      `json:"noMeta,omitempty"`
+	NoFormat        bool      `json:"noFormat,omitempty"`
+	Cache           bool      `json:"cache,omitempty"`
+	Truncate        int       `json:"truncate,omitempty"`
+	Conn            Conn      `json:"-"`
+	Hook            QueryHook `json:"-"`
+}
+
+type QueryHook struct {
+	SetContentType     func(string)
+	SetContentEncoding func(string)
+	SetStatusCode      func(int)
+	SetUserMessage     func(string)
+}
+
+var connectQueryConn = func(ctx context.Context) (Conn, error) {
+	conn, err := spi.Connect(ctx, "sys")
+	if err != nil {
+		return nil, err
+	}
+	return &sqlConnAdapter{Conn: conn}, nil
+}
+
+type sqlConnAdapter struct {
+	*sql.Conn
+}
+
+func (c *sqlConnAdapter) PrepareContext(ctx context.Context, query string) (Stmt, error) {
+	stmt, err := c.Conn.PrepareContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlStmtAdapter{Stmt: stmt}, nil
+}
+
+func (c *sqlConnAdapter) QueryContext(ctx context.Context, query string, args ...any) (Rows, error) {
+	rows, err := c.Conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlRowsAdapter{Rows: rows}, nil
+}
+
+func (c *sqlConnAdapter) ExecContext(ctx context.Context, query string, args ...any) (Result, error) {
+	result, err := c.Conn.ExecContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlResultAdapter{result: result}, nil
+}
+
+type sqlStmtAdapter struct {
+	*sql.Stmt
+}
+
+func (s *sqlStmtAdapter) QueryContext(ctx context.Context, args ...any) (Rows, error) {
+	rows, err := s.Stmt.QueryContext(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	return &sqlRowsAdapter{Rows: rows}, nil
+}
+
+type sqlRowsAdapter struct {
+	*sql.Rows
+}
+
+type sqlResultAdapter struct {
+	result sql.Result
+}
+
+func (a *sqlResultAdapter) RowsAffected() (int64, error) {
+	return a.result.RowsAffected()
+}
+
+func NewQueryRequest() *QueryRequest {
+	return &QueryRequest{Output: "box", Header: true, Heading: true, TimeFormat: "ns", Preview: 10}
+}
+
+func (q *QueryRequest) DecodeJSON(r io.Reader) error {
+	var body struct {
+		SqlText      string `json:"q"`
+		Params       any    `json:"p"`
+		Preview      int    `json:"preview"`
+		TimeFormat   string `json:"timeformat"`
+		Timezone     string `json:"tz"`
+		BinaryFormat string `json:"binaryformat"`
+		RowsFlattern bool   `json:"rowsFlattern"`
+		RowsArray    bool   `json:"rowsArray"`
+		Transpose    bool   `json:"transpose"`
+		Precision    int    `json:"precision"`
+		RowNum       bool   `json:"rownum"`
+		Heading      bool   `json:"heading"`
+		Header       bool   `json:"header"`
+		Delimiter    string `json:"delimiter"`
+		BoxStyle     string `json:"boxStyle"`
+		BoxSeparate  bool   `json:"boxSeparateColumns"`
+		BoxBorder    bool   `json:"boxDrawBorder"`
+		Output       string `json:"output"`
+		Format       string `json:"format"`
+		ReplyTo      string `json:"replyTo"`
+		Database     string `json:"database"`
+		User         string `json:"user"`
+		Password     string `json:"password"`
+		AuthKey      string `json:"authKey"`
+		NoCache      bool   `json:"noCache"`
+		NoMeta       bool   `json:"noMeta"`
+		NoFormat     bool   `json:"noFormat"`
+		Cache        bool   `json:"cache"`
+		Truncate     int    `json:"truncate"`
+	}
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		return err
+	}
+	q.SqlText = body.SqlText
+	q.Preview = body.Preview
+	q.TimeFormat = body.TimeFormat
+	q.Timezone = body.Timezone
+	q.BinaryFormat = body.BinaryFormat
+	q.RowsFlattern = body.RowsFlattern
+	q.RowsArray = body.RowsArray
+	q.Transpose = body.Transpose
+	q.Precision = body.Precision
+	q.RowNum = body.RowNum
+	q.Heading = body.Heading
+	q.Header = body.Header
+	q.Delimiter = body.Delimiter
+	q.BoxStyle = body.BoxStyle
+	q.BoxSeparateCols = body.BoxSeparate
+	q.BoxDrawBorder = body.BoxBorder
+	q.Output = body.Output
+	q.Format = body.Format
+	q.ReplyTo = body.ReplyTo
+	q.Database = body.Database
+	q.User = body.User
+	q.Password = body.Password
+	q.AuthKey = body.AuthKey
+	q.NoCache = body.NoCache
+	q.NoMeta = body.NoMeta
+	q.NoFormat = body.NoFormat
+	q.Cache = body.Cache
+	q.Truncate = body.Truncate
+	if body.Params == nil {
+		q.Params = nil
+		return nil
+	}
+	params, err := ParseQueryParams(body.Params)
+	if err != nil {
+		return err
+	}
+	q.Params = params
+	return nil
+}
+
+func (q *QueryRequest) DecodeQuery(v url.Values) error {
+	if v == nil {
+		return nil
+	}
+	q.SqlText = v.Get("q")
+	q.Preview = parseInt(v.Get("preview"))
+	q.TimeFormat = v.Get("timeformat")
+	q.Timezone = v.Get("tz")
+	q.BinaryFormat = v.Get("binaryformat")
+	q.RowsFlattern = parseBool(v.Get("rowsFlattern"))
+	q.RowsArray = parseBool(v.Get("rowsArray"))
+	q.Transpose = parseBool(v.Get("transpose"))
+	q.Precision = parseInt(v.Get("precision"))
+	q.RowNum = parseBool(v.Get("rownum"))
+	q.Heading = parseBool(v.Get("heading"))
+	q.Header = parseBool(v.Get("header"))
+	q.Delimiter = v.Get("delimiter")
+	q.BoxStyle = v.Get("boxStyle")
+	q.BoxSeparateCols = parseBool(v.Get("boxSeparateColumns"))
+	q.BoxDrawBorder = parseBool(v.Get("boxDrawBorder"))
+	q.Output = v.Get("output")
+	q.Format = v.Get("format")
+	q.ReplyTo = v.Get("replyTo")
+	q.Database = v.Get("database")
+	q.User = v.Get("user")
+	q.Password = v.Get("password")
+	q.AuthKey = v.Get("authKey")
+	q.NoCache = parseBool(v.Get("noCache"))
+	q.NoMeta = parseBool(v.Get("noMeta"))
+	q.NoFormat = parseBool(v.Get("noFormat"))
+	q.Cache = parseBool(v.Get("cache"))
+	q.Truncate = parseInt(v.Get("truncate"))
+	if raw := v.Get("p"); raw != "" {
+		params, err := ParseQueryParams(raw)
+		if err != nil {
+			return err
+		}
+		q.Params = params
+	}
+	return nil
+}
+
+func (q *QueryRequest) DecodePostForm(v url.Values) error {
+	return q.DecodeQuery(v)
+}
+
+func ParseQueryParams(raw any) ([]any, error) {
+	switch value := raw.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		text := strings.TrimSpace(value)
+		if text == "" {
+			return nil, nil
+		}
+		var parsed []any
+		if err := json.Unmarshal([]byte(text), &parsed); err != nil {
+			return nil, fmt.Errorf("invalid p: %w", err)
+		}
+		return normalizeParams(parsed)
+	case []any:
+		return normalizeParams(value)
+	case []string:
+		res := make([]any, 0, len(value))
+		for _, item := range value {
+			res = append(res, item)
+		}
+		return res, nil
+	default:
+		return nil, fmt.Errorf("invalid p: unsupported type %T", raw)
+	}
+}
+
+func normalizeParams(params []any) ([]any, error) {
+	res := make([]any, 0, len(params))
+	for _, item := range params {
+		norm, err := NormalizeQueryParamValue(item)
+		if err != nil {
+			return nil, fmt.Errorf("invalid p: %w", err)
+		}
+		res = append(res, norm)
+	}
+	return res, nil
+}
+
+func NormalizeQueryParamValue(value any) (any, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case string, bool, int, int8, int16, int32, int64:
+		return v, nil
+	case float32:
+		if float64(v) == math.Trunc(float64(v)) {
+			return int(v), nil
+		}
+		return float64(v), nil
+	case float64:
+		if v == math.Trunc(v) {
+			return int(v), nil
+		}
+		return v, nil
+	case json.Number:
+		if strings.ContainsAny(v.String(), ".eE") {
+			f, err := strconv.ParseFloat(v.String(), 64)
+			if err != nil {
+				return nil, err
+			}
+			return f, nil
+		}
+		if i, err := strconv.ParseInt(v.String(), 10, 64); err == nil {
+			return i, nil
+		}
+		if i, err := strconv.Atoi(v.String()); err == nil {
+			return i, nil
+		}
+		return nil, fmt.Errorf("invalid syntax")
+	case []any, []string:
+		return nil, fmt.Errorf("invalid p: scalar required, got slice")
+	case map[string]any:
+		return nil, fmt.Errorf("invalid p: scalar required, got map")
+	default:
+		return nil, fmt.Errorf("unsupported bind parameter type %T", value)
+	}
+}
+
+func (q *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHook) error {
+	if q.SqlText == "" {
+		return fmt.Errorf("query sql is empty")
+	}
+	output := normalizeRequestedOutputFormat(q.Output, q.Format)
+	if output == "none" {
+		return nil
+	}
+	if hook == nil {
+		hook = &QueryHook{}
+	}
+
+	conn, err := q.ensureConn(ctx)
+	if err != nil {
+		return err
+	}
+
+	stmtType := spi.DetectSQLStatementType(q.SqlText)
+	if !stmtType.IsFetch() {
+		result, err := conn.ExecContext(ctx, q.SqlText, q.Params...)
+		if err != nil {
+			return err
+		}
+		if hook.SetUserMessage != nil {
+			rawRows, _ := result.RowsAffected()
+			hook.SetUserMessage(spi.MakeUserMessage(stmtType, rawRows))
+		}
+		return nil
+	}
+
+	queryText := q.SqlText
+	switch stmtType {
+	case spi.SQLStatementTypeDescribe:
+		queryText = describeToShowTableQuery(q.SqlText)
+	}
+
+	rows, err := conn.QueryContext(ctx, queryText, q.Params...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	timeLocation, err := util.ParseTimeLocation(q.Timezone, time.UTC)
+	if err != nil {
+		return err
+	}
+
+	columnTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return err
+	}
+	columnNames, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	outWriter := w
+	if outWriter == nil {
+		outWriter = io.Discard
+	}
+	if hook.SetContentType != nil {
+		hook.SetContentType(contentTypeForFormat(output))
+	}
+	timeFormatter := util.NewTimeFormatter(util.Timeformat(q.TimeFormat), util.TimeLocation(timeLocation))
+	binaryFormatter := util.NewBinaryFormatter(q.BinaryFormat)
+	rowCount, err := renderRowsByFormat(outWriter, output, q.Heading, rows, columnNames, columnTypes, q.TimeFormat, timeLocation.String(), timeFormatter, binaryFormatter, stmtType, q.Preview)
+	if err != nil {
+		return err
+	}
+	if hook.SetUserMessage != nil {
+		hook.SetUserMessage(userMessageForStatement(stmtType, rowCount))
+	}
+	return nil
+}
+
+func normalizeRequestedOutputFormat(output, format string) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		output = strings.TrimSpace(format)
+	}
+	if output == "" {
+		output = "box"
+	}
+	return strings.ToLower(output)
+}
+
+func contentTypeForFormat(output string) string {
+	switch output {
+	case "json":
+		return "application/json"
+	case "ndjson":
+		return "application/x-ndjson"
+	case "csv":
+		return "text/csv; charset=utf-8"
+	case "markdown":
+		return "text/markdown"
+	case "html":
+		return "text/html"
+	case "text":
+		return "text/plain"
+	default:
+		return "text/plain"
+	}
+}
+
+func renderRowsByFormat(w io.Writer, output string, heading bool, rows Rows, columnNames []string, columnTypes []*sql.ColumnType, timeFormat, tzName string, timeFormatter *util.TimeFormatter, binaryFormatter *util.BinaryFormatter, stmtType spi.SQLStatementType, limit int) (int64, error) {
+	if output == "none" {
+		return 0, nil
+	}
+
+	switch strings.ToLower(output) {
+	case "json":
+		return renderJSONOutput(w, rows, columnNames, columnTypes, timeFormatter, binaryFormatter, stmtType, limit)
+	case "ndjson":
+		return renderNDJSONOutput(w, rows, columnNames, timeFormatter, binaryFormatter, limit)
+	case "csv":
+		return renderCSVOutput(w, heading, rows, columnNames, timeFormatter, binaryFormatter, limit)
+	default:
+		return renderTableOutput(w, heading, rows, columnNames, columnTypes, timeFormat, tzName, timeFormatter, binaryFormatter, stmtType, limit)
+	}
+}
+
+func shouldAppendTimezoneToHeader(timeFormat string) bool {
+	switch strings.ToLower(strings.TrimSpace(timeFormat)) {
+	case "", "ns", "us", "ms", "s", "ns.str", "us.str", "ms.str", "s.str":
+		return false
+	default:
+		return true
+	}
+}
+
+func formatTableHeaderLabel(name, columnTypeName, timeFormat, tzName string) string {
+	if !strings.EqualFold(strings.TrimSpace(columnTypeName), "datetime") {
+		return name
+	}
+	if !shouldAppendTimezoneToHeader(timeFormat) {
+		return name
+	}
+	if strings.TrimSpace(tzName) == "" {
+		return name
+	}
+	return fmt.Sprintf("%s(%s)", name, tzName)
+}
+
+func renderTableOutput(w io.Writer, heading bool, rows Rows, columnNames []string, columnTypes []*sql.ColumnType, timeFormat, tzName string, timeFormatter *util.TimeFormatter, binaryFormatter *util.BinaryFormatter, stmtType spi.SQLStatementType, limit int) (int64, error) {
+	tw := table.NewWriter()
+	tw.SetOutputMirror(w)
+	style := table.StyleDefault
+	style.Options.SeparateColumns = true
+	style.Options.DrawBorder = true
+	tw.SetStyle(style)
+
+	if heading && len(columnNames) > 0 {
+		header := make([]any, len(columnNames))
+		for i, name := range columnNames {
+			columnTypeName := ""
+			if i < len(columnTypes) && columnTypes[i] != nil {
+				columnTypeName = columnTypes[i].DatabaseTypeName()
+			}
+			header[i] = formatTableHeaderLabel(name, columnTypeName, timeFormat, tzName)
+		}
+		tw.AppendHeader(table.Row(header))
+	}
+
+	nrows := int64(0)
+	rawRows := make([][]any, 0)
+	for rows.Next() {
+		nrows++
+		dests := make([]any, len(columnNames))
+		for i := range dests {
+			dests[i] = new(any)
+		}
+		if err := rows.Scan(dests...); err != nil {
+			return 0, err
+		}
+		values := make([]any, 0, len(dests))
+		for _, dest := range dests {
+			value := any(nil)
+			if p, ok := dest.(*any); ok {
+				value = *p
+			}
+			values = append(values, value)
+		}
+		rawRows = append(rawRows, values)
+	}
+
+	displayRows := previewRows(rawRows, limit)
+	for i, values := range displayRows {
+		if shouldRenderEllipsisRow(rawRows, limit, i) {
+			tw.AppendRow(table.Row(makeEllipsisRow(len(columnNames))))
+			continue
+		}
+		formatted := make([]any, 0, len(values))
+		for _, value := range values {
+			formatted = append(formatted, formatValueForTextOutput(value, timeFormatter, binaryFormatter))
+		}
+		tw.AppendRow(table.Row(formatted))
+	}
+
+	tw.Render()
+	userMessage := userMessageForStatement(stmtType, nrows)
+	if userMessage != "" {
+		_, _ = io.WriteString(w, "\n")
+		_, _ = io.WriteString(w, userMessage)
+	}
+	return nrows, nil
+}
+
+func renderJSONOutput(w io.Writer, rows Rows, columnNames []string, columnTypes []*sql.ColumnType, timeFormatter *util.TimeFormatter, binaryFormatter *util.BinaryFormatter, stmtType spi.SQLStatementType, limit int) (int64, error) {
+	nrows := int64(0)
+	rawRows := make([][]any, 0)
+	_, _ = io.WriteString(w, `{"data":{"columns":`)
+	if err := json.NewEncoder(w).Encode(columnNames); err != nil {
+		return 0, err
+	}
+	_, _ = io.WriteString(w, `,"types":`)
+	if err := json.NewEncoder(w).Encode(columnTypeNamesForColumns(columnNames, columnTypes)); err != nil {
+		return 0, err
+	}
+	_, _ = io.WriteString(w, `,"rows":[`)
+	for rows.Next() {
+		nrows++
+		values := make([]any, len(columnNames))
+		for i := range values {
+			values[i] = new(any)
+		}
+		if err := rows.Scan(values...); err != nil {
+			return 0, err
+		}
+		raw := make([]any, 0, len(values))
+		for _, value := range values {
+			if p, ok := value.(*any); ok {
+				raw = append(raw, *p)
+			} else {
+				raw = append(raw, nil)
+			}
+		}
+		rawRows = append(rawRows, raw)
+	}
+	displayRows := previewRows(rawRows, limit)
+	firstRow := true
+	for i, values := range displayRows {
+		if shouldRenderEllipsisRow(rawRows, limit, i) {
+			continue
+		}
+		if !firstRow {
+			_, _ = io.WriteString(w, ",")
+		}
+		firstRow = false
+		rowValues := make([]any, 0, len(values))
+		for _, value := range values {
+			rowValues = append(rowValues, formatValueForJSONOutput(value, timeFormatter, binaryFormatter))
+		}
+		if err := json.NewEncoder(w).Encode(rowValues); err != nil {
+			return 0, err
+		}
+	}
+	reason := "success"
+	if stmtType != spi.SQLStatementTypeOther {
+		reason = userMessageForStatement(stmtType, nrows)
+	}
+	_, _ = io.WriteString(w, `],"success":true,"reason":"`)
+	_, _ = io.WriteString(w, strings.ReplaceAll(reason, `"`, `\\"`))
+	_, _ = io.WriteString(w, `","elapse":"0s"}`)
+	return nrows, nil
+}
+
+func renderNDJSONOutput(w io.Writer, rows Rows, columnNames []string, timeFormatter *util.TimeFormatter, binaryFormatter *util.BinaryFormatter, limit int) (int64, error) {
+	nrows := int64(0)
+	rawRows := make([][]any, 0)
+	for rows.Next() {
+		nrows++
+		values := make([]any, len(columnNames))
+		for i := range values {
+			values[i] = new(any)
+		}
+		if err := rows.Scan(values...); err != nil {
+			return 0, err
+		}
+		raw := make([]any, 0, len(values))
+		for _, value := range values {
+			if p, ok := value.(*any); ok {
+				raw = append(raw, *p)
+			} else {
+				raw = append(raw, nil)
+			}
+		}
+		rawRows = append(rawRows, raw)
+	}
+	displayRows := previewRows(rawRows, limit)
+	for i, values := range displayRows {
+		if shouldRenderEllipsisRow(rawRows, limit, i) {
+			continue
+		}
+		rowMap := make(map[string]any, len(columnNames))
+		for i, name := range columnNames {
+			if i < len(values) {
+				rowMap[name] = formatValueForJSONOutput(values[i], timeFormatter, binaryFormatter)
+			}
+		}
+		if err := json.NewEncoder(w).Encode(rowMap); err != nil {
+			return 0, err
+		}
+	}
+	return nrows, nil
+}
+
+func renderCSVOutput(w io.Writer, heading bool, rows Rows, columnNames []string, timeFormatter *util.TimeFormatter, binaryFormatter *util.BinaryFormatter, limit int) (int64, error) {
+	nrows := int64(0)
+	rawRows := make([][]any, 0)
+	if heading && len(columnNames) > 0 {
+		_, _ = fmt.Fprintf(w, "%s\n", strings.Join(columnNames, ","))
+	}
+	for rows.Next() {
+		nrows++
+		values := make([]any, len(columnNames))
+		for i := range values {
+			values[i] = new(any)
+		}
+		if err := rows.Scan(values...); err != nil {
+			return 0, err
+		}
+		raw := make([]any, 0, len(values))
+		for _, value := range values {
+			if p, ok := value.(*any); ok {
+				raw = append(raw, *p)
+			} else {
+				raw = append(raw, nil)
+			}
+		}
+		rawRows = append(rawRows, raw)
+	}
+	displayRows := previewRows(rawRows, limit)
+	for i, values := range displayRows {
+		if shouldRenderEllipsisRow(rawRows, limit, i) {
+			ellipsis := make([]string, len(columnNames))
+			for j := range ellipsis {
+				ellipsis[j] = "..."
+			}
+			_, _ = fmt.Fprintf(w, "%s\n", strings.Join(ellipsis, ","))
+			continue
+		}
+		parts := make([]string, 0, len(values))
+		for _, value := range values {
+			parts = append(parts, formatValueForTextOutput(value, timeFormatter, binaryFormatter))
+		}
+		_, _ = fmt.Fprintf(w, "%s\n", strings.Join(parts, ","))
+	}
+	return nrows, nil
+}
+
+func columnTypeNamesForColumns(columnNames []string, columnTypes []*sql.ColumnType) []string {
+	res := make([]string, len(columnNames))
+	for i := range res {
+		res[i] = "string"
+		if len(columnTypes) > i && columnTypes[i] != nil {
+			res[i] = columnTypes[i].DatabaseTypeName()
+		}
+	}
+	return res
+}
+
+func previewRows(rows [][]any, limit int) [][]any {
+	if limit <= 0 || len(rows) <= limit {
+		return rows
+	}
+	headCount := limit / 2
+	if headCount <= 0 {
+		headCount = 1
+	}
+	tailCount := limit - headCount
+	if tailCount <= 0 {
+		tailCount = 1
+	}
+	if headCount+tailCount >= len(rows) {
+		return rows
+	}
+	preview := make([][]any, 0, headCount+tailCount+1)
+	preview = append(preview, rows[:headCount]...)
+	preview = append(preview, makeEllipsisRow(len(rows[0])))
+	preview = append(preview, rows[len(rows)-tailCount:]...)
+	return preview
+}
+
+func shouldRenderEllipsisRow(rows [][]any, limit int, index int) bool {
+	if limit <= 0 || len(rows) <= limit {
+		return false
+	}
+	headCount := limit / 2
+	if headCount <= 0 {
+		headCount = 1
+	}
+	tailCount := limit - headCount
+	if tailCount <= 0 {
+		tailCount = 1
+	}
+	if headCount+tailCount >= len(rows) {
+		return false
+	}
+	return index == headCount
+}
+
+func makeEllipsisRow(columnCount int) []any {
+	row := make([]any, columnCount)
+	for i := range row {
+		row[i] = "..."
+	}
+	return row
+}
+
+func describeToShowTableQuery(sqlText string) string {
+	trimmed := strings.TrimSpace(sqlText)
+	trimmed = strings.TrimPrefix(strings.ToUpper(trimmed), "DESCRIBE")
+	trimmed = strings.TrimSpace(trimmed)
+	trimmed = strings.TrimPrefix(trimmed, "DESC")
+	trimmed = strings.TrimSpace(trimmed)
+	return "SHOW TABLE " + trimmed
+}
+
+func userMessageForStatement(stmtType spi.SQLStatementType, rowCount int64) string {
+	switch stmtType {
+	case spi.SQLStatementTypeShow, spi.SQLStatementTypeExplain:
+		return spi.MakeUserMessage(spi.SQLStatementTypeSelect, rowCount)
+	default:
+		return spi.MakeUserMessage(stmtType, rowCount)
+	}
+}
+
+func formatValueForJSONOutput(value any, timeFormatter *util.TimeFormatter, binaryFormatter *util.BinaryFormatter) any {
+	if value == nil {
+		return nil
+	}
+	if t, ok := value.(time.Time); ok {
+		if timeFormatter != nil {
+			return timeFormatter.Format(t)
+		}
+		return t.Format(time.RFC3339Nano)
+	}
+	if b, ok := value.([]byte); ok {
+		if binaryFormatter != nil {
+			return binaryFormatter.Format(b)
+		}
+		return string(b)
+	}
+	if s, ok := value.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return value
+}
+
+func formatValueForTextOutput(value any, timeFormatter *util.TimeFormatter, binaryFormatter *util.BinaryFormatter) string {
+	if value == nil {
+		return "NULL"
+	}
+	if t, ok := value.(time.Time); ok {
+		if timeFormatter != nil {
+			return timeFormatter.Format(t)
+		}
+		return t.Format(time.RFC3339Nano)
+	}
+	if b, ok := value.([]byte); ok {
+		if binaryFormatter != nil {
+			return binaryFormatter.Format(b)
+		}
+		return string(b)
+	}
+	if s, ok := value.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%v", value)
+}
+
+func (q *QueryRequest) ensureConn(ctx context.Context) (Conn, error) {
+	if q.Conn != nil {
+		return q.Conn, nil
+	}
+	conn, err := connectQueryConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	q.Conn = conn
+	return conn, nil
+}
+
+func (q *QueryRequest) HandleQuery(w io.Writer, hook *QueryHook) error {
+	return q.Execute(context.Background(), w, hook)
+}
+
+func (q *QueryRequest) ToJSON() ([]byte, error) {
+	return json.Marshal(q)
+}
+
+func (q *QueryRequest) FromJSON(data []byte) error {
+	return q.DecodeJSON(bytes.NewReader(data))
+}
+
+func NewQueryRequestFromJSON(data []byte) (*QueryRequest, error) {
+	q := NewQueryRequest()
+	return q, q.FromJSON(data)
+}
+
+func (q *QueryRequest) AddHook(hook *QueryHook) {
+	if hook != nil {
+		q.Hook = *hook
+	}
+}
+
+func (q *QueryRequest) GetQueryText() string          { return q.SqlText }
+func (q *QueryRequest) GetParams() []any              { return q.Params }
+func (q *QueryRequest) SetQueryText(text string)      { q.SqlText = text }
+func (q *QueryRequest) SetParams(params []any)        { q.Params = params }
+func (q *QueryRequest) SetOutput(output string)       { q.Output = output }
+func (q *QueryRequest) SetFormat(format string)       { q.Format = format }
+func (q *QueryRequest) SetPreview(preview int)        { q.Preview = preview }
+func (q *QueryRequest) SetTimeFormat(format string)   { q.TimeFormat = format }
+func (q *QueryRequest) SetTimezone(tz string)         { q.Timezone = tz }
+func (q *QueryRequest) SetBinaryFormat(format string) { q.BinaryFormat = format }
+func (q *QueryRequest) SetRowsFlattern(value bool)    { q.RowsFlattern = value }
+func (q *QueryRequest) SetRowsArray(value bool)       { q.RowsArray = value }
+func (q *QueryRequest) SetTranspose(value bool)       { q.Transpose = value }
+func (q *QueryRequest) SetPrecision(precision int)    { q.Precision = precision }
+func (q *QueryRequest) SetRowNum(value bool)          { q.RowNum = value }
+func (q *QueryRequest) SetHeading(value bool)         { q.Heading = value }
+func (q *QueryRequest) SetHeader(value bool)          { q.Header = value }
+func (q *QueryRequest) SetDelimiter(delimiter string) { q.Delimiter = delimiter }
+func (q *QueryRequest) SetBoxStyle(style string)      { q.BoxStyle = style }
+func (q *QueryRequest) SetBoxSeparateCols(value bool) { q.BoxSeparateCols = value }
+func (q *QueryRequest) SetBoxDrawBorder(value bool)   { q.BoxDrawBorder = value }
+func (q *QueryRequest) SetReplyTo(replyTo string)     { q.ReplyTo = replyTo }
+func (q *QueryRequest) SetDatabase(database string)   { q.Database = database }
+func (q *QueryRequest) SetUser(user string)           { q.User = user }
+func (q *QueryRequest) SetPassword(password string)   { q.Password = password }
+func (q *QueryRequest) SetAuthKey(authKey string)     { q.AuthKey = authKey }
+func (q *QueryRequest) SetNoCache(value bool)         { q.NoCache = value }
+func (q *QueryRequest) SetNoMeta(value bool)          { q.NoMeta = value }
+
+func parseInt(raw string) int {
+	if raw == "" {
+		return 0
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+func parseBool(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false
+	}
+	return b
+}

--- a/mods/util/mdconv/sqlext/sql_request_test.go
+++ b/mods/util/mdconv/sqlext/sql_request_test.go
@@ -1,0 +1,598 @@
+package sqlext
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/machbase/neo-server/v8/mods/util"
+	"github.com/machbase/neo-server/v8/spi"
+	"github.com/stretchr/testify/require"
+	"github.com/yuin/goldmark/ast"
+)
+
+func TestDecodeQueryRequestJSONNormalizesParams(t *testing.T) {
+	req := &QueryRequest{}
+	err := req.DecodeJSON(strings.NewReader(`{"q":"select * from t where a = ?","p":[1,1.5,true,"neo"],"binaryformat":"base64"}`))
+	require.NoError(t, err)
+	require.Equal(t, "select * from t where a = ?", req.SqlText)
+	require.Equal(t, []any{1, 1.5, true, "neo"}, req.Params)
+	require.Equal(t, "base64", req.BinaryFormat)
+}
+
+func TestDecodeQueryRequestJSONRejectsCompositeParam(t *testing.T) {
+	req := &QueryRequest{}
+	err := req.DecodeJSON(strings.NewReader(`{"q":"select * from t","p":[{"nested":1}]}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid p")
+	require.Contains(t, err.Error(), "scalar")
+}
+
+func TestParseQueryParams(t *testing.T) {
+	params, err := ParseQueryParams("   ")
+	require.NoError(t, err)
+	require.Nil(t, params)
+
+	params, err = ParseQueryParams(`[1,2.5,false,"x"]`)
+	require.NoError(t, err)
+	require.Equal(t, []any{1, 2.5, false, "x"}, params)
+
+	_, err = ParseQueryParams(`{"not":"an array"}`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid p")
+}
+
+type stubConn struct {
+	lastQuery   string
+	columns     []string
+	columnTypes []*sql.ColumnType
+	rows        []any
+	multiRows   [][]any
+}
+
+func (c *stubConn) PrepareContext(_ context.Context, query string) (Stmt, error) {
+	return &stubStmt{}, nil
+}
+
+func (c *stubConn) QueryContext(_ context.Context, query string, args ...any) (Rows, error) {
+	c.lastQuery = query
+	columns := []string{"value"}
+	if len(c.columns) > 0 {
+		columns = c.columns
+	}
+	if len(c.multiRows) > 0 {
+		return &stubRows{columns: columns, columnTypes: c.columnTypes, multiValues: c.multiRows}, nil
+	}
+	return &stubRows{columns: columns, columnTypes: c.columnTypes, values: c.rows}, nil
+}
+
+func (c *stubConn) ExecContext(_ context.Context, query string, args ...any) (Result, error) {
+	c.lastQuery = query
+	return &stubResult{}, nil
+}
+
+func (c *stubConn) Close() error { return nil }
+
+type stubStmt struct{}
+
+func (s *stubStmt) QueryContext(_ context.Context, args ...any) (Rows, error) {
+	return &stubRows{columns: []string{"value"}}, nil
+}
+
+func (s *stubStmt) Close() error { return nil }
+
+type stubResult struct{}
+
+func (r *stubResult) RowsAffected() (int64, error) { return 0, nil }
+
+type stubRows struct {
+	columns     []string
+	columnTypes []*sql.ColumnType
+	values      []any
+	multiValues [][]any
+	index       int
+}
+
+func (r *stubRows) Columns() ([]string, error) {
+	return r.columns, nil
+}
+
+func (r *stubRows) ColumnTypes() ([]*sql.ColumnType, error) {
+	return r.columnTypes, nil
+}
+
+func (r *stubRows) Close() error { return nil }
+
+func (r *stubRows) Next() bool {
+	if len(r.multiValues) > 0 {
+		if r.index >= len(r.multiValues) {
+			return false
+		}
+		r.index++
+		return true
+	}
+	if r.index >= 1 {
+		return false
+	}
+	r.index++
+	return true
+}
+
+func (r *stubRows) Scan(dest ...any) error {
+	if len(r.multiValues) > 0 {
+		rowValues := r.multiValues[r.index-1]
+		for i, v := range rowValues {
+			if i >= len(dest) {
+				break
+			}
+			if p, ok := dest[i].(*any); ok {
+				*p = v
+				continue
+			}
+			if p, ok := dest[i].(*string); ok {
+				*p = v.(string)
+				continue
+			}
+			dest[i] = v
+		}
+		return nil
+	}
+	if len(r.values) == 0 {
+		return nil
+	}
+	for i, v := range r.values {
+		if i >= len(dest) {
+			break
+		}
+		if p, ok := dest[i].(*any); ok {
+			*p = v
+			continue
+		}
+		if p, ok := dest[i].(*string); ok {
+			*p = v.(string)
+			continue
+		}
+		dest[i] = v
+	}
+	return nil
+}
+
+func TestExecuteUsesInjectedConn(t *testing.T) {
+	conn := &stubConn{rows: []any{"neo"}}
+	req := &QueryRequest{SqlText: "select 1", Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Equal(t, "select 1", conn.lastQuery)
+	require.Contains(t, out.String(), "neo")
+}
+
+func TestExecuteConnectsWhenConnUnset(t *testing.T) {
+	prev := connectQueryConn
+	t.Cleanup(func() { connectQueryConn = prev })
+
+	conn := &stubConn{}
+	connectQueryConn = func(ctx context.Context) (Conn, error) {
+		return conn, nil
+	}
+
+	req := &QueryRequest{SqlText: "select 1"}
+	err := req.Execute(context.Background(), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, req.Conn)
+	require.Equal(t, "select 1", conn.lastQuery)
+}
+
+func TestExecuteBoxFormatWritesRows(t *testing.T) {
+	conn := &stubConn{}
+	conn.rows = []any{"neo"}
+	req := &QueryRequest{SqlText: "select 1", Format: "box", Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "neo")
+}
+
+func TestExecuteTableFormatUsesGoPrettyTable(t *testing.T) {
+	conn := &stubConn{columns: []string{"value"}, rows: []any{"neo"}}
+	req := &QueryRequest{SqlText: "select 1", Format: "table", Heading: true, Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	got := out.String()
+	require.Contains(t, got, "VALUE")
+	require.Contains(t, got, "neo")
+	require.Contains(t, got, "+")
+}
+
+func TestExecuteCompactsLargeResultsWhenLimitExceeded(t *testing.T) {
+	rows := make([][]any, 0, 12)
+	for i := 0; i < 12; i++ {
+		rows = append(rows, []any{fmt.Sprintf("row-%02d", i+1)})
+	}
+	conn := &stubConn{columns: []string{"value"}, multiRows: rows}
+	req := &QueryRequest{SqlText: "select 1", Output: "table", Preview: 10, Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	got := out.String()
+	require.Contains(t, got, "...")
+	require.Contains(t, got, "row-01")
+	require.Contains(t, got, "row-12")
+}
+
+func TestExecuteTableFormatAddsTimezoneToDatetimeHeaders(t *testing.T) {
+	ct := &sql.ColumnType{}
+	field := reflect.ValueOf(ct).Elem().FieldByName("databaseType")
+	require.True(t, field.IsValid())
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.Addr().Pointer())).Elem().SetString("datetime")
+	conn := &stubConn{columns: []string{"ts"}, columnTypes: []*sql.ColumnType{ct}, rows: []any{time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)}}
+	req := &QueryRequest{SqlText: "select 1", Format: "table", Heading: true, TimeFormat: "2006-01-02 15:04:05", Timezone: "Asia/Seoul", Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "TS(ASIA/SEOUL)")
+}
+
+func TestExecuteFormatOptionUsesServerStyleEncoder(t *testing.T) {
+	conn := &stubConn{}
+	conn.rows = []any{"neo"}
+	req := &QueryRequest{SqlText: "select 1", Format: "json", Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), `"neo"`)
+}
+
+func TestExecuteAppendsUserMessageToTableOutput(t *testing.T) {
+	conn := &stubConn{rows: []any{"neo"}}
+	req := &QueryRequest{SqlText: "select 1", Output: "box", Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "a row selected.")
+}
+
+func TestExecuteSetsJSONReasonToUserMessage(t *testing.T) {
+	conn := &stubConn{rows: []any{"neo"}}
+	req := &QueryRequest{SqlText: "select 1", Output: "json", Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), `"reason":"a row selected."`)
+}
+
+func TestExecuteDescribeUsesShowTableQuery(t *testing.T) {
+	conn := &stubConn{}
+	req := &QueryRequest{SqlText: "describe tag_data", Conn: conn}
+	var out bytes.Buffer
+
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Equal(t, "SHOW TABLE TAG_DATA", conn.lastQuery)
+	require.Contains(t, out.String(), "a row selected.")
+}
+
+func TestExecuteAppliesFormattingOptionsPerOutputFormat(t *testing.T) {
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	payload := []byte{0x01, 0x02}
+	cases := []struct {
+		name       string
+		output     string
+		wantString []string
+	}{
+		{name: "box", output: "box", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
+		{name: "json", output: "json", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
+		{name: "ndjson", output: "ndjson", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
+		{name: "csv", output: "csv", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &stubConn{columns: []string{"ts", "payload"}, rows: []any{ts, payload}}
+			req := &QueryRequest{
+				SqlText:      "select 1",
+				Output:       tc.output,
+				TimeFormat:   "2006-01-02 15:04:05",
+				Timezone:     "Asia/Seoul",
+				BinaryFormat: "hex",
+				Conn:         conn,
+			}
+			var out bytes.Buffer
+
+			err := req.Execute(context.Background(), &out, nil)
+			require.NoError(t, err)
+			got := out.String()
+			for _, want := range tc.wantString {
+				require.Contains(t, got, want)
+			}
+		})
+	}
+}
+
+func TestNormalizeQueryParamValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    any
+		wantErr string
+	}{
+		{name: "nil", input: nil, want: nil},
+		{name: "string", input: "neo", want: "neo"},
+		{name: "bool", input: true, want: true},
+		{name: "int", input: 3, want: 3},
+		{name: "float", input: 1.25, want: 1.25},
+		{name: "json integer", input: json.Number("42"), want: int64(42)},
+		{name: "json float", input: json.Number("3.14"), want: 3.14},
+		{name: "invalid json number", input: json.Number("nope"), wantErr: "invalid syntax"},
+		{name: "slice", input: []any{"x"}, wantErr: "scalar"},
+		{name: "map", input: map[string]any{"x": 1}, wantErr: "scalar"},
+		{name: "struct", input: struct{ Value string }{Value: "x"}, wantErr: "unsupported bind parameter type"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeQueryParamValue(tc.input)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDecodeQueryParsesURLValuesAndPostForm(t *testing.T) {
+	req := &QueryRequest{}
+	values := url.Values{
+		"q":                  {"select 1"},
+		"preview":            {"7"},
+		"timeformat":         {"2006-01-02 15:04:05"},
+		"tz":                 {"Asia/Seoul"},
+		"binaryformat":       {"base64"},
+		"rowsFlattern":       {"true"},
+		"rowsArray":          {"true"},
+		"transpose":          {"true"},
+		"precision":          {"3"},
+		"rownum":             {"true"},
+		"heading":            {"false"},
+		"header":             {"false"},
+		"delimiter":          {"|"},
+		"boxStyle":           {"rounded"},
+		"boxSeparateColumns": {"true"},
+		"boxDrawBorder":      {"false"},
+		"output":             {"json"},
+		"format":             {"csv"},
+		"replyTo":            {"neo"},
+		"database":           {"sys"},
+		"user":               {"u"},
+		"password":           {"p"},
+		"authKey":            {"k"},
+		"noCache":            {"true"},
+		"noMeta":             {"true"},
+		"noFormat":           {"true"},
+		"cache":              {"true"},
+		"truncate":           {"9"},
+		"p":                  {"[1,2]"},
+	}
+
+	require.NoError(t, req.DecodeQuery(values))
+	require.Equal(t, "select 1", req.SqlText)
+	require.Equal(t, 7, req.Preview)
+	require.Equal(t, "Asia/Seoul", req.Timezone)
+	require.True(t, req.RowsFlattern)
+	require.True(t, req.RowsArray)
+	require.True(t, req.Transpose)
+	require.Equal(t, 3, req.Precision)
+	require.True(t, req.RowNum)
+	require.False(t, req.Heading)
+	require.False(t, req.Header)
+	require.Equal(t, "|", req.Delimiter)
+	require.True(t, req.BoxSeparateCols)
+	require.False(t, req.BoxDrawBorder)
+	require.Equal(t, "json", req.Output)
+	require.Equal(t, "csv", req.Format)
+	require.True(t, req.NoCache)
+	require.True(t, req.NoMeta)
+	require.True(t, req.NoFormat)
+	require.True(t, req.Cache)
+	require.Equal(t, 9, req.Truncate)
+	require.Equal(t, []any{1, 2}, req.Params)
+
+	postReq := &QueryRequest{}
+	require.NoError(t, postReq.DecodePostForm(values))
+	require.Equal(t, "select 1", postReq.SqlText)
+}
+
+func TestQueryRequestSettersCoverAccessorPaths(t *testing.T) {
+	req := NewQueryRequest()
+	req.SetQueryText("select 1")
+	req.SetParams([]any{1, "neo"})
+	req.SetOutput("json")
+	req.SetFormat("csv")
+	req.SetPreview(7)
+	req.SetTimeFormat("2006-01-02 15:04:05")
+	req.SetTimezone("Asia/Seoul")
+	req.SetBinaryFormat("base64")
+	req.SetRowsFlattern(true)
+	req.SetRowsArray(true)
+	req.SetTranspose(true)
+	req.SetPrecision(3)
+	req.SetRowNum(true)
+	req.SetHeading(false)
+	req.SetHeader(false)
+	req.SetDelimiter("|")
+	req.SetBoxStyle("rounded")
+	req.SetBoxSeparateCols(true)
+	req.SetBoxDrawBorder(false)
+	req.SetReplyTo("neo")
+	req.SetDatabase("sys")
+	req.SetUser("u")
+	req.SetPassword("p")
+	req.SetAuthKey("k")
+	req.SetNoCache(true)
+	req.SetNoMeta(true)
+
+	require.Equal(t, "select 1", req.GetQueryText())
+	require.Equal(t, []any{1, "neo"}, req.GetParams())
+	require.Equal(t, "json", req.Output)
+	require.Equal(t, "csv", req.Format)
+	require.Equal(t, 7, req.Preview)
+	require.Equal(t, "2006-01-02 15:04:05", req.TimeFormat)
+	require.Equal(t, "Asia/Seoul", req.Timezone)
+	require.Equal(t, "base64", req.BinaryFormat)
+	require.True(t, req.RowsFlattern)
+	require.True(t, req.RowsArray)
+	require.True(t, req.Transpose)
+	require.Equal(t, 3, req.Precision)
+	require.True(t, req.RowNum)
+	require.False(t, req.Heading)
+	require.False(t, req.Header)
+	require.Equal(t, "|", req.Delimiter)
+	require.Equal(t, "rounded", req.BoxStyle)
+	require.True(t, req.BoxSeparateCols)
+	require.False(t, req.BoxDrawBorder)
+	require.Equal(t, "neo", req.ReplyTo)
+	require.Equal(t, "sys", req.Database)
+	require.Equal(t, "u", req.User)
+	require.Equal(t, "p", req.Password)
+	require.Equal(t, "k", req.AuthKey)
+	require.True(t, req.NoCache)
+	require.True(t, req.NoMeta)
+
+	hook := &QueryHook{SetUserMessage: func(string) {}}
+	req.AddHook(hook)
+	require.NotNil(t, req.Hook.SetUserMessage)
+}
+
+func TestOutputFormattingHelpersAndRenderRowsByFormat(t *testing.T) {
+	require.Equal(t, "box", normalizeRequestedOutputFormat("", ""))
+	require.Equal(t, "json", normalizeRequestedOutputFormat(" JSON ", ""))
+	require.Equal(t, "csv", normalizeRequestedOutputFormat("", "CSV"))
+	require.Equal(t, "application/json", contentTypeForFormat("json"))
+	require.Equal(t, "application/x-ndjson", contentTypeForFormat("ndjson"))
+	require.Equal(t, "text/csv; charset=utf-8", contentTypeForFormat("csv"))
+	require.Equal(t, "text/markdown", contentTypeForFormat("markdown"))
+	require.Equal(t, "text/html", contentTypeForFormat("html"))
+	require.Equal(t, "text/plain", contentTypeForFormat("text"))
+	require.Equal(t, "text/plain", contentTypeForFormat("unknown"))
+	require.False(t, shouldAppendTimezoneToHeader("ns"))
+	require.True(t, shouldAppendTimezoneToHeader("2006-01-02 15:04:05"))
+	require.Equal(t, "ts", formatTableHeaderLabel("ts", "string", "ns", ""))
+	require.Equal(t, "ts(Asia/Seoul)", formatTableHeaderLabel("ts", "datetime", "2006-01-02 15:04:05", "Asia/Seoul"))
+	require.Equal(t, "ts", formatTableHeaderLabel("ts", "datetime", "ns", "Asia/Seoul"))
+
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	payload := []byte{0x01, 0x02}
+	rows := &stubRows{columns: []string{"ts", "payload"}, values: []any{ts, payload}}
+
+	var jsonOut bytes.Buffer
+	_, err := renderRowsByFormat(&jsonOut, "json", true, rows, []string{"ts", "payload"}, nil, "2006-01-02 15:04:05", "UTC", util.NewTimeFormatter(util.Timeformat("2006-01-02 15:04:05"), util.TimeLocation(time.UTC)), util.NewBinaryFormatter("hex"), spi.SQLStatementTypeSelect, 10)
+	require.NoError(t, err)
+	require.Contains(t, jsonOut.String(), "2024-01-02 03:04:05")
+
+	rows.index = 0
+	var ndjsonOut bytes.Buffer
+	_, err = renderRowsByFormat(&ndjsonOut, "ndjson", true, rows, []string{"ts", "payload"}, nil, "2006-01-02 15:04:05", "UTC", util.NewTimeFormatter(util.Timeformat("2006-01-02 15:04:05"), util.TimeLocation(time.UTC)), util.NewBinaryFormatter("hex"), spi.SQLStatementTypeSelect, 10)
+	require.NoError(t, err)
+	require.Contains(t, ndjsonOut.String(), "0x0102")
+
+	rows.index = 0
+	var csvOut bytes.Buffer
+	_, err = renderRowsByFormat(&csvOut, "csv", true, rows, []string{"ts", "payload"}, nil, "2006-01-02 15:04:05", "UTC", util.NewTimeFormatter(util.Timeformat("2006-01-02 15:04:05"), util.TimeLocation(time.UTC)), util.NewBinaryFormatter("hex"), spi.SQLStatementTypeSelect, 10)
+	require.NoError(t, err)
+	require.Contains(t, csvOut.String(), "2024-01-02 03:04:05")
+
+	rows.index = 0
+	var tableOut bytes.Buffer
+	_, err = renderRowsByFormat(&tableOut, "table", true, rows, []string{"ts", "payload"}, nil, "2006-01-02 15:04:05", "UTC", util.NewTimeFormatter(util.Timeformat("2006-01-02 15:04:05"), util.TimeLocation(time.UTC)), util.NewBinaryFormatter("hex"), spi.SQLStatementTypeSelect, 10)
+	require.NoError(t, err)
+	require.Contains(t, tableOut.String(), "TS")
+	require.Contains(t, tableOut.String(), "0x0102")
+
+	var noneOut bytes.Buffer
+	_, err = renderRowsByFormat(&noneOut, "none", true, rows, nil, nil, "", "", nil, nil, spi.SQLStatementTypeSelect, 10)
+	require.NoError(t, err)
+	require.Empty(t, noneOut.String())
+}
+
+func TestPreviewSourceRunSQLAndRendererHelpers(t *testing.T) {
+	require.Equal(t, "", previewSource("select 1;\nselect 2;", Options{Source: "hide"}))
+	require.Equal(t, "select 1;\nselect 2;", previewSource("select 1;\nselect 2;", Options{Source: "all"}))
+	require.Equal(t, "select 2;", previewSource("select 1;\nselect 2;", Options{Source: "2"}))
+	require.Equal(t, "select 2;", previewSource("select 1;\nselect 2;", Options{Source: "2-2"}))
+
+	prev := connectQueryConn
+	t.Cleanup(func() { connectQueryConn = prev })
+	conn := &stubConn{columns: []string{"value"}, rows: []any{"neo"}}
+	connectQueryConn = func(ctx context.Context) (Conn, error) {
+		return conn, nil
+	}
+	var out strings.Builder
+	require.NoError(t, runSQL("select 1", Options{Format: "json", Timeout: time.Millisecond}, &out))
+	require.Contains(t, out.String(), "neo")
+
+	body := "a,b\n1,2\n"
+	require.Equal(t, byte(','), detectCSVDelimiter(body))
+	require.Equal(t, []string{"a", "b\n1", "2\n"}, mustSplitCSVFields(t, body, ','))
+	require.Equal(t, []string{"1", "2"}, mustSplitCSVFields(t, "1,2", ','))
+	var buf testBufWriter
+	renderer := &HTMLRenderer{}
+	status, err := renderer.Render(&buf, nil, &Block{Source: "select 1", Options: Options{Execute: true, Format: "csv"}, Output: body}, true)
+	require.NoError(t, err)
+	require.Equal(t, ast.WalkContinue, status)
+	require.Contains(t, buf.String(), "sqlext-result")
+}
+
+type testBufWriter struct {
+	strings.Builder
+}
+
+func (w *testBufWriter) Write(p []byte) (int, error) {
+	return w.Builder.Write(p)
+}
+
+func (w *testBufWriter) WriteString(s string) (int, error) {
+	return w.Builder.WriteString(s)
+}
+
+func (w *testBufWriter) Available() int {
+	return 1024 * 1024
+}
+
+func (w *testBufWriter) Buffered() int {
+	return w.Len()
+}
+
+func (w *testBufWriter) Reset() {
+	w.Builder.Reset()
+}
+
+func (w *testBufWriter) Flush() error {
+	return nil
+}
+
+func mustSplitCSVFields(t *testing.T, line string, delim byte) []string {
+	t.Helper()
+	fields, ok := splitCSVFields(line, delim)
+	require.True(t, ok)
+	return fields
+}

--- a/mods/util/mdconv/sqlext/sqlext_test.go
+++ b/mods/util/mdconv/sqlext/sqlext_test.go
@@ -1,0 +1,63 @@
+package sqlext_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/machbase/neo-server/v8/mods/util/mdconv"
+	"github.com/machbase/neo-server/v8/mods/util/mdconv/sqlext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqlFenceRendersAsCodeBlockByDefault(t *testing.T) {
+	src := strings.Join([]string{
+		"```sql",
+		"select 1;",
+		"```",
+	}, "\n")
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+	result := out.String()
+	require.NotContains(t, result, `class="sqlext"`)
+	require.Contains(t, result, "<pre")
+}
+
+func TestSqlExecuteRendersResultBlock(t *testing.T) {
+	src := strings.Join([]string{
+		"```sql {execute=true}",
+		"select 1 as v;",
+		"```",
+	}, "\n")
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+	result := out.String()
+	require.Contains(t, result, `class="sqlext"`)
+	require.Contains(t, result, `class="sqlext-result"`)
+}
+
+func TestSqlSourceOptionRendersSourcePreview(t *testing.T) {
+	src := strings.Join([]string{
+		"```sql {execute=true,source=show}",
+		"select 1;",
+		"```",
+	}, "\n")
+	var out bytes.Buffer
+	conv := mdconv.New()
+	err := conv.ConvertString(src, &out)
+	require.NoError(t, err)
+	result := out.String()
+	require.Contains(t, result, "select 1;")
+}
+
+func TestParseOptionsUsesFormatAndHeaderAliases(t *testing.T) {
+	opts := sqlext.ParseOptions(`{execute=true,format=csv,header=skip,p=[1,"neo"]}`)
+	require.True(t, opts.Execute)
+	require.Equal(t, "csv", opts.Format)
+	require.Equal(t, "skip", opts.Header)
+	require.Len(t, opts.Params, 2)
+}

--- a/mods/util/mdconv/sqlext/transformer.go
+++ b/mods/util/mdconv/sqlext/transformer.go
@@ -1,0 +1,100 @@
+package sqlext
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+type Transformer struct{}
+
+var sqlLang = []byte("sql")
+
+func (t *Transformer) Transform(doc *ast.Document, reader text.Reader, _ parser.Context) {
+	var blocks []*ast.FencedCodeBlock
+	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		cb, ok := node.(*ast.FencedCodeBlock)
+		if !ok {
+			return ast.WalkContinue, nil
+		}
+		lang := cb.Language(reader.Source())
+		if !bytes.Equal(lang, sqlLang) {
+			return ast.WalkContinue, nil
+		}
+		blocks = append(blocks, cb)
+		return ast.WalkContinue, nil
+	})
+
+	for _, cb := range blocks {
+		var buf bytes.Buffer
+		lines := cb.Lines()
+		for i := 0; i < lines.Len(); i++ {
+			segment := lines.At(i)
+			buf.Write(segment.Value(reader.Source()))
+		}
+		code := buf.String()
+		info := ""
+		if cb.Info != nil {
+			segment := cb.Info.Segment
+			info = string(segment.Value(reader.Source()))
+		}
+		opts := ParseOptions(info)
+		var out strings.Builder
+		if !opts.Execute {
+			continue
+		}
+		start := time.Now()
+		if err := runSQL(code, opts, &out); err != nil {
+			out.WriteString(err.Error())
+		}
+		elapsed := time.Since(start)
+		node := &Block{Source: previewSource(code, opts), Options: opts, Output: out.String(), TimedOut: false}
+		if opts.Timeout > 0 && elapsed > opts.Timeout {
+			node.TimedOut = true
+			node.Output = fmt.Sprintf("timed out after %s", opts.Timeout)
+		}
+		parent := cb.Parent()
+		if parent != nil {
+			parent.ReplaceChild(parent, cb, node)
+		}
+	}
+}
+
+func previewSource(code string, opts Options) string {
+	if opts.Source == "" || strings.EqualFold(opts.Source, "hide") {
+		return ""
+	}
+	if strings.EqualFold(opts.Source, "all") {
+		return code
+	}
+	return SelectSourceLines(code, opts.Source)
+}
+
+func runSQL(code string, opts Options, out *strings.Builder) error {
+	req := NewQueryRequest()
+	req.SqlText = code
+	req.Params = opts.Params
+	req.Output = opts.Format
+	req.Preview = opts.Preview
+	req.TimeFormat = opts.Timeformat
+	req.Timezone = opts.TimeLocation
+	req.BinaryFormat = opts.BinaryFormat
+	req.Header = opts.Header == "skip"
+	req.Delimiter = opts.Delimiter
+	ctx := context.Background()
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+	return req.HandleQuery(out, nil)
+}


### PR DESCRIPTION
This pull request introduces a new markdown extension, `jshext`, for enhanced support of `jsh` fenced code blocks in the markdown converter. The extension allows code blocks to be executed and their results rendered alongside the source, with flexible options for source/result display and execution timeout. The implementation includes the extension logic, AST node definitions, execution engine integration, option parsing, rendering, and comprehensive tests. Additionally, the extension is registered in the markdown converter, and documentation is provided.

**New `jshext` extension for executable JSH code blocks:**

- **Extension implementation and integration:**
  - Added `jshext` extension with AST node (`Block`), parser transformer, HTML renderer, and option parsing logic. The extension is registered in the markdown converter so that `jsh` code fences can be executed and rendered with results. (`mods/util/mdconv/jshext/ast.go`, `mods/util/mdconv/jshext/extender.go`, `mods/util/mdconv/jshext/renderer.go`, `mods/util/mdconv/jshext/transformer.go`, `mods/util/mdconv/jshext/options.go`, `mods/util/mdconv/mdconv.go`) [[1]](diffhunk://#diff-507142e0ad5d198cabf965ced588b36d70a2b7fb4762b5389e905e852b7cfaa5R1-R25) [[2]](diffhunk://#diff-ccfe5232cb570ed93268043ae573f6f2df8544aecb12d8872e54b87bace735b4R1-R19) [[3]](diffhunk://#diff-c67c6b2898c5e690de141db4a024a3a612bc5cc330d39655217aa9b94c5e04b4R1-R42) [[4]](diffhunk://#diff-2cf1e0f4bd384c0036f19d24342c93173cb667342416c424e2b60f6ccbab4da1R1-R81) [[5]](diffhunk://#diff-7597945e2ff5353c7f0bf22eb16fb640fca6e943d889e5bbba24c96bcde7b2f5R1-R142) [[6]](diffhunk://#diff-32bb58c6237e899c9a0870e0720d62ee01d79c7b2bb773861f6016fd999cbcedR15-R17) [[7]](diffhunk://#diff-32bb58c6237e899c9a0870e0720d62ee01d79c7b2bb773861f6016fd999cbcedR103-R104)

- **JSH engine integration:**
  - Implemented execution logic for `jsh` code blocks, including support for execution timeout, capturing stdout/stderr, error handling, and formatting results as plain text or JSON. (`mods/util/mdconv/jshext/engine_runner.go`)

- **Tests and documentation:**
  - Added comprehensive tests covering execution, rendering, source line selection, result formatting, and option parsing. Provided a detailed README documenting usage, options, and examples. (`mods/util/mdconv/jshext/jshext_test.go`, `mods/util/mdconv/jshext/README.md`) [[1]](diffhunk://#diff-ccf4f11164f560e2529b96cd00eb7706b6f00eeeff9ee7098dbd953fa9b2283cR1-R177) [[2]](diffhunk://#diff-2b4af2d3b0c9b688eab8ab1a3e365d5f76642f5abe491b44dca4dbef37ef5d43R1-R71)

**General improvements and test coverage:**

- **Option parsing robustness:**
  - Improved inline option parsing with additional tests for error branches and edge cases in chart fence option parsing. (`mods/util/mdconv/chartext/options_test.go`)

- **Converter test enhancements:**
  - Added tests for D2 code fence rendering, panic recovery, and language mapping for code fences. (`mods/util/mdconv/mdconv_test.go`)