### PR TITLE
Enhance SQL execution with TQL API

### DIFF
--- a/mods/server/server.go
+++ b/mods/server/server.go
@@ -1016,6 +1016,7 @@ func (s *Server) startHttpServer() error {
 	}
 	util.AddShutdownHook(func() { s.httpd.Stop() })
 
+	spi.SetDefaultHttpEndpoint(s.Http.Listeners)
 	tql.SetHttpAddresses(s.Http.Listeners)
 	tql.SetServerKeyPath(s.ServerPrivateKeyPath())
 	tql.StartCache(tql.CacheOption{MaxCapacity: 500})

--- a/mods/util/mdconv/sqlext/README.md
+++ b/mods/util/mdconv/sqlext/README.md
@@ -29,10 +29,10 @@ The extension supports the following options:
   - controls the time zone used for formatting
 - `binaryformat` (`base64|hex|bytes|preview`, default: `hex`)
   - controls how binary values are formatted
-- `preview` (`int` or `unlimit|none`, default: `10`)
+- `preview` (`int` or `all`, default: `10`)
   - controls how many rows are shown when a result set is rendered in preview form
   - when a query returns more rows than the preview size, the renderer shows the first and last rows with an ellipsis in the middle
-  - use `unlimit` or `none` to disable the compact preview behavior and show the full result
+  - use `all` to disable the compact preview behavior and show the full result
 - `params` / `p` (array-like value)
   - supplies bind parameters for the SQL statement
   - example: `params=[1,"neo"]` or `p=[1,"neo"]`
