### PR TITLE
import 명령 성능 개선: CSV 읽기/파싱 경로 네이티브화 (240~300s -> 25.9s)

### DIFF
--- a/jsh/lib/events.js
+++ b/jsh/lib/events.js
@@ -6,30 +6,30 @@ class EventEmitter {
         this._events = {};
         this._maxListeners = 10;
     }
-    
+
     on(event, listener) {
         if (typeof listener !== 'function') {
             throw new TypeError('The listener must be a function');
         }
-        
+
         if (!this._events[event]) {
             this._events[event] = [];
         }
-        
+
         this._events[event].push(listener);
-        
+
         // Warn if too many listeners
         if (this._events[event].length > this._maxListeners) {
             console.warn(`MaxListenersExceededWarning: Possible EventEmitter memory leak detected. ${this._events[event].length} ${event} listeners added.`);
         }
-        
+
         return this;
     }
-    
+
     addListener(event, listener) {
         return this.on(event, listener);
     }
-    
+
     once(event, listener) {
         const onceWrapper = (...args) => {
             listener.apply(this, args);
@@ -38,12 +38,12 @@ class EventEmitter {
         onceWrapper.listener = listener;
         return this.on(event, onceWrapper);
     }
-    
+
     removeListener(event, listener) {
         if (!this._events[event]) {
             return this;
         }
-        
+
         const listeners = this._events[event];
         for (let i = listeners.length - 1; i >= 0; i--) {
             if (listeners[i] === listener || listeners[i].listener === listener) {
@@ -51,18 +51,18 @@ class EventEmitter {
                 break;
             }
         }
-        
+
         if (listeners.length === 0) {
             delete this._events[event];
         }
-        
+
         return this;
     }
-    
+
     off(event, listener) {
         return this.removeListener(event, listener);
     }
-    
+
     removeAllListeners(event) {
         if (event) {
             delete this._events[event];
@@ -71,16 +71,33 @@ class EventEmitter {
         }
         return this;
     }
-    
-    emit(event, ...args) {
-        if (!this._events[event]) {
+
+    emit(event) {
+        const handlers = this._events[event];
+        if (!handlers || handlers.length === 0) {
             return false;
         }
-        
-        const listeners = this._events[event].slice();
-        for (const listener of listeners) {
+
+        // Copy only when more than one listener may mutate the list during dispatch.
+        const listeners = handlers.length === 1 ? handlers : handlers.slice();
+        const argc = arguments.length;
+        for (let i = 0; i < listeners.length; i++) {
+            const listener = listeners[i];
             try {
-                listener.apply(this, args);
+                switch (argc) {
+                    case 1:
+                        listener.call(this);
+                        break;
+                    case 2:
+                        listener.call(this, arguments[1]);
+                        break;
+                    case 3:
+                        listener.call(this, arguments[1], arguments[2]);
+                        break;
+                    default:
+                        listener.apply(this, Array.prototype.slice.call(arguments, 1));
+                        break;
+                }
             } catch (err) {
                 // If there's an error listener, emit error event
                 if (event !== 'error' && this._events['error']) {
@@ -90,27 +107,27 @@ class EventEmitter {
                 }
             }
         }
-        
+
         return true;
     }
-    
+
     listeners(event) {
         return this._events[event] ? this._events[event].slice() : [];
     }
-    
+
     listenerCount(event) {
         return this._events[event] ? this._events[event].length : 0;
     }
-    
+
     eventNames() {
         return Object.keys(this._events);
     }
-    
+
     setMaxListeners(n) {
         this._maxListeners = n;
         return this;
     }
-    
+
     getMaxListeners() {
         return this._maxListeners;
     }

--- a/jsh/lib/fs.js
+++ b/jsh/lib/fs.js
@@ -333,10 +333,7 @@ class ReadStream extends EventEmitter {
 
             if (this.encoding === null || this.encoding === 'buffer') {
                 // Must copy since buffer will be reused in next read
-                const uint8Data = new Uint8Array(bytesRead);
-                for (let i = 0; i < bytesRead; i++) {
-                    uint8Data[i] = this._buffer[i];
-                }
+                const uint8Data = this._buffer.slice(0, bytesRead);
                 this.emit('data', uint8Data);
                 return uint8Data;
             }

--- a/jsh/lib/parser/csv.js
+++ b/jsh/lib/parser/csv.js
@@ -3,29 +3,6 @@
 const { Transform } = require('stream');
 const _parser = require('@jsh/parser');
 
-function byteLen(value) {
-    if (value == null) {
-        return 0;
-    }
-    if (typeof value === 'string') {
-        if (typeof TextEncoder !== 'undefined') {
-            return new TextEncoder().encode(value).length;
-        }
-        return value.length;
-    }
-    if (value.byteLength !== undefined) {
-        return value.byteLength;
-    }
-    if (Array.isArray(value)) {
-        return value.length;
-    }
-    const str = String(value);
-    if (typeof TextEncoder !== 'undefined') {
-        return new TextEncoder().encode(str).length;
-    }
-    return str.length;
-}
-
 /**
  * CSV Parser
  * Parses CSV data and emits row objects
@@ -47,32 +24,42 @@ class CSVParser extends Transform {
         this.mapHeaders = options.mapHeaders || null;
         this.mapValues = options.mapValues || null;
         this.trimLeadingSpace = options.trimLeadingSpace !== false;
+        // 'object' emits {header: value}, 'array' emits the raw field list (much cheaper).
+        this.rowMode = options.rowMode === 'array' ? 'array' : 'object';
 
         // Internal state
-        this.bufferChunks = [];  // Array of string chunks for O(n) concatenation
-        this.bufferLength = 0;   // Track total buffer length
         this.lineNumber = 0;
         this.headersParsed = false;
         this.columnHeaders = null;
-        this.skippedLines = 0;
         this.bytesWritten = 0;
         this.bytesRead = 0;
+        this._decoder = null;
+    }
+
+    // The decoder is created lazily so that options assigned after construction are honored.
+    _ensureDecoder() {
+        if (!this._decoder) {
+            this._decoder = _parser.NewCSVDecoder({
+                separator: this.separator,
+                quote: this.quote,
+                escape: this.escape,
+                commentChar: this.commentChar,
+                skipComments: !!this.skipComments,
+                trimLeadingSpace: this.trimLeadingSpace,
+                skipLines: this.skipLines,
+            });
+        }
+        return this._decoder;
     }
 
     _transform(chunk, encoding, callback) {
         try {
-            const incomingBytes = byteLen(chunk);
-            this.bytesWritten += incomingBytes;
-
-            // Convert chunk to string
-            const str = (typeof chunk === 'string') ? chunk : chunk.toString('utf-8');
-
-            // Use array buffering to avoid O(n²) string concatenation
-            this.bufferChunks.push(str);
-            this.bufferLength += str.length;
-
-            // Process complete lines
-            this.processBuffer(callback);
+            const decoder = this._ensureDecoder();
+            const err = this._consume(decoder, decoder.write(chunk));
+            if (err) {
+                return callback(err);
+            }
+            callback();
         } catch (err) {
             callback(err);
         }
@@ -80,70 +67,73 @@ class CSVParser extends Transform {
 
     _flush(callback) {
         try {
-            // Join any remaining buffered chunks and process
-            const remaining = this.bufferChunks.join('');
-            if (remaining.length > 0) {
-                this.bytesRead += byteLen(remaining);
+            const decoder = this._ensureDecoder();
+            const err = this._consume(decoder, decoder.flush());
+            if (err) {
+                return callback(err);
             }
-            if (remaining.trim().length > 0) {
-                this.processLine(remaining, callback);
-            }
-            this.bufferChunks = [];
-            this.bufferLength = 0;
             callback();
         } catch (err) {
             callback(err);
         }
     }
 
-    processBuffer(callback) {
-        // Join all buffered chunks into a single string
-        const buffer = this.bufferChunks.join('');
-        const lines = buffer.split('\n');
-
-        // Keep the last incomplete line in buffer as a single chunk
-        const incompleteLine = lines.pop() || '';
-        this.bufferChunks = incompleteLine ? [incompleteLine] : [];
-        this.bufferLength = incompleteLine.length;
-
-        // Process each complete line
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            this.bytesRead += byteLen(line + '\n');
-            const err = this.processLine(line);
-            if (err) {
-                return callback(err);
-            }
+    // Returns the sole 'data' listener when rows can be delivered without any
+    // per-row transformation, so the emit() dispatch can be bypassed.
+    _fastListener() {
+        if (this.rowMode !== 'array' || this.mapValues || this.strict) {
+            return null;
         }
-
-        callback();
+        const handlers = this._events && this._events['data'];
+        return handlers && handlers.length === 1 ? handlers[0] : null;
     }
 
-    processLine(line) {
-        this.lineNumber++;
-
-        // Remove trailing \r (for \r\n line endings)
-        line = line.replace(/\r$/, '');
-
-        // Skip initial lines if configured
-        if (this.skippedLines < this.skipLines) {
-            this.skippedLines++;
+    _consume(decoder, records) {
+        this.bytesWritten = decoder.bytesWritten();
+        this.bytesRead = decoder.bytesRead();
+        if (!records) {
+            this.lineNumber = decoder.lineNumber();
             return null;
         }
-
-        // Skip empty lines
-        if (line.trim().length === 0) {
+        const count = records.length;
+        let i = 0;
+        while (i < count && !this.headersParsed) {
+            const err = this.processRecord(records[i]);
+            if (err) {
+                return err;
+            }
+            i++;
+        }
+        const fast = this._fastListener();
+        if (fast) {
+            for (; i < count; i++) {
+                try {
+                    fast.call(this, records[i]);
+                } catch (err) {
+                    if (!this._events['error']) {
+                        throw err;
+                    }
+                    this.emit('error', err);
+                }
+            }
+            this.lineNumber = decoder.lineNumber();
             return null;
         }
-
-        // Skip comments
-        if (this.skipComments && line.trim().startsWith(this.commentChar)) {
-            return null;
+        const recordLines = this.strict ? decoder.recordLines() : null;
+        for (; i < count; i++) {
+            if (recordLines) {
+                this.lineNumber = recordLines[i];
+            }
+            const err = this.processRecord(records[i]);
+            if (err) {
+                return err;
+            }
         }
+        this.lineNumber = decoder.lineNumber();
+        return null;
+    }
 
-        // Parse the CSV line
-        const fields = this.parseCSVLine(line);
-
+    processRecord(fields) {
         // Handle headers
         if (!this.headersParsed) {
             if (Array.isArray(this.headers)) {
@@ -154,20 +144,26 @@ class CSVParser extends Transform {
                 return this.emitRow(fields);
             } else if (this.headers === false) {
                 // No headers, use column indices
-                this.columnHeaders = fields.map((_, i) => String(i));
+                this.columnHeaders = [];
+                for (let i = 0; i < fields.length; i++) {
+                    this.columnHeaders.push(String(i));
+                }
                 this.headersParsed = true;
                 // This line is data, not headers
                 return this.emitRow(fields);
             } else {
                 // First line is headers (default behavior)
-                this.columnHeaders = fields;
-
-                // Apply header mapping if provided
-                if (this.mapHeaders) {
-                    this.columnHeaders = this.columnHeaders.map((header, index) => {
-                        const mapped = this.mapHeaders({ header, index });
-                        return mapped !== null && mapped !== undefined ? mapped : header;
-                    }).filter(h => h !== null && h !== undefined);
+                this.columnHeaders = [];
+                for (let i = 0; i < fields.length; i++) {
+                    let header = fields[i];
+                    if (this.mapHeaders) {
+                        const mapped = this.mapHeaders({ header, index: i });
+                        if (mapped === null || mapped === undefined) {
+                            continue;
+                        }
+                        header = mapped;
+                    }
+                    this.columnHeaders.push(header);
                 }
 
                 this.headersParsed = true;
@@ -180,54 +176,6 @@ class CSVParser extends Transform {
         return this.emitRow(fields);
     }
 
-    parseCSVLine(line) {
-        const fields = [];
-        let fieldChars = [];  // Use array building instead of string concatenation
-        let inQuotes = false;
-        let i = 0;
-
-        while (i < line.length) {
-            const char = line[i];
-            const nextChar = i + 1 < line.length ? line[i + 1] : '';
-
-            if (inQuotes) {
-                if (char === this.escape && nextChar === this.quote) {
-                    // Escaped quote
-                    fieldChars.push(this.quote);
-                    i += 2;
-                } else if (char === this.quote) {
-                    // End of quoted field
-                    inQuotes = false;
-                    i++;
-                } else {
-                    fieldChars.push(char);
-                    i++;
-                }
-            } else {
-                if (char === this.quote) {
-                    // Start of quoted field
-                    inQuotes = true;
-                    i++;
-                } else if (char === this.separator) {
-                    // Field separator
-                    const field = fieldChars.join('');
-                    fields.push(this.trimLeadingSpace ? field.trimStart() : field);
-                    fieldChars = [];
-                    i++;
-                } else {
-                    fieldChars.push(char);
-                    i++;
-                }
-            }
-        }
-
-        // Add the last field
-        const field = fieldChars.join('');
-        fields.push(this.trimLeadingSpace ? field.trimStart() : field);
-
-        return fields;
-    }
-
     emitRow(fields) {
         // Check strict mode
         if (this.strict && fields.length !== this.columnHeaders.length) {
@@ -237,6 +185,11 @@ class CSVParser extends Transform {
             );
             this.emit('error', err);
             return err;
+        }
+
+        if (this.rowMode === 'array' && !this.mapValues) {
+            this.emit('data', fields);
+            return null;
         }
 
         // Build row object

--- a/jsh/lib/parser/csvdecoder.go
+++ b/jsh/lib/parser/csvdecoder.go
@@ -1,0 +1,274 @@
+package parser
+
+import (
+	"bytes"
+
+	"github.com/dop251/goja"
+)
+
+// CSVDecoder is an incremental, line oriented CSV decoder backing lib/parser/csv.js.
+// It splits the input on '\n' before parsing fields, which keeps the exact semantics
+// of the previous JavaScript implementation (newlines inside quoted fields are not supported).
+type CSVDecoder struct {
+	rt               *goja.Runtime
+	separator        byte
+	quote            byte
+	escape           byte
+	commentChar      byte
+	skipComments     bool
+	trimLeadingSpace bool
+	skipLines        int64
+
+	carry        []byte
+	fieldBuf     []byte
+	skippedLines int64
+	lineNumber   int64
+	bytesWritten int64
+	bytesRead    int64
+	recordLines  []int64
+}
+
+func optByte(options map[string]any, key string, def byte) byte {
+	if v, ok := options[key].(string); ok && len(v) > 0 {
+		return v[0]
+	}
+	return def
+}
+
+// NewCSVDecoder creates an incremental CSV decoder.
+func NewCSVDecoder(options map[string]any) *CSVDecoder {
+	if options == nil {
+		options = map[string]any{}
+	}
+	d := &CSVDecoder{
+		separator:        optByte(options, "separator", ','),
+		quote:            optByte(options, "quote", '"'),
+		commentChar:      optByte(options, "commentChar", '#'),
+		trimLeadingSpace: true,
+	}
+	d.escape = optByte(options, "escape", d.quote)
+	if v, ok := options["skipComments"].(bool); ok {
+		d.skipComments = v
+	}
+	if v, ok := options["trimLeadingSpace"].(bool); ok {
+		d.trimLeadingSpace = v
+	}
+	if v, ok := options["skipLines"].(int64); ok {
+		d.skipLines = v
+	}
+	return d
+}
+
+func csvChunkBytes(chunk any) []byte {
+	switch v := chunk.(type) {
+	case nil:
+		return nil
+	case string:
+		return []byte(v)
+	case []byte:
+		return v
+	case goja.ArrayBuffer:
+		return v.Bytes()
+	case []any:
+		buf := make([]byte, 0, len(v))
+		for _, it := range v {
+			switch n := it.(type) {
+			case int64:
+				buf = append(buf, byte(n))
+			case float64:
+				buf = append(buf, byte(n))
+			}
+		}
+		return buf
+	default:
+		return nil
+	}
+}
+
+// Write feeds a chunk and returns the records of every complete line it contains.
+func (d *CSVDecoder) Write(chunk any) goja.Value {
+	return d.toJS(d.Decode(chunk))
+}
+
+// Flush decodes the trailing line that is not terminated by a newline.
+func (d *CSVDecoder) Flush() goja.Value {
+	return d.toJS(d.DecodeTail())
+}
+
+// toJS materializes plain JavaScript arrays; a Go slice would be wrapped in a
+// reflection proxy that allocates a new object on every element access.
+func (d *CSVDecoder) toJS(records [][]string) goja.Value {
+	if d.rt == nil {
+		return nil
+	}
+	if len(records) == 0 {
+		return goja.Null()
+	}
+	rows := make([]any, len(records))
+	for i, rec := range records {
+		fields := make([]any, len(rec))
+		for j, f := range rec {
+			fields[j] = f
+		}
+		rows[i] = d.rt.NewArray(fields...)
+	}
+	return d.rt.NewArray(rows...)
+}
+
+// Decode feeds a chunk and returns the records of every complete line it contains.
+func (d *CSVDecoder) Decode(chunk any) [][]string {
+	in := csvChunkBytes(chunk)
+	d.bytesWritten += int64(len(in))
+	d.recordLines = d.recordLines[:0]
+
+	var data []byte
+	if len(d.carry) > 0 {
+		data = make([]byte, 0, len(d.carry)+len(in))
+		data = append(data, d.carry...)
+		data = append(data, in...)
+		d.carry = d.carry[:0]
+	} else {
+		data = in
+	}
+
+	var records [][]string
+	start := 0
+	for start < len(data) {
+		idx := bytes.IndexByte(data[start:], '\n')
+		if idx < 0 {
+			break
+		}
+		line := data[start : start+idx]
+		start += idx + 1
+		d.bytesRead += int64(len(line)) + 1
+		if rec, ok := d.decodeLine(line); ok {
+			records = append(records, rec)
+			d.recordLines = append(d.recordLines, d.lineNumber)
+		}
+	}
+	if start < len(data) {
+		d.carry = append(d.carry[:0], data[start:]...)
+	}
+	return records
+}
+
+// DecodeTail decodes the trailing line that is not terminated by a newline.
+func (d *CSVDecoder) DecodeTail() [][]string {
+	d.recordLines = d.recordLines[:0]
+	if len(d.carry) == 0 {
+		return nil
+	}
+	line := d.carry
+	d.carry = nil
+	d.bytesRead += int64(len(line))
+	if len(bytes.TrimSpace(line)) == 0 {
+		return nil
+	}
+	rec, ok := d.decodeLine(line)
+	if !ok {
+		return nil
+	}
+	d.recordLines = append(d.recordLines, d.lineNumber)
+	return [][]string{rec}
+}
+
+func (d *CSVDecoder) BytesWritten() int64 { return d.bytesWritten }
+func (d *CSVDecoder) BytesRead() int64    { return d.bytesRead }
+func (d *CSVDecoder) LineNumber() int64   { return d.lineNumber }
+
+// RecordLines returns the physical line number of each record of the last Write/Flush call.
+func (d *CSVDecoder) RecordLines() []int64 { return d.recordLines }
+
+func (d *CSVDecoder) decodeLine(line []byte) ([]string, bool) {
+	d.lineNumber++
+	if n := len(line); n > 0 && line[n-1] == '\r' {
+		line = line[:n-1]
+	}
+	if d.skippedLines < d.skipLines {
+		d.skippedLines++
+		return nil, false
+	}
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return nil, false
+	}
+	if d.skipComments && trimmed[0] == d.commentChar {
+		return nil, false
+	}
+	return d.parseFields(line), true
+}
+
+func trimLeadingSpaceBytes(f []byte) []byte {
+	i := 0
+	for i < len(f) {
+		switch f[i] {
+		case ' ', '\t', '\r', '\v', '\f':
+			i++
+			continue
+		}
+		break
+	}
+	return f[i:]
+}
+
+func (d *CSVDecoder) parseFields(line []byte) []string {
+	if bytes.IndexByte(line, d.quote) < 0 {
+		fields := make([]string, 0, bytes.Count(line, []byte{d.separator})+1)
+		start := 0
+		for i := 0; i <= len(line); i++ {
+			if i < len(line) && line[i] != d.separator {
+				continue
+			}
+			f := line[start:i]
+			if d.trimLeadingSpace {
+				f = trimLeadingSpaceBytes(f)
+			}
+			fields = append(fields, string(f))
+			start = i + 1
+		}
+		return fields
+	}
+
+	fields := make([]string, 0, bytes.Count(line, []byte{d.separator})+1)
+	buf := d.fieldBuf[:0]
+	inQuotes := false
+	for i := 0; i < len(line); {
+		c := line[i]
+		if inQuotes {
+			switch {
+			case c == d.escape && i+1 < len(line) && line[i+1] == d.quote:
+				buf = append(buf, d.quote)
+				i += 2
+			case c == d.quote:
+				inQuotes = false
+				i++
+			default:
+				buf = append(buf, c)
+				i++
+			}
+			continue
+		}
+		switch c {
+		case d.quote:
+			inQuotes = true
+			i++
+		case d.separator:
+			fields = append(fields, d.finishField(buf))
+			buf = buf[:0]
+			i++
+		default:
+			buf = append(buf, c)
+			i++
+		}
+	}
+	fields = append(fields, d.finishField(buf))
+	d.fieldBuf = buf[:0]
+	return fields
+}
+
+func (d *CSVDecoder) finishField(buf []byte) string {
+	if d.trimLeadingSpace {
+		buf = trimLeadingSpaceBytes(buf)
+	}
+	return string(buf)
+}

--- a/jsh/lib/parser/parser.go
+++ b/jsh/lib/parser/parser.go
@@ -32,6 +32,11 @@ func Module(_ context.Context, rt *goja.Runtime, module *goja.Object) {
 	// Export native functions
 	m := module.Get("exports").(*goja.Object)
 	m.Set("NewCSVReader", NewCSVReader)
+	m.Set("NewCSVDecoder", func(options map[string]any) *CSVDecoder {
+		d := NewCSVDecoder(options)
+		d.rt = rt
+		return d
+	})
 	m.Set("NewLineReader", NewLineReader)
 }
 

--- a/jsh/usr/bin/import.js
+++ b/jsh/usr/bin/import.js
@@ -77,6 +77,7 @@ for (let i = 0; i < colDefs.length; i++) {
 
 const csvParser = parser.csv({
     separator: config.format === 'tsv' ? '\t' : ',',
+    rowMode: 'array',
 })
 
 switch (config.header) {
@@ -95,6 +96,7 @@ switch (config.header) {
 
 let nRows = 0;
 let totalSize = 0;
+const PROGRESS_INTERVAL = 10000;
 if (config.input !== '-') {
     fs.statSync(config.input).isFile() ? totalSize = fs.statSync(config.input).size : totalSize = 0;
 }
@@ -108,7 +110,7 @@ appender = appender.withInputColumns(...columnNames);
 
 let inputStat = () => { return 0 };
 
-let inputFile = fs.createReadStream(config.input, { highWaterMark: 4 * 1024, encoding: 'buffer' })
+let inputFile = fs.createReadStream(config.input, { highWaterMark: 1024 * 1024, encoding: 'buffer' })
 if (config.compress === 'gzip') {
     const gunzip = zlib.createGunzip();
     gunzip.on('error', function (err) {
@@ -142,42 +144,34 @@ inputFile.on('headers', (headers) => {
         }
         if (found === -1) {
             throw new Error(`Column '${headers[i]}' not found in table '${tableName}'`);
-        } else {
-            // do not use `colDefs[found].name` here
-            // since the `row` object of `inputFile.on('data', row)` has case-sensitive keys
-            // which are the same as the original header names in the input file,
-            // so we need to use the original header name instead of the column name in the table schema (colDefs[found].name)
-            columnNames.push(headers[i]);
-            columnTypes.push(colDefs[found].type.toString());
         }
+        columnNames.push(colDefs[found].name);
+        columnTypes.push(colDefs[found].type.toString());
     }
+    // rebind the appender to the column order of the input file
+    appender = appender.withInputColumns(...columnNames);
 });
 inputFile.on('data', (row) => {
     nRows++;
-    tracker.setValue(inputStat());
+    if (nRows % PROGRESS_INTERVAL === 0) {
+        tracker.setValue(inputStat());
+    }
     if (nRows == 1 && config.header === 'skip') {
         // skip header row, do nothing
         return;
     }
-    let rec = [];
-    for (let i = 0; i < columnNames.length; i++) {
-        let colName = columnNames[i];
-        let colType = columnTypes[i];
-        let value = row[colName];
-        switch (colType) {
+    const rec = new Array(columnTypes.length);
+    for (let i = 0; i < columnTypes.length; i++) {
+        let value = row[i];
+        switch (columnTypes[i]) {
             case 'datetime':
                 value = pretty.parseTime(value, config.timeformat, config.tz);
                 break;
-            case "double":
+            case 'double':
                 value = parseFloat(value);
                 break;
         }
-        if (value === config.nullValue) {
-            rec.push(null);
-            continue;
-        } else {
-            rec.push(value);
-        }
+        rec[i] = value === config.nullValue ? null : value;
     }
     if (config.dryRun) {
         if (config.verbose) {


### PR DESCRIPTION
machbase/neo#1465

## 요약

`import` 명령의 CSV 읽기/파싱 경로를 개선하여 **240~300초 → 25.9초 (약 10배)** 로 단축했습니다.

287MB / 10,078,200행 / 3컬럼 CSV 기준 `import --dry-run` 실측값입니다.

| 항목 | before | after |
|---|---|---|
| `import --dry-run` 전체 | 240~300s | **25.9s** (11.07M/s) |
| 파일 읽기만 (`encoding:'buffer'`) | 22.0s | 0.04s |
| 읽기 + CSV 파이프 (행 카운트) | 184.4s | 5.6s |
| 위 + `parseTime` / `parseFloat` | 213.9s | 24.7s |
| 네이티브 디코딩만 | – | 0.93s |

## 변경 내역

### `jsh/lib/fs.js`
`ReadStream._read()` 가 `encoding: 'buffer'` 일 때 파일 전체 바이트 수만큼 JS 루프를 돌며 복사하던 것을
`Uint8Array.slice()` 로 교체했습니다. (22.0s → 0.04s)

### `jsh/lib/parser/csvdecoder.go` (신규)
청크 단위 증분 CSV 디코더 `CSVDecoder` 를 추가했습니다.

- 기존 JS 구현과 동일한 의미를 유지합니다: `\n` 단위 분할 후 필드 파싱, `\r\n`, escaped quote,
  `trimLeadingSpace`, `skipLines`, `skipComments`, 빈 줄 skip, `bytesWritten` / `bytesRead` 카운팅.
- quote 가 없는 라인은 `IndexByte` 기반 fast path 를 사용합니다.
- 결과를 Go 슬라이스가 아닌 실제 JS 배열(`rt.NewArray`)로 반환하여, goja reflect 래퍼가 원소 접근마다
  객체를 할당하는 비용을 제거했습니다.

### `jsh/lib/parser/parser.go`
`NewCSVDecoder` 를 `@jsh/parser` 에 등록했습니다.

### `jsh/lib/parser/csv.js`
- 문자 단위 파싱을 수행하던 `parseCSVLine()` 과 `processBuffer()` / `processLine()` / `byteLen()` 을 제거하고
  네이티브 디코더에 위임합니다. (141.2s → 0.93s)
- `rowMode: 'array'` 옵션을 추가했습니다. 행 객체(`{header: value}`) 생성을 생략하고 필드 배열을 그대로
  전달합니다. 기본값은 기존과 동일한 `'object'` 이므로 하위 호환됩니다.
- `data` 리스너가 하나뿐이고 행당 변환이 필요 없는 경우 `emit()` 디스패치를 우회합니다.

### `jsh/lib/events.js`
`emit()` 에서 rest 파라미터 배열 할당과 (리스너가 하나일 때의) 리스너 배열 `slice()` 복사를 제거하고,
인자 2개 이하는 `call()` 로 직접 호출하도록 했습니다.

### `jsh/usr/bin/import.js`
- `highWaterMark` 4KB → 1MB.
- `tracker.setValue()` 를 행마다 호출하던 것을 10,000행마다 호출하도록 변경했습니다.
- `rowMode: 'array'` 와 인덱스 기반 rec 구성을 사용합니다.
- **부수적 버그 수정**: `--header columns` 사용 시 입력 파일의 컬럼 순서로 `withInputColumns()` 를
  재바인딩합니다. 기존에는 테이블 컬럼 순서로 고정되어, 파일의 컬럼 순서가 테이블과 다르면 값이
  어긋나 입력되었습니다.

## 검증

- `go test ./jsh/...` 전체 통과.
- 수동 검증: 구분자와 escaped quote 를 포함한 quoted 필드, leading space trim,
  `headers` 옵션(default / `false` / 배열), `bytesWritten` / `bytesRead` 정확성,
  컬럼 순서가 뒤바뀐 파일에 대한 `--header columns`, `--compress gzip` 경로 모두 정상 동작 확인.

## 남은 개선 여지

- `pretty.parseTime()` / `parseFloat()` 가 행당 goja→Go 호출로 여전히 약 11s 를 차지합니다.
  디코더가 컬럼 타입을 받아 Go 에서 타입 변환까지 수행하면 추가 단축이 가능합니다.
- 실제 append(비 dry-run) 경로의 `appender.append(...rec)` 비용은 아직 측정하지 않았습니다.
