### PR TITLE
Update gopcua/opcua dependency to v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
-	github.com/gopcua/opcua v0.8.1-0.20260528125848-add34eeb01b2
+	github.com/gopcua/opcua v0.9.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hymkor/go-multiline-ny v0.22.4

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f h1:HU1RgM6NALf/KW9HEY
 github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f/go.mod h1:67FPmZWbr+KDT/VlpWtw6sO9XSjpJmLuHpoLmWiTGgY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gopcua/opcua v0.8.1-0.20260528125848-add34eeb01b2 h1:hc7xR0GoauSJRjO3PodSpbd2GuTuR3bZMjh/qrKYqdI=
-github.com/gopcua/opcua v0.8.1-0.20260528125848-add34eeb01b2/go.mod h1:Z6aellk0gIzznZd2UX+Syd/hUMBt65gRlTakpGo6se8=
+github.com/gopcua/opcua v0.9.0 h1:IWkQSOOr4ZxzqbvYTUPzT4Ld4I927ldfFcJMInHvYiI=
+github.com/gopcua/opcua v0.9.0/go.mod h1:Z6aellk0gIzznZd2UX+Syd/hUMBt65gRlTakpGo6se8=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=


### PR DESCRIPTION
This pull request updates the `github.com/gopcua/opcua` dependency in the `go.mod` file to a newer version.

Dependency update:

* Upgraded the `github.com/gopcua/opcua` module from version `v0.8.1-0.20260528125848-add34eeb01b2` to `v0.9.0` in `go.mod`, ensuring the project uses the latest features and bug fixes from the library.