@@ -84,7 +84,7 @@ select * from generate_series(1, 20) as t(v);
 ```
 ~~~
 
-When the result contains more rows than the preview size, the output shows the first and last rows with an ellipsis in between.
+When the result contains more rows than the preview size, the output shows the first and last rows with an ellipsis in between. To show the full result instead, set `preview=all`.
 
 ### 5. Show source preview lines
 
@@ -107,8 +107,6 @@ select ?, ?;
 ~~~
 
 The fenced block can pass bind parameters through the `p` option.
-
-To show the full result instead of the compact preview, set `preview=none` or `preview=unlimit`.
 
 ### 7. Render as CSV with custom header behavior
 

--- a/mods/util/mdconv/sqlext/options.go
+++ b/mods/util/mdconv/sqlext/options.go
@@ -89,7 +89,7 @@ func ParseOptions(info string) Options {
 
 func parsePreviewValue(val string) int {
 	v := strings.ToLower(strings.TrimSpace(val))
-	if v == "" || v == "unlimit" || v == "none" {
+	if v == "" || v == "all" || v == "unlimit" || v == "none" {
 		return 0
 	}
 	if n, err := strconv.Atoi(v); err == nil {

--- a/mods/util/mdconv/sqlext/sql_request.go
+++ b/mods/util/mdconv/sqlext/sql_request.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -86,6 +87,11 @@ type QueryHook struct {
 	SetContentEncoding func(string)
 	SetStatusCode      func(int)
 	SetUserMessage     func(string)
+}
+
+var tqlBaseURL = ""
+var tqlDoRequest = func(req *http.Request) (*http.Response, error) {
+	return http.DefaultClient.Do(req)
 }
 
 var connectQueryConn = func(ctx context.Context) (Conn, error) {
@@ -364,12 +370,15 @@ func (q *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHook
 		hook = &QueryHook{}
 	}
 
-	conn, err := q.ensureConn(ctx)
-	if err != nil {
-		return err
+	stmtType := spi.DetectSQLStatementType(q.SqlText)
+	if q.Conn != nil {
+		return q.executeWithConn(ctx, w, hook, q.Conn, stmtType, output)
 	}
 
-	stmtType := spi.DetectSQLStatementType(q.SqlText)
+	return q.executeWithTQL(ctx, w, hook, stmtType, output)
+}
+
+func (q *QueryRequest) executeWithConn(ctx context.Context, w io.Writer, hook *QueryHook, conn Conn, stmtType spi.SQLStatementType, output string) error {
 	if !stmtType.IsFetch() {
 		result, err := conn.ExecContext(ctx, q.SqlText, q.Params...)
 		if err != nil {
@@ -424,6 +433,136 @@ func (q *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHook
 		hook.SetUserMessage(userMessageForStatement(stmtType, rowCount))
 	}
 	return nil
+}
+
+func (q *QueryRequest) executeWithTQL(ctx context.Context, w io.Writer, hook *QueryHook, stmtType spi.SQLStatementType, output string) error {
+	var body strings.Builder
+	body.WriteString("SQL(")
+	body.WriteString(quoteTQLString(q.SqlText))
+	if len(q.Params) > 0 {
+		for _, param := range q.Params {
+			body.WriteString(", ")
+			body.WriteString(quoteTQLValue(param))
+		}
+	}
+	body.WriteString(")")
+	if q.Preview > 0 {
+		body.WriteString("\nTAKE(")
+		body.WriteString(strconv.Itoa(q.Preview))
+		body.WriteString(")")
+	}
+
+	switch strings.ToLower(output) {
+	case "json":
+		body.WriteString("\nJSON(")
+	case "ndjson":
+		body.WriteString("\nNDJSON(")
+	case "csv":
+		body.WriteString("\nCSV(")
+	default:
+		body.WriteString("\nBOX(")
+	}
+
+	options := make([]string, 0, 8)
+	if q.TimeFormat != "" {
+		options = append(options, fmt.Sprintf("timeformat('%s')", escapeTQLString(q.TimeFormat)))
+	}
+	if q.Timezone != "" {
+		options = append(options, fmt.Sprintf("tz('%s')", escapeTQLString(q.Timezone)))
+	}
+	if q.BinaryFormat != "" {
+		options = append(options, fmt.Sprintf("binaryformat('%s')", escapeTQLString(q.BinaryFormat)))
+	}
+	if q.Precision > 0 {
+		options = append(options, fmt.Sprintf("precision(%d)", q.Precision))
+	}
+	if q.RowNum {
+		options = append(options, "rownum(true)")
+	}
+	if q.RowsFlattern {
+		options = append(options, "rowsFlatten(true)")
+	}
+	if q.RowsArray {
+		options = append(options, "rowsArray(true)")
+	}
+	if q.Heading {
+		options = append(options, "heading(true)")
+	}
+	if q.Header {
+		options = append(options, "header(true)")
+	}
+	if q.BoxStyle != "" {
+		options = append(options, fmt.Sprintf("boxStyle('%s')", escapeTQLString(q.BoxStyle)))
+	}
+	if len(options) > 0 {
+		body.WriteString(strings.Join(options, ", "))
+	}
+	body.WriteString(")")
+
+	if tqlBaseURL == "" {
+		tqlBaseURL = spi.DefaultHttpEndpoint()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tqlBaseURL+"/db/tql", strings.NewReader(body.String()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "text/plain")
+
+	resp, err := tqlDoRequest(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("tql request failed: %s", resp.Status)
+	}
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return err
+	}
+	if hook.SetUserMessage != nil {
+		hook.SetUserMessage(userMessageForStatement(stmtType, 0))
+	}
+	return nil
+}
+
+func quoteTQLString(text string) string {
+	return "{<<END_OF_SQL\n" + text + "\nEND_OF_SQL}"
+}
+
+func quoteTQLValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return fmt.Sprintf("'%s'", escapeTQLString(v))
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case nil:
+		return "null"
+	case int:
+		return strconv.Itoa(v)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return fmt.Sprintf("'%s'", escapeTQLString(fmt.Sprint(v)))
+	}
+}
+
+func escapeTQLString(text string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(text, `\`, `\\`), `'`, `\\'`)
 }
 
 func normalizeRequestedOutputFormat(output, format string) string {

--- a/mods/util/mdconv/sqlext/sql_request.go
+++ b/mods/util/mdconv/sqlext/sql_request.go
@@ -19,25 +19,6 @@ import (
 	"github.com/machbase/neo-server/v8/spi"
 )
 
-// Conn is the minimal database connection abstraction used by shared SQL request helpers.
-type Conn interface {
-	PrepareContext(ctx context.Context, query string) (Stmt, error)
-	QueryContext(ctx context.Context, query string, args ...any) (Rows, error)
-	ExecContext(ctx context.Context, query string, args ...any) (Result, error)
-	Close() error
-}
-
-// Result is the minimal execution result abstraction used by shared SQL request helpers.
-type Result interface {
-	RowsAffected() (int64, error)
-}
-
-// Stmt is the minimal statement abstraction used by shared SQL request helpers.
-type Stmt interface {
-	QueryContext(ctx context.Context, args ...any) (Rows, error)
-	Close() error
-}
-
 // Rows is the minimal row set abstraction used by shared SQL request helpers.
 type Rows interface {
 	Columns() ([]string, error)
@@ -78,7 +59,6 @@ type QueryRequest struct {
 	NoFormat        bool      `json:"noFormat,omitempty"`
 	Cache           bool      `json:"cache,omitempty"`
 	Truncate        int       `json:"truncate,omitempty"`
-	Conn            Conn      `json:"-"`
 	Hook            QueryHook `json:"-"`
 }
 
@@ -92,66 +72,6 @@ type QueryHook struct {
 var tqlBaseURL = ""
 var tqlDoRequest = func(req *http.Request) (*http.Response, error) {
 	return http.DefaultClient.Do(req)
-}
-
-var connectQueryConn = func(ctx context.Context) (Conn, error) {
-	conn, err := spi.Connect(ctx, "sys")
-	if err != nil {
-		return nil, err
-	}
-	return &sqlConnAdapter{Conn: conn}, nil
-}
-
-type sqlConnAdapter struct {
-	*sql.Conn
-}
-
-func (c *sqlConnAdapter) PrepareContext(ctx context.Context, query string) (Stmt, error) {
-	stmt, err := c.Conn.PrepareContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	return &sqlStmtAdapter{Stmt: stmt}, nil
-}
-
-func (c *sqlConnAdapter) QueryContext(ctx context.Context, query string, args ...any) (Rows, error) {
-	rows, err := c.Conn.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	return &sqlRowsAdapter{Rows: rows}, nil
-}
-
-func (c *sqlConnAdapter) ExecContext(ctx context.Context, query string, args ...any) (Result, error) {
-	result, err := c.Conn.ExecContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	return &sqlResultAdapter{result: result}, nil
-}
-
-type sqlStmtAdapter struct {
-	*sql.Stmt
-}
-
-func (s *sqlStmtAdapter) QueryContext(ctx context.Context, args ...any) (Rows, error) {
-	rows, err := s.Stmt.QueryContext(ctx, args...)
-	if err != nil {
-		return nil, err
-	}
-	return &sqlRowsAdapter{Rows: rows}, nil
-}
-
-type sqlRowsAdapter struct {
-	*sql.Rows
-}
-
-type sqlResultAdapter struct {
-	result sql.Result
-}
-
-func (a *sqlResultAdapter) RowsAffected() (int64, error) {
-	return a.result.RowsAffected()
 }
 
 func NewQueryRequest() *QueryRequest {
@@ -371,68 +291,7 @@ func (q *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHook
 	}
 
 	stmtType := spi.DetectSQLStatementType(q.SqlText)
-	if q.Conn != nil {
-		return q.executeWithConn(ctx, w, hook, q.Conn, stmtType, output)
-	}
-
 	return q.executeWithTQL(ctx, w, hook, stmtType, output)
-}
-
-func (q *QueryRequest) executeWithConn(ctx context.Context, w io.Writer, hook *QueryHook, conn Conn, stmtType spi.SQLStatementType, output string) error {
-	if !stmtType.IsFetch() {
-		result, err := conn.ExecContext(ctx, q.SqlText, q.Params...)
-		if err != nil {
-			return err
-		}
-		if hook.SetUserMessage != nil {
-			rawRows, _ := result.RowsAffected()
-			hook.SetUserMessage(spi.MakeUserMessage(stmtType, rawRows))
-		}
-		return nil
-	}
-
-	queryText := q.SqlText
-	switch stmtType {
-	case spi.SQLStatementTypeDescribe:
-		queryText = describeToShowTableQuery(q.SqlText)
-	}
-
-	rows, err := conn.QueryContext(ctx, queryText, q.Params...)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	timeLocation, err := util.ParseTimeLocation(q.Timezone, time.UTC)
-	if err != nil {
-		return err
-	}
-
-	columnTypes, err := rows.ColumnTypes()
-	if err != nil {
-		return err
-	}
-	columnNames, err := rows.Columns()
-	if err != nil {
-		return err
-	}
-	outWriter := w
-	if outWriter == nil {
-		outWriter = io.Discard
-	}
-	if hook.SetContentType != nil {
-		hook.SetContentType(contentTypeForFormat(output))
-	}
-	timeFormatter := util.NewTimeFormatter(util.Timeformat(q.TimeFormat), util.TimeLocation(timeLocation))
-	binaryFormatter := util.NewBinaryFormatter(q.BinaryFormat)
-	rowCount, err := renderRowsByFormat(outWriter, output, q.Heading, rows, columnNames, columnTypes, q.TimeFormat, timeLocation.String(), timeFormatter, binaryFormatter, stmtType, q.Preview)
-	if err != nil {
-		return err
-	}
-	if hook.SetUserMessage != nil {
-		hook.SetUserMessage(userMessageForStatement(stmtType, rowCount))
-	}
-	return nil
 }
 
 func (q *QueryRequest) executeWithTQL(ctx context.Context, w io.Writer, hook *QueryHook, stmtType spi.SQLStatementType, output string) error {
@@ -960,18 +819,6 @@ func formatValueForTextOutput(value any, timeFormatter *util.TimeFormatter, bina
 		return s.String()
 	}
 	return fmt.Sprintf("%v", value)
-}
-
-func (q *QueryRequest) ensureConn(ctx context.Context) (Conn, error) {
-	if q.Conn != nil {
-		return q.Conn, nil
-	}
-	conn, err := connectQueryConn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	q.Conn = conn
-	return conn, nil
 }
 
 func (q *QueryRequest) HandleQuery(w io.Writer, hook *QueryHook) error {

--- a/mods/util/mdconv/sqlext/sql_request_test.go
+++ b/mods/util/mdconv/sqlext/sql_request_test.go
@@ -6,6 +6,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
@@ -176,20 +179,28 @@ func TestExecuteUsesInjectedConn(t *testing.T) {
 	require.Contains(t, out.String(), "neo")
 }
 
-func TestExecuteConnectsWhenConnUnset(t *testing.T) {
-	prev := connectQueryConn
-	t.Cleanup(func() { connectQueryConn = prev })
+func TestExecuteUsesTQLAPIWhenConnUnset(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/db/tql", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer server.Close()
 
-	conn := &stubConn{}
-	connectQueryConn = func(ctx context.Context) (Conn, error) {
-		return conn, nil
-	}
+	prevBaseURL := tqlBaseURL
+	tqlBaseURL = server.URL
+	t.Cleanup(func() { tqlBaseURL = prevBaseURL })
 
-	req := &QueryRequest{SqlText: "select 1"}
-	err := req.Execute(context.Background(), nil, nil)
+	req := &QueryRequest{SqlText: "select 1", Output: "json", Preview: 3}
+	var out bytes.Buffer
+	err := req.Execute(context.Background(), &out, nil)
 	require.NoError(t, err)
-	require.NotNil(t, req.Conn)
-	require.Equal(t, "select 1", conn.lastQuery)
+	require.Contains(t, gotBody, "SQL(")
+	require.Contains(t, out.String(), `"ok":true`)
 }
 
 func TestExecuteBoxFormatWritesRows(t *testing.T) {
@@ -540,11 +551,17 @@ func TestPreviewSourceRunSQLAndRendererHelpers(t *testing.T) {
 	require.Equal(t, "select 2;", previewSource("select 1;\nselect 2;", Options{Source: "2"}))
 	require.Equal(t, "select 2;", previewSource("select 1;\nselect 2;", Options{Source: "2-2"}))
 
-	prev := connectQueryConn
-	t.Cleanup(func() { connectQueryConn = prev })
-	conn := &stubConn{columns: []string{"value"}, rows: []any{"neo"}}
-	connectQueryConn = func(ctx context.Context) (Conn, error) {
-		return conn, nil
+	prevDoRequest := tqlDoRequest
+	t.Cleanup(func() { tqlDoRequest = prevDoRequest })
+	tqlDoRequest = func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "SQL(")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"data":{"columns":["value"],"types":["string"],"rows":[["neo"]]},"success":true,"reason":"a row selected.","elapse":"0s"}`)),
+			Header:     make(http.Header),
+		}, nil
 	}
 	var out strings.Builder
 	require.NoError(t, runSQL("select 1", Options{Format: "json", Timeout: time.Millisecond}, &out))

