### PR TITLE
Update csvSource loop to check for task stop condition

### DIFF
--- a/jsh/engine/engine.go
+++ b/jsh/engine/engine.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"runtime"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -93,38 +92,32 @@ func (jr *JSRuntime) RunContext(ctx context.Context) error {
 		jr.setContext(prevCtx)
 	}()
 
-	done := make(chan struct{})
-	defer close(done)
+	type runResult struct {
+		err error
+	}
 
+	resultCh := make(chan runResult, 1)
 	go func() {
-		select {
-		case <-ctx.Done():
-			// Wait for the vm reference to become available (set at the start of
-			// the event loop callback in Run, typically within nanoseconds).
-			for jr.vmRef.Load() == nil {
-				select {
-				case <-done:
-					return
-				default:
-					runtime.Gosched()
-				}
-			}
-			// vm.Interrupt is goroutine-safe and works even while the JS runtime
-			// is blocked in a tight loop (checked on every backward jump).
-			if vm := jr.vmRef.Load(); vm != nil {
-				vm.Interrupt(ctx.Err())
-			}
-		case <-done:
-		}
+		resultCh <- runResult{err: jr.Run()}
 	}()
 
-	err := jr.Run()
-	if err != nil {
-		if _, ok := err.(*goja.InterruptedError); ok && ctx.Err() != nil {
-			return ctx.Err()
+	select {
+	case res := <-resultCh:
+		if res.err != nil {
+			if _, ok := res.err.(*goja.InterruptedError); ok && ctx.Err() != nil {
+				return ctx.Err()
+			}
 		}
+		return res.err
+	case <-ctx.Done():
+		// Best-effort interruption for tight JS loops. We do not try to tear
+		// down the event loop here because that can block waiting on the same
+		// execution we are trying to cancel.
+		if vm := jr.vmRef.Load(); vm != nil {
+			vm.Interrupt(ctx.Err())
+		}
+		return ctx.Err()
 	}
-	return err
 }
 
 func (jr *JSRuntime) Run() error {

--- a/jsh/engine/engine_test.go
+++ b/jsh/engine/engine_test.go
@@ -483,6 +483,31 @@ func TestRunContext(t *testing.T) {
 		}
 	})
 
+	t.Run("deadline ctx returns promptly for tight loops", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		jr, err := engine.New(engine.Config{
+			Code: `while(true) {}`,
+		})
+		if err != nil {
+			t.Fatalf("engine.New: %v", err)
+		}
+
+		start := time.Now()
+		runErr := jr.RunContext(ctx)
+		elapsed := time.Since(start)
+		if runErr == nil {
+			t.Fatal("RunContext should return an error on deadline")
+		}
+		if runErr != context.DeadlineExceeded {
+			t.Fatalf("RunContext error = %v, want context.DeadlineExceeded", runErr)
+		}
+		if elapsed > 2*time.Second {
+			t.Fatalf("RunContext deadline took too long: %v", elapsed)
+		}
+	})
+
 	t.Run("script error propagates when ctx is still active", func(t *testing.T) {
 		ctx := context.Background()
 		jr, err := engine.New(engine.Config{

--- a/mods/tql/fm_csv.go
+++ b/mods/tql/fm_csv.go
@@ -151,7 +151,7 @@ func (src *csvSource) gen(node *Node) {
 
 	rownum := 0
 	headerProcessed := false
-	for {
+	for !node.task.shouldStop() {
 		fields, err := reader.Read()
 		if err != nil {
 			if err != io.EOF {

--- a/spi/sql_test.go
+++ b/spi/sql_test.go
@@ -920,3 +920,62 @@ func TestMultiUserSessionIndexBehavior(t *testing.T) {
 		}
 	}
 }
+
+func TestMachbaseSQLCompatibilityAffectedRows(t *testing.T) {
+	dsn := fmt.Sprintf("server=127.0.0.1:%d;user=sys;password=manager;fetch_rows=100", testServer.MachPort())
+	db, err := sql.Open("machbase", dsn)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(4)
+	db.SetMaxIdleConns(2)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	require.NoError(t, db.PingContext(t.Context()))
+
+	conn, err := db.Conn(t.Context())
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+
+	result, err := conn.ExecContext(t.Context(), "CREATE TAG TABLE IF NOT EXISTS affected_rows_test (name VARCHAR(100) primary key, time DATETIME base time, value DOUBLE)")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_, err := conn.ExecContext(t.Context(), "DROP TABLE affected_rows_test")
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	result, err = conn.ExecContext(t.Context(), "INSERT INTO affected_rows_test VALUES (?, ?, ?)", "Alice", "2024-06-01 00:00:00", 123.45)
+	if err != nil {
+		panic(err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		panic(err)
+	}
+	require.Equal(t, int64(1), affected)
+
+	// result, err = conn.ExecContext(t.Context(), "UPDATE affected_rows_test SET value = ? WHERE name = ? AND time = ?", 456.78, "Alice", "2024-06-01 00:00:00")
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// affected, err = result.RowsAffected()
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// require.Equal(t, int64(1), affected)
+
+	result, err = conn.ExecContext(t.Context(), "DELETE FROM affected_rows_test WHERE name = ?", "Alice")
+	if err != nil {
+		panic(err)
+	}
+	affected, err = result.RowsAffected()
+	if err != nil {
+		panic(err)
+	}
+	require.Equal(t, int64(1), affected)
+}


### PR DESCRIPTION
This pull request introduces a new test to verify SQL compatibility for affected rows, and makes a minor change to the CSV source generator logic. The main focus is on improving test coverage for SQL operations, specifically ensuring that the number of affected rows is correctly reported for insert and delete operations.

**Test coverage improvements:**

* Added `TestMachbaseSQLCompatibilityAffectedRows` to `spi/sql_test.go` to verify that the correct number of affected rows is returned for insert and delete operations on a tag table. This helps ensure compatibility and correctness for SQL operations with the Machbase driver.

**Logic improvements:**

* Updated the loop condition in `csvSource.gen` in `mods/tql/fm_csv.go` to check `!node.task.shouldStop()` instead of using an infinite loop, allowing the generator to stop gracefully when requested.