--- a/mods/util/mdconv/sqlext/sql_request_test.go
+++ b/mods/util/mdconv/sqlext/sql_request_test.go
@@ -10,11 +10,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/machbase/neo-server/v8/mods/util"
 	"github.com/machbase/neo-server/v8/spi"
@@ -52,49 +50,6 @@ func TestParseQueryParams(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid p")
 }
-
-type stubConn struct {
-	lastQuery   string
-	columns     []string
-	columnTypes []*sql.ColumnType
-	rows        []any
-	multiRows   [][]any
-}
-
-func (c *stubConn) PrepareContext(_ context.Context, query string) (Stmt, error) {
-	return &stubStmt{}, nil
-}
-
-func (c *stubConn) QueryContext(_ context.Context, query string, args ...any) (Rows, error) {
-	c.lastQuery = query
-	columns := []string{"value"}
-	if len(c.columns) > 0 {
-		columns = c.columns
-	}
-	if len(c.multiRows) > 0 {
-		return &stubRows{columns: columns, columnTypes: c.columnTypes, multiValues: c.multiRows}, nil
-	}
-	return &stubRows{columns: columns, columnTypes: c.columnTypes, values: c.rows}, nil
-}
-
-func (c *stubConn) ExecContext(_ context.Context, query string, args ...any) (Result, error) {
-	c.lastQuery = query
-	return &stubResult{}, nil
-}
-
-func (c *stubConn) Close() error { return nil }
-
-type stubStmt struct{}
-
-func (s *stubStmt) QueryContext(_ context.Context, args ...any) (Rows, error) {
-	return &stubRows{columns: []string{"value"}}, nil
-}
-
-func (s *stubStmt) Close() error { return nil }
-
-type stubResult struct{}
-
-func (r *stubResult) RowsAffected() (int64, error) { return 0, nil }
 
 type stubRows struct {
 	columns     []string
@@ -168,17 +123,6 @@ func (r *stubRows) Scan(dest ...any) error {
 	return nil
 }
 
-func TestExecuteUsesInjectedConn(t *testing.T) {
-	conn := &stubConn{rows: []any{"neo"}}
-	req := &QueryRequest{SqlText: "select 1", Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	require.Equal(t, "select 1", conn.lastQuery)
-	require.Contains(t, out.String(), "neo")
-}
-
 func TestExecuteUsesTQLAPIWhenConnUnset(t *testing.T) {
 	var gotBody string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -203,138 +147,47 @@ func TestExecuteUsesTQLAPIWhenConnUnset(t *testing.T) {
 	require.Contains(t, out.String(), `"ok":true`)
 }
 
-func TestExecuteBoxFormatWritesRows(t *testing.T) {
-	conn := &stubConn{}
-	conn.rows = []any{"neo"}
-	req := &QueryRequest{SqlText: "select 1", Format: "box", Conn: conn}
-	var out bytes.Buffer
+func TestExecuteBuildsTQLRequestBody(t *testing.T) {
+	prevDoRequest := tqlDoRequest
+	t.Cleanup(func() { tqlDoRequest = prevDoRequest })
 
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	require.Contains(t, out.String(), "neo")
-}
-
-func TestExecuteTableFormatUsesGoPrettyTable(t *testing.T) {
-	conn := &stubConn{columns: []string{"value"}, rows: []any{"neo"}}
-	req := &QueryRequest{SqlText: "select 1", Format: "table", Heading: true, Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	got := out.String()
-	require.Contains(t, got, "VALUE")
-	require.Contains(t, got, "neo")
-	require.Contains(t, got, "+")
-}
-
-func TestExecuteCompactsLargeResultsWhenLimitExceeded(t *testing.T) {
-	rows := make([][]any, 0, 12)
-	for i := 0; i < 12; i++ {
-		rows = append(rows, []any{fmt.Sprintf("row-%02d", i+1)})
-	}
-	conn := &stubConn{columns: []string{"value"}, multiRows: rows}
-	req := &QueryRequest{SqlText: "select 1", Output: "table", Preview: 10, Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	got := out.String()
-	require.Contains(t, got, "...")
-	require.Contains(t, got, "row-01")
-	require.Contains(t, got, "row-12")
-}
-
-func TestExecuteTableFormatAddsTimezoneToDatetimeHeaders(t *testing.T) {
-	ct := &sql.ColumnType{}
-	field := reflect.ValueOf(ct).Elem().FieldByName("databaseType")
-	require.True(t, field.IsValid())
-	reflect.NewAt(field.Type(), unsafe.Pointer(field.Addr().Pointer())).Elem().SetString("datetime")
-	conn := &stubConn{columns: []string{"ts"}, columnTypes: []*sql.ColumnType{ct}, rows: []any{time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)}}
-	req := &QueryRequest{SqlText: "select 1", Format: "table", Heading: true, TimeFormat: "2006-01-02 15:04:05", Timezone: "Asia/Seoul", Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	require.Contains(t, out.String(), "TS(ASIA/SEOUL)")
-}
-
-func TestExecuteFormatOptionUsesServerStyleEncoder(t *testing.T) {
-	conn := &stubConn{}
-	conn.rows = []any{"neo"}
-	req := &QueryRequest{SqlText: "select 1", Format: "json", Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	require.Contains(t, out.String(), `"neo"`)
-}
-
-func TestExecuteAppendsUserMessageToTableOutput(t *testing.T) {
-	conn := &stubConn{rows: []any{"neo"}}
-	req := &QueryRequest{SqlText: "select 1", Output: "box", Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	require.Contains(t, out.String(), "a row selected.")
-}
-
-func TestExecuteSetsJSONReasonToUserMessage(t *testing.T) {
-	conn := &stubConn{rows: []any{"neo"}}
-	req := &QueryRequest{SqlText: "select 1", Output: "json", Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	require.Contains(t, out.String(), `"reason":"a row selected."`)
-}
-
-func TestExecuteDescribeUsesShowTableQuery(t *testing.T) {
-	conn := &stubConn{}
-	req := &QueryRequest{SqlText: "describe tag_data", Conn: conn}
-	var out bytes.Buffer
-
-	err := req.Execute(context.Background(), &out, nil)
-	require.NoError(t, err)
-	require.Equal(t, "SHOW TABLE TAG_DATA", conn.lastQuery)
-	require.Contains(t, out.String(), "a row selected.")
-}
-
-func TestExecuteAppliesFormattingOptionsPerOutputFormat(t *testing.T) {
-	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
-	payload := []byte{0x01, 0x02}
-	cases := []struct {
-		name       string
-		output     string
-		wantString []string
-	}{
-		{name: "box", output: "box", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
-		{name: "json", output: "json", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
-		{name: "ndjson", output: "ndjson", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
-		{name: "csv", output: "csv", wantString: []string{"2024-01-02 12:04:05", "0x0102"}},
+	tqlDoRequest = func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		got := string(body)
+		require.Contains(t, got, "SQL(")
+		require.Contains(t, got, "TAKE(3)")
+		require.Contains(t, got, "JSON(")
+		require.Contains(t, got, "timeformat('2006-01-02 15:04:05')")
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"ok":true}`)), Header: make(http.Header)}, nil
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			conn := &stubConn{columns: []string{"ts", "payload"}, rows: []any{ts, payload}}
-			req := &QueryRequest{
-				SqlText:      "select 1",
-				Output:       tc.output,
-				TimeFormat:   "2006-01-02 15:04:05",
-				Timezone:     "Asia/Seoul",
-				BinaryFormat: "hex",
-				Conn:         conn,
-			}
-			var out bytes.Buffer
+	req := &QueryRequest{SqlText: "select 1", Output: "json", Preview: 3, TimeFormat: "2006-01-02 15:04:05", Timezone: "Asia/Seoul"}
+	var out bytes.Buffer
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), `"ok":true`)
+}
 
-			err := req.Execute(context.Background(), &out, nil)
-			require.NoError(t, err)
-			got := out.String()
-			for _, want := range tc.wantString {
-				require.Contains(t, got, want)
-			}
-		})
+func TestExecuteUsesTQLAPIAndPreservesQueryText(t *testing.T) {
+	prevDoRequest := tqlDoRequest
+	t.Cleanup(func() { tqlDoRequest = prevDoRequest })
+
+	var gotBody string
+	tqlDoRequest = func(req *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		gotBody = string(body)
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"ok":true}`)), Header: make(http.Header)}, nil
 	}
+
+	req := &QueryRequest{SqlText: "select 1", Output: "json", Preview: 2}
+	var out bytes.Buffer
+	err := req.Execute(context.Background(), &out, nil)
+	require.NoError(t, err)
+	require.Contains(t, gotBody, "{<<END_OF_SQL")
+	require.Contains(t, gotBody, "select 1")
+	require.Contains(t, gotBody, "TAKE(2)")
 }
 
 func TestNormalizeQueryParamValue(t *testing.T) {

--- a/mods/util/mdconv/sqlext/sqlext_test.go
+++ b/mods/util/mdconv/sqlext/sqlext_test.go
@@ -61,3 +61,8 @@ func TestParseOptionsUsesFormatAndHeaderAliases(t *testing.T) {
 	require.Equal(t, "skip", opts.Header)
 	require.Len(t, opts.Params, 2)
 }
+
+func TestParseOptionsUsesAllToDisablePreviewCompaction(t *testing.T) {
+	opts := sqlext.ParseOptions(`{execute=true,preview=all}`)
+	require.Equal(t, 0, opts.Preview)
+}

--- a/spi/database.go
+++ b/spi/database.go
@@ -487,3 +487,66 @@ func MakeUserMessage(smtType SQLStatementType, rowsCount int64) string {
 		return "executed."
 	}
 }
+
+var defaultHttpLocalEndpoint string
+
+func SetDefaultHttpEndpoint(addrs []string) {
+	bestAddr := ""
+	bestScore := -1
+	for _, addr := range addrs {
+		normalized, score := normalizeHTTPListenerAddress(addr)
+		if normalized == "" {
+			continue
+		}
+		if score > bestScore {
+			bestAddr = normalized
+			bestScore = score
+		}
+	}
+	defaultHttpLocalEndpoint = bestAddr
+}
+
+func normalizeHTTPListenerAddress(addr string) (string, int) {
+	trimmed := strings.TrimSpace(addr)
+	if trimmed == "" {
+		return "", 0
+	}
+
+	scheme := ""
+	if idx := strings.Index(trimmed, "://"); idx >= 0 {
+		scheme = trimmed[:idx]
+		trimmed = trimmed[idx+3:]
+	}
+
+	switch scheme {
+	case "http", "https":
+		return addr, 3
+	case "unix":
+		return addr, 0
+	}
+
+	host, port, err := net.SplitHostPort(trimmed)
+	if err != nil {
+		return addr, 0
+	}
+
+	host = strings.Trim(host, "[]")
+	if host == "" {
+		return "http://127.0.0.1:" + port, 2
+	}
+
+	switch host {
+	case "0.0.0.0":
+		return "http://127.0.0.1:" + port, 2
+	case "::", "[::]":
+		return "http://[::1]:" + port, 2
+	case "127.0.0.1", "::1", "localhost":
+		return "http://" + net.JoinHostPort(host, port), 3
+	default:
+		return "http://" + net.JoinHostPort(host, port), 1
+	}
+}
+
+func DefaultHttpEndpoint() string {
+	return defaultHttpLocalEndpoint
+}

--- a/spi/database_test.go
+++ b/spi/database_test.go
@@ -255,6 +255,42 @@ func TestVerifyTokenExpired(t *testing.T) {
 	require.False(t, VerifyToken(token, 1*time.Millisecond))
 }
 
+func TestSetDefaultHttpEndpointSelectsLoopbackFriendlyURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		addrs    []string
+		expected string
+	}{
+		{
+			name:     "ipv4 wildcard",
+			addrs:    []string{"tcp://0.0.0.0:5655"},
+			expected: "http://127.0.0.1:5655",
+		},
+		{
+			name:     "ipv6 wildcard",
+			addrs:    []string{"tcp://[::]:5655"},
+			expected: "http://[::1]:5655",
+		},
+		{
+			name:     "ipv6 loopback",
+			addrs:    []string{"tcp://[::1]:5655"},
+			expected: "http://[::1]:5655",
+		},
+		{
+			name:     "explicit host",
+			addrs:    []string{"tcp://192.168.0.10:5655"},
+			expected: "http://192.168.0.10:5655",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetDefaultHttpEndpoint(tt.addrs)
+			require.Equal(t, tt.expected, DefaultHttpEndpoint())
+		})
+	}
+}
+
 func TestDefaultPoolDatabaseNotConfigured(t *testing.T) {
 	oldDB := defaultDatabase
 	oldKey := defaultDatabaseKey


### PR DESCRIPTION
This pull request refactors the SQL execution layer in the `mods/util/mdconv/sqlext` package to remove direct database connection logic and instead route all SQL execution through the TQL HTTP API. It also updates the documentation and tests to reflect this change, and simplifies the options for previewing result sets.

**Major refactor: switch to TQL HTTP API for SQL execution**
- All SQL execution now happens via HTTP requests to the TQL API, removing the previous direct connection and statement abstraction layers. This centralizes query handling and aligns with the server's web-based architecture. [[1]](diffhunk://#diff-179dbe6e5eaea52430de6c2e55d5ebad51fb6f49201c8069b97fd38593133106L21-L39) [[2]](diffhunk://#diff-179dbe6e5eaea52430de6c2e55d5ebad51fb6f49201c8069b97fd38593133106L80) [[3]](diffhunk://#diff-179dbe6e5eaea52430de6c2e55d5ebad51fb6f49201c8069b97fd38593133106L91-R74) [[4]](diffhunk://#diff-179dbe6e5eaea52430de6c2e55d5ebad51fb6f49201c8069b97fd38593133106L367-R426) [[5]](diffhunk://#diff-179dbe6e5eaea52430de6c2e55d5ebad51fb6f49201c8069b97fd38593133106L826-L837)

**Documentation and options updates**
- The `preview` option in the SQL extension is now documented and implemented to use `all` to show the full result set, deprecating previous values like `unlimit` and `none`. [[1]](diffhunk://#diff-d775fc21dc63f2b8afd984b982c9f106ee2c18d82a52caceb3704c3eb1f3d48fL32-R35) [[2]](diffhunk://#diff-d775fc21dc63f2b8afd984b982c9f106ee2c18d82a52caceb3704c3eb1f3d48fL87-R87) [[3]](diffhunk://#diff-d775fc21dc63f2b8afd984b982c9f106ee2c18d82a52caceb3704c3eb1f3d48fL111-L112) [[4]](diffhunk://#diff-27754dbfe2014d8ab3357632d69ca919fa7ece78b70f4841167905a501212f74L92-R92)

**Test suite overhaul**
- Tests are rewritten to mock and verify HTTP interactions with the TQL API, removing reliance on stubbed database connections. This ensures that tests reflect the new execution path and validate the correct request body construction and response handling. [[1]](diffhunk://#diff-66dc69cf7844297f529a4a5a57f7ea0b1f22a7f5d5c97453d93a29e58235930dR9-L14) [[2]](diffhunk://#diff-66dc69cf7844297f529a4a5a57f7ea0b1f22a7f5d5c97453d93a29e58235930dL53-L95) [[3]](diffhunk://#diff-66dc69cf7844297f529a4a5a57f7ea0b1f22a7f5d5c97453d93a29e58235930dL168-R190) [[4]](diffhunk://#diff-66dc69cf7844297f529a4a5a57f7ea0b1f22a7f5d5c97453d93a29e58235930dL543-R417)

**Minor improvements**
- Added missing imports for HTTP handling.
- Server startup now sets the default HTTP endpoint for SPI, ensuring consistent endpoint configuration.