### PR TITLE
Named param query

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/lib/pq v1.12.3
-	github.com/machbase/neo-client/v2 v2.0.0-20260827070104-16fb068a6921
+	github.com/machbase/neo-client/v2 v2.0.0-20260828143639-96ae5efad8d1
 	github.com/machbase/neo-engine/v8 v8.5.11-0.20260825141658-fe9aa668f0bc
 	github.com/magefile/mage v1.16.0
 	github.com/mattn/go-colorable v0.1.14

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIiZhtifTV5OUqqiP82UAl0h87xj/l9k=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/machbase/neo-client/v2 v2.0.0-20260827070104-16fb068a6921 h1:LCO/ycUT6tUeFz69AEw2x0aEREDOUUH0ikSBjzJuh80=
-github.com/machbase/neo-client/v2 v2.0.0-20260827070104-16fb068a6921/go.mod h1:5DmIxqFEwDV3LATPXQKxEwVcepjLxnUDPbDHPfkkVZM=
+github.com/machbase/neo-client/v2 v2.0.0-20260828143639-96ae5efad8d1 h1:oNw+m8Hss9BC4XNu1TSecqjLpQmTMvW/nDjneeXbNMY=
+github.com/machbase/neo-client/v2 v2.0.0-20260828143639-96ae5efad8d1/go.mod h1:5DmIxqFEwDV3LATPXQKxEwVcepjLxnUDPbDHPfkkVZM=
 github.com/machbase/neo-engine/v8 v8.5.11-0.20260825141658-fe9aa668f0bc h1:Mg+HTcf7BQrzl9G6+WV9znM1GenpFsKzqOmMPRDro5U=
 github.com/machbase/neo-engine/v8 v8.5.11-0.20260825141658-fe9aa668f0bc/go.mod h1:b4epDziTEbSEgO2xEWBZpGcTkVT+H2/aVc+EnnfdLYw=
 github.com/magefile/mage v1.16.0 h1:2naaPmNwrMicCdLBCRDw288hcyClO9lmnm6FMpXyJ5I=

--- a/jsh/lib/db/dbms.go
+++ b/jsh/lib/db/dbms.go
@@ -254,17 +254,21 @@ func (c *CONN) Exec(call goja.FunctionCall) goja.Value {
 		}
 	}
 
-	result, err := c.conn.ExecContext(c.db.ctx, sqlText, params...)
-	_ = result
+	meta := client.Meta{}
+	ctx := context.WithValue(c.db.ctx, client.MetaKey, &meta)
+	result, err := c.conn.ExecContext(ctx, sqlText, params...)
 	if err != nil {
 		panic(c.db.rt.NewGoError(err))
 	}
-	sqlType := spi.DetectSQLStatementType(sqlText)
 	affected, err := result.RowsAffected()
 	if err != nil {
 		panic(c.db.rt.NewGoError(err))
 	}
-	message := spi.MakeUserMessage(sqlType, affected)
+	var message string
+	if message = meta.Message(); message == "" {
+		sqlType := spi.DetectSQLStatementType(sqlText)
+		message = spi.MakeUserMessage(sqlType, affected)
+	}
 	return c.db.rt.ToValue(map[string]any{
 		"message":      message,
 		"rowsAffected": affected,

--- a/jsh/lib/db/dbms_test.go
+++ b/jsh/lib/db/dbms_test.go
@@ -97,122 +97,117 @@ func dropTagTables() {
 }
 
 func TestDBMS(t *testing.T) {
-	tests := []test_engine.TestCase{
-		{
-			Name: "dbms-select-no-rows",
-			Script: `
-				db = require("@jsh/db");
-				client = new db.Client();
-				try {
-					conn = client.connect();
-					rows = conn.query("select * from tag_data")
-					cols = rows.columns()
-					console.println("cols.names:", JSON.stringify(cols.columns));
-					console.println("cols.types:", JSON.stringify(cols.types));
-					count = 0;
-					for (let rec = rows.next(); rec != null; rec = rows.next()) {
-						console.println(rec);
-						count++;
-					}
-					console.println("rows:", count);
-				} catch(e) {
-				 	console.println("Error:", e);
-				} finally {
-				 	//!! intentionally not close, to see if it properly warns
-				 	// if (rows) rows.close();
-				 	// if (conn) conn.close();
+	test_engine.TestCase{
+		Name: "dbms-select-no-rows",
+		Script: `
+			db = require("@jsh/db");
+			client = new db.Client();
+			try {
+				conn = client.connect();
+				rows = conn.query("select * from tag_data")
+				cols = rows.columns()
+				console.println("cols.names:", JSON.stringify(cols.columns));
+				console.println("cols.types:", JSON.stringify(cols.types));
+				count = 0;
+				for (let rec = rows.next(); rec != null; rec = rows.next()) {
+					console.println(rec);
+					count++;
 				}
-			`,
-			Output: []string{
-				`cols.names: ["NAME","TIME","VALUE","SHORT_VALUE","USHORT_VALUE","INT_VALUE","UINT_VALUE","LONG_VALUE","ULONG_VALUE","STR_VALUE","JSON_VALUE","IPV4_VALUE","IPV6_VALUE","BIN_VALUE"]`,
-				`cols.types: ["VARCHAR","DATETIME","DOUBLE","SHORT","USHORT","INTEGER","UINTEGER","LONG","ULONG","VARCHAR","JSON","IPV4","IPV6","BINARY"]`,
-				"rows: 0",
-			},
+				console.println("rows:", count);
+			} catch(e) {
+				console.println("Error:", e);
+			} finally {
+				//!! intentionally not close, to see if it properly warns
+				// if (rows) rows.close();
+				// if (conn) conn.close();
+			}
+		`,
+		Output: []string{
+			`cols.names: ["NAME","TIME","VALUE","SHORT_VALUE","USHORT_VALUE","INT_VALUE","UINT_VALUE","LONG_VALUE","ULONG_VALUE","STR_VALUE","JSON_VALUE","IPV4_VALUE","IPV6_VALUE","BIN_VALUE"]`,
+			`cols.types: ["VARCHAR","DATETIME","DOUBLE","SHORT","USHORT","INTEGER","UINTEGER","LONG","ULONG","VARCHAR","JSON","IPV4","IPV6","BINARY"]`,
+			"rows: 0",
 		},
-		{
-			Name: "dbms-insert",
-			Script: `
-				const db = require("@jsh/db");
-				const { now } = require("@jsh/system");
-				client = new db.Client({lowerCaseColumns:true});
-				try{
-					conn = client.connect();
-					result = conn.exec("insert into tag_data (name, time, value) values (?, ?, ?)",
-						"test-js", 1745324796000000000, 1.234);
-					console.println("rowsAffected:", result.rowsAffected, "message:", result.message);
-					
-					conn.exec("EXEC table_flush(tag_data)")
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "dbms-insert",
+		Script: `
+			const db = require("@jsh/db");
+			const { now } = require("@jsh/system");
+			client = new db.Client({lowerCaseColumns:true});
+			try{
+				conn = client.connect();
+				result = conn.exec("insert into tag_data (name, time, value) values (?, ?, ?)",
+					"test-js", 1745324796000000000, 1.234);
+				console.println("rowsAffected:", result.rowsAffected, "message:", result.message);
+				
+				conn.exec("EXEC table_flush(tag_data)")
 
-					rows = conn.query("select name, time, value from tag_data where name = ?", "test-js")
-					for (const rec of rows) {
-						console.println(...rec);
-					}
-
-					rows = conn.query("select name, time, value from tag_data where name = ?", "test-js")
-					console.println("cols.names:", JSON.stringify(rows.columnNames()));
-					console.println("cols.types:", JSON.stringify(rows.columnTypes()));
-					for (let rec = rows.next(); rec != null; rec = rows.next()) {
-						console.println(rec.name+", "+rec.time.unix()+", "+rec.value);
-						for( const n in rec) {
-							console.println("for_in", n, ":", rec[n]);
-						}
-					}
-
-					row = conn.queryRow("select count(*) from tag_data where name = ?", "test-js")
-					console.println("queryRow:", row.values["count(*)"]);
-				} catch(e) {
-					console.println("Error:", e.message);
-				} finally {
-					if (rows) rows.close();
-				 	if (conn) conn.close();
+				rows = conn.query("select name, time, value from tag_data where name = ?", "test-js")
+				for (const rec of rows) {
+					console.println(...rec);
 				}
-			`,
-			Output: []string{
-				"rowsAffected: 1 message: a row inserted.",
-				fmt.Sprintf("test-js %s 1.234", time.Unix(1745324796, 0).Format("2006-01-02 15:04:05")),
-				`cols.names: ["name","time","value"]`,
-				`cols.types: ["VARCHAR","DATETIME","DOUBLE"]`,
-				"test-js, 1745324796, 1.234",
-				"for_in name : test-js",
-				fmt.Sprintf("for_in time : %s", time.Unix(1745324796, 0).Format("2006-01-02 15:04:05")),
-				"for_in value : 1.234",
-				"queryRow: 1",
-			},
-		},
-		{
-			Name: "dbms-append",
-			Script: `
-				const db = require("@jsh/db");
-				const { now, parseTime } = require("@jsh/system");
-				client = new db.Client({lowerCaseColumns:true});
-				console.println("client.supportAppend:", client.supportAppend);
-				var conn = null;
-				var appender = null;
-				try{
-					conn = client.connect();
-					appender = conn.appender("tag_data", "name", "time", "value");
-					let tsFrom = new Date();
-					for (let i = 0; i < 100; i++) {
-						let ts = tsFrom.getTime() + 1000;
-						appender.append("test-append", new Date(ts), i);
+
+				rows = conn.query("select name, time, value from tag_data where name = ?", "test-js")
+				console.println("cols.names:", JSON.stringify(rows.columnNames()));
+				console.println("cols.types:", JSON.stringify(rows.columnTypes()));
+				for (let rec = rows.next(); rec != null; rec = rows.next()) {
+					console.println(rec.name+", "+rec.time.unix()+", "+rec.value);
+					for( const n in rec) {
+						console.println("for_in", n, ":", rec[n]);
 					}
-				} catch(e) {
-					console.println("Error:", e);
-				} finally {
-				 	if (appender) appender.close();
-					if (conn) conn.close();
 				}
-				console.println("appender:", appender.result().success, appender.result().fail);
-			`,
-			Output: []string{
-				"client.supportAppend: true",
-				"appender: 100 0",
-			},
+
+				row = conn.queryRow("select count(*) from tag_data where name = ?", "test-js")
+				console.println("queryRow:", row.values["count(*)"]);
+			} catch(e) {
+				console.println("Error:", e.message);
+			} finally {
+				if (rows) rows.close();
+				if (conn) conn.close();
+			}
+		`,
+		Output: []string{
+			"rowsAffected: 1 message: a row inserted.",
+			fmt.Sprintf("test-js %s 1.234", time.Unix(1745324796, 0).Format("2006-01-02 15:04:05")),
+			`cols.names: ["name","time","value"]`,
+			`cols.types: ["VARCHAR","DATETIME","DOUBLE"]`,
+			"test-js, 1745324796, 1.234",
+			"for_in name : test-js",
+			fmt.Sprintf("for_in time : %s", time.Unix(1745324796, 0).Format("2006-01-02 15:04:05")),
+			"for_in value : 1.234",
+			"queryRow: 1",
 		},
-	}
-	for _, tc := range tests {
-		test_engine.RunTest(t, tc)
-	}
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "dbms-append",
+		Script: `
+			const db = require("@jsh/db");
+			const { now, parseTime } = require("@jsh/system");
+			client = new db.Client({lowerCaseColumns:true});
+			console.println("client.supportAppend:", client.supportAppend);
+			var conn = null;
+			var appender = null;
+			try{
+				conn = client.connect();
+				appender = conn.appender("tag_data", "name", "time", "value");
+				let tsFrom = new Date();
+				for (let i = 0; i < 100; i++) {
+					let ts = tsFrom.getTime() + 1000;
+					appender.append("test-append", new Date(ts), i);
+				}
+			} catch(e) {
+				console.println("Error:", e);
+			} finally {
+				if (appender) appender.close();
+				if (conn) conn.close();
+			}
+			console.println("appender:", appender.result().success, appender.result().fail);
+		`,
+		Output: []string{
+			"client.supportAppend: true",
+			"appender: 100 0",
+		},
+	}.RunTest(t)
 }
 
 func TestPostgreSql(t *testing.T) {
@@ -244,52 +239,47 @@ func TestPostgreSql(t *testing.T) {
 		t.Fatalf("could not connect to postgres: %v", err)
 	}
 
-	tests := []test_engine.TestCase{
-		{
-			Name: "dbms-postgresql",
-			Script: `
-				const db = require("@jsh/db");
-				const { now, parseTime } = require("@jsh/system");
-				
-				client = new db.Client({
-					driver: "postgres",
-					dataSource: "` + dsn + `",
-					lowerCaseColumns:true,
-				});
-				var conn = null;
-				var rows = null;
-				try{
-					conn = client.connect();
-					r = conn.exec("CREATE TABLE test (id SERIAL PRIMARY KEY, name TEXT)");
-					console.println("create table:", r.message);
-					r = conn.exec("INSERT INTO test (name) VALUES ($1)", "foo")
-					console.println("insert foo:", r.message, r.rowsAffected);
-					r = conn.exec("INSERT INTO test (name) VALUES ($1)", "bar")
-					console.println("insert bar:", r.message, r.rowsAffected);
+	test_engine.TestCase{
+		Name: "dbms-postgresql",
+		Script: `
+			const db = require("@jsh/db");
+			const { now, parseTime } = require("@jsh/system");
+			
+			client = new db.Client({
+				driver: "postgres",
+				dataSource: "` + dsn + `",
+				lowerCaseColumns:true,
+			});
+			var conn = null;
+			var rows = null;
+			try{
+				conn = client.connect();
+				r = conn.exec("CREATE TABLE test (id SERIAL PRIMARY KEY, name TEXT)");
+				console.println("create table:", r.message);
+				r = conn.exec("INSERT INTO test (name) VALUES ($1)", "foo")
+				console.println("insert foo:", r.message, r.rowsAffected);
+				r = conn.exec("INSERT INTO test (name) VALUES ($1)", "bar")
+				console.println("insert bar:", r.message, r.rowsAffected);
 
-					rows = conn.query("SELECT * FROM test ORDER BY id");
-					console.println("cols.names:", JSON.stringify(rows.columnNames()));
-					for (const rec of rows) {
-						console.println(...rec);
-					}
-				} catch(e) {
-					console.println("Error:", e.message);
-				} finally {
-				 	if(rows) rows.close();
-					if(conn) conn.close();
+				rows = conn.query("SELECT * FROM test ORDER BY id");
+				console.println("cols.names:", JSON.stringify(rows.columnNames()));
+				for (const rec of rows) {
+					console.println(...rec);
 				}
-			`,
-			Output: []string{
-				"create table: Created successfully.",
-				"insert foo: a row inserted. 1",
-				"insert bar: a row inserted. 1",
-				`cols.names: ["id","name"]`,
-				"1 foo",
-				"2 bar",
-			},
+			} catch(e) {
+				console.println("Error:", e.message);
+			} finally {
+				if(rows) rows.close();
+				if(conn) conn.close();
+			}
+		`,
+		Output: []string{
+			"create table: Created successfully.",
+			"insert foo: a row inserted. 1",
+			"insert bar: a row inserted. 1",
+			`cols.names: ["id","name"]`,
+			"1 foo",
+			"2 bar",
 		},
-	}
-	for _, tc := range tests {
-		test_engine.RunTest(t, tc)
-	}
+	}.RunTest(t)
 }

--- a/jsh/lib/machcli/machcli.go
+++ b/jsh/lib/machcli/machcli.go
@@ -36,6 +36,9 @@ func Module(ctx context.Context, rt *goja.Runtime, module *goja.Object) {
 	exports.Set("Explain", Explain)
 	exports.Set("Message", Message)
 	exports.Set("IsFetchable", IsFetchable)
+	exports.Set("Named", func(name string, value any) sql.NamedArg {
+		return sql.Named(name, value)
+	})
 }
 
 func Unbox(value any) any {

--- a/jsh/lib/machcli/machcli.js
+++ b/jsh/lib/machcli/machcli.js
@@ -54,7 +54,17 @@ class Connection {
     // IMPORTANT: caller should call rows.close() after using rows
     query() {
         let ctx = _machcli.Context(this.ctx);
-        let rows = this.conn.queryContext(ctx, ...arguments);
+        let args;
+        if (arguments.length === 2 && typeof arguments[1] === 'object' && typeof arguments[0] === 'string' && arguments[0].indexOf(':') >= 0) {
+            // so it is a named parameter object. We need to convert it to an array of values.
+            const sql = arguments[0];
+            const namedParams = arguments[1];
+            const paramValues = Object.keys(namedParams).map(key => _machcli.Named(key, namedParams[key]));
+            args = [sql, ...paramValues];
+        } else {
+            args = Array.from(arguments);
+        }
+        let rows = this.conn.queryContext(ctx, ...args);
         return new Rows(ctx, rows);
     }
     queryRow() {

--- a/jsh/lib/machcli/machcli_test.go
+++ b/jsh/lib/machcli/machcli_test.go
@@ -31,239 +31,269 @@ func TestMain(m *testing.M) {
 
 func TestDatabase(t *testing.T) {
 	tick, _ := time.ParseInLocation(time.DateTime, "2025-12-17 16:49:28", time.Local)
-
-	tests := []test_engine.TestCase{
-		{
-			Name: "mach_exec",
-			Script: `
-				const {Client} = require('machcli');
-				const conf = require("process").env.get("conf");
-				const tick = require("process").env.get("tick");
-				try {
-					db = new Client(conf);
-					conn = db.connect();
-					result = conn.exec("CREATE TAG TABLE IF NOT EXISTS TAG (NAME VARCHAR(100) primary key, TIME DATETIME basetime, VALUE DOUBLE, JSON_VALUE JSON)");
-					console.println("Created Table Message:", result.message);
-
-					// null record max test, sql.Null[uint64]
-					const rows = conn.query("select max(_id) as max_id from _tag_meta")
-					const rec = rows.next()
-					console.println("done:", rec.done);
-					console.println("rows.max_id:", rec.max_id); // expect null
-					rows.close();
-
-					result = conn.exec("CREATE VIEW TAGVIEW as select * from TAG where name='jsh'");
-					console.println("Created View Message:", result.message);
-
-					result = conn.exec("INSERT INTO TAG values(?, ?, ?, ?)", 'jsh', tick, 123, '{"key": "value"}');
-					console.println("Inserted rows:", result.rowsAffected, "Message:", result.message);
-				} catch(err) {
-					console.println("Error: ", err.message);
-				} finally {
-					conn && conn.close();
-				 	db && db.close();
-				}
-			`,
-			Output: []string{
-				"Created Table Message: table created.",
-				"done: false",
-				"rows.max_id: null",
-				"Created View Message: view created.",
-				"Inserted rows: 1 Message: a row inserted.",
-			},
+	vars := map[string]any{
+		"conf": map[string]any{
+			"host":     "127.0.0.1",
+			"port":     machcliTestServer.MachPort(),
+			"user":     "sys",
+			"password": "manager",
 		},
-		{
-			Name: "mach_table_types",
-			Script: `
-				const {Client, stringTableType} = require('machcli');
-				const conf = require("process").env.get("conf");
+		"tick": tick,
+	}
+
+	test_engine.TestCase{
+		Name: "mach_exec",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const conf = require("process").env.get("conf");
+			const tick = require("process").env.get("tick");
+			try {
 				db = new Client(conf);
 				conn = db.connect();
-				rows = conn.query("SELECT NAME, TYPE from M$SYS_TABLES ORDER BY NAME");
-				for (const row of rows) {
-					if (row.NAME.startsWith("_")) continue;
-					console.println("TABLE:", row.NAME, "TYPE:", stringTableType(row.TYPE));
-				}
-				rows.close();
-				conn.close();
-				db.close();
-			`,
-			Output: []string{
-				"TABLE: TAG TYPE: Tag",
-				"TABLE: TAGVIEW TYPE: View",
-			},
-		},
-		{
-			Name: "mach_append",
-			Script: `
-				const {Client} = require('machcli');
-				const {now} = require("process");
-				const conf = require("process").env.get("conf");
-				try {
-					db = new Client(conf);
-					conn = db.connect();
-					appender = conn.append("TAG");
-					for (let i = 0; i < 99; i++) {
-						appender.append('jsh', now(), 123 + i, '{"append":${i}}');
-					}
-					appender.flush();
-					result = appender.close();
-					console.println("Appended rows:", ...result);
-				} catch(err) {
-					console.println("Error: ", err.message);
-				} finally {
-					conn && conn.close();
-				 	db && db.close();
-				}
-			`,
-			Output: []string{
-				"Appended rows: 99 0",
-			},
-		},
-		{
-			Name: "mach_exec_flush",
-			Script: `
-				const {Client} = require('machcli');
-				const conf = require("process").env.get("conf");
-				try {
-					db = new Client(conf);
-					conn = db.connect();
-					result = conn.exec('exec table_flush(TAG)');
-					console.println("result:", result.message);
-				} catch(err) {
-					console.println("Error: ", err.message);
-				} finally {
-					conn && conn.close();
-				 	db && db.close();
-				}
-			`,
-			Output: []string{
-				"result: table flushed.",
-			},
-		},
-		{
-			Name: "mach_query_row",
-			Script: `
-				const {Client} = require('machcli');
-				const conf = require("process").env.get("conf");
-				try {
-					db = new Client(conf);
-					conn = db.connect();
-					row = conn.queryRow("SELECT count(*) from TAG");
-					console.println("ROWNUM:", row._ROWNUM, "Count:", row["count(*)"]);
-				} catch(err) {
-					console.println("Error: ", err.message);
-				} finally {
-					conn && conn.close();
-				 	db && db.close();
-				}
-			`,
-			Output: []string{
-				"ROWNUM: 1 Count: 100",
-			},
-		},
-		{
-			Name: "mach_query",
-			Script: `
-				const {Client} = require('machcli');
-				const conf = require("process").env.get("conf");
-				try {
-					db = new Client(conf);
-					conn = db.connect();
-					rows = conn.query("SELECT * from TAG order by time limit ?", 1);
-					for (const row of rows) {
-						console.println("NAME:", row.NAME, "TIME:", row.TIME, "VALUE:", row.VALUE, "JSON_VALUE:", typeof row.JSON_VALUE);
-					}
-					console.println(rows.message());
-				} catch(err) {
-					console.println("Error: ", err.message);
-				} finally {
-					rows && rows.close();
-					conn && conn.close();
-				 	db && db.close();
-				}
-			`,
-			Output: []string{
-				fmt.Sprintf("NAME: jsh TIME: %s VALUE: 123 JSON_VALUE: string", tick.Local().Format(time.DateTime)),
-				"a row selected.",
-			},
-		},
-		{
-			Name: "mach_query_stat",
-			Script: `
-				const {Client} = require('machcli');
-				const conf = require("process").env.get("conf");
-				var db, conn, rows;
-				try {
-					db = new Client(conf);
-					conn = db.connect();
-					rows = conn.query("SELECT * from v$TAG_STAT order by name");
-					console.println("{\"rows\": [");
-					for (const row of rows) {
-						console.println(JSON.stringify(row), ",");
-					}
-					console.println("], \"reason\":", "\"" + rows.message() + "\"");
-					console.println("}");
-				} catch(err) {
-					console.println("Error: ", err.message);
-				} finally {
-					rows && rows.close();
-					conn && conn.close();
-				 	db && db.close();
-				}
-			`,
-			ExpectFunc: func(t *testing.T, result string) {
-				require.Equal(t, "jsh", gjson.Get(result, "rows.0.NAME").String(), result)
-				require.Equal(t, int64(100), gjson.Get(result, "rows.0.ROW_COUNT").Int(), result)
-				require.Regexp(t, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*`, gjson.Get(result, "rows.0.MIN_TIME").String(), result)
-				require.Regexp(t, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*`, gjson.Get(result, "rows.0.MAX_TIME").String(), result)
-				require.Contains(t, result, "\"MIN_VALUE\":null", result)
-				require.Contains(t, result, "\"MIN_VALUE_TIME\":null", result)
-				require.Contains(t, result, "\"MAX_VALUE\":null", result)
-				require.Contains(t, result, "\"MAX_VALUE_TIME\":null", result)
-				require.Regexp(t, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*`, gjson.Get(result, "rows.0.RECENT_ROW_TIME").String(), result)
-				require.Equal(t, "a row selected.", gjson.Get(result, "reason").String(), result)
-			},
-		},
-		{
-			Name: "mach_explain",
-			Script: `
-				const {Client} = require('machcli');
-				const conf = require('process').env.get('conf');
-				try {
-					db = new Client(conf);
-					conn = db.connect();
-					result = conn.explain("SELECT * from TAG order by time limit 1");
-					console.println(result);
-				} catch(err) {
-					console.println("Error: ", err.message);
-				} finally {
-					conn && conn.close();
-				 	db && db.close();
-				}
-			`,
-			Output: []string{
-				" PROJECT",
-				"  LIMIT SORT",
-				"   TAG READ (RAW)",
-				"    KEYVALUE FULL SCAN (_TAG_DATA_0)",
-				"    VOLATILE FULL SCAN (_TAG_META)",
-			},
-		},
-	}
+				result = conn.exec("CREATE TAG TABLE IF NOT EXISTS TAG (NAME VARCHAR(100) primary key, TIME DATETIME basetime, VALUE DOUBLE, JSON_VALUE JSON)");
+				console.println("Created Table Message:", result.message);
 
-	for _, tc := range tests {
-		tc.Vars = map[string]any{
-			"conf": map[string]any{
-				"host":     "127.0.0.1",
-				"port":     machcliTestServer.MachPort(),
-				"user":     "sys",
-				"password": "manager",
-			},
-			"tick": tick,
-		}
-		test_engine.RunTest(t, tc)
-	}
+				// null record max test, sql.Null[uint64]
+				const rows = conn.query("select max(_id) as max_id from _tag_meta")
+				const rec = rows.next()
+				console.println("done:", rec.done);
+				console.println("rows.max_id:", rec.max_id); // expect null
+				rows.close();
+
+				result = conn.exec("CREATE VIEW TAGVIEW as select * from TAG where name='jsh'");
+				console.println("Created View Message:", result.message);
+
+				result = conn.exec("INSERT INTO TAG values(?, ?, ?, ?)", 'jsh', tick, 123, '{"key": "value"}');
+				console.println("Inserted rows:", result.rowsAffected, "Message:", result.message);
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		Output: []string{
+			"Created Table Message: table created.",
+			"done: false",
+			"rows.max_id: null",
+			"Created View Message: view created.",
+			"Inserted rows: 1 Message: a row inserted.",
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_table_types",
+		Vars: vars,
+		Script: `
+			const {Client, stringTableType} = require('machcli');
+			const conf = require("process").env.get("conf");
+			db = new Client(conf);
+			conn = db.connect();
+			rows = conn.query("SELECT NAME, TYPE from M$SYS_TABLES ORDER BY NAME");
+			for (const row of rows) {
+				if (row.NAME.startsWith("_")) continue;
+				console.println("TABLE:", row.NAME, "TYPE:", stringTableType(row.TYPE));
+			}
+			rows.close();
+			conn.close();
+			db.close();
+		`,
+		Output: []string{
+			"TABLE: TAG TYPE: Tag",
+			"TABLE: TAGVIEW TYPE: View",
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_append",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const {now} = require("process");
+			const conf = require("process").env.get("conf");
+			try {
+				db = new Client(conf);
+				conn = db.connect();
+				appender = conn.append("TAG");
+				for (let i = 0; i < 99; i++) {
+					appender.append('jsh', now(), 123 + i, '{"append":${i}}');
+				}
+				appender.flush();
+				result = appender.close();
+				console.println("Appended rows:", ...result);
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		Output: []string{
+			"Appended rows: 99 0",
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_exec_flush",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const conf = require("process").env.get("conf");
+			try {
+				db = new Client(conf);
+				conn = db.connect();
+				result = conn.exec('exec table_flush(TAG)');
+				console.println("result:", result.message);
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		Output: []string{
+			"result: table flushed.",
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_query_row",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const conf = require("process").env.get("conf");
+			try {
+				db = new Client(conf);
+				conn = db.connect();
+				row = conn.queryRow("SELECT count(*) from TAG");
+				console.println("ROWNUM:", row._ROWNUM, "Count:", row["count(*)"]);
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		Output: []string{
+			"ROWNUM: 1 Count: 100",
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_query",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const conf = require("process").env.get("conf");
+			try {
+				db = new Client(conf);
+				conn = db.connect();
+				rows = conn.query("SELECT * from TAG order by time limit ?", 1);
+				for (const row of rows) {
+					console.println("NAME:", row.NAME, "TIME:", row.TIME, "VALUE:", row.VALUE, "JSON_VALUE:", typeof row.JSON_VALUE);
+				}
+				console.println(rows.message());
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				rows && rows.close();
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		Output: []string{
+			fmt.Sprintf("NAME: jsh TIME: %s VALUE: 123 JSON_VALUE: string", tick.Local().Format(time.DateTime)),
+			"a row selected.",
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_query_named_params",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const conf = require("process").env.get("conf");
+			var db, conn, rows;
+			try {
+				db = new Client(conf);
+				conn = db.connect();
+				rows = conn.query("SELECT * from TAG where name = :name order by time limit :one", {one: 1, name: "jsh"});
+				for (const row of rows) {
+					console.println("NAME:", row.NAME, "TIME:", row.TIME, "VALUE:", row.VALUE, "JSON_VALUE:", row.JSON_VALUE);
+				}
+				console.println(rows.message());
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				rows && rows.close();
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		Output: []string{
+			fmt.Sprintf("NAME: jsh TIME: %s VALUE: 123 JSON_VALUE: {\"key\": \"value\"}", tick.Local().Format(time.DateTime)),
+			"a row selected.",
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_query_stat",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const conf = require("process").env.get("conf");
+			var db, conn, rows;
+			try {
+				db = new Client(conf);
+				conn = db.connect();
+				rows = conn.query("SELECT * from v$TAG_STAT order by name");
+				console.println("{\"rows\": [");
+				for (const row of rows) {
+					console.println(JSON.stringify(row), ",");
+				}
+				console.println("], \"reason\":", "\"" + rows.message() + "\"");
+				console.println("}");
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				rows && rows.close();
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		ExpectFunc: func(t *testing.T, result string) {
+			require.Equal(t, "jsh", gjson.Get(result, "rows.0.NAME").String(), result)
+			require.Equal(t, int64(100), gjson.Get(result, "rows.0.ROW_COUNT").Int(), result)
+			require.Regexp(t, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*`, gjson.Get(result, "rows.0.MIN_TIME").String(), result)
+			require.Regexp(t, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*`, gjson.Get(result, "rows.0.MAX_TIME").String(), result)
+			require.Contains(t, result, "\"MIN_VALUE\":null", result)
+			require.Contains(t, result, "\"MIN_VALUE_TIME\":null", result)
+			require.Contains(t, result, "\"MAX_VALUE\":null", result)
+			require.Contains(t, result, "\"MAX_VALUE_TIME\":null", result)
+			require.Regexp(t, `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.*`, gjson.Get(result, "rows.0.RECENT_ROW_TIME").String(), result)
+			require.Equal(t, "a row selected.", gjson.Get(result, "reason").String(), result)
+		},
+	}.RunTest(t)
+	test_engine.TestCase{
+		Name: "mach_explain",
+		Vars: vars,
+		Script: `
+			const {Client} = require('machcli');
+			const conf = require('process').env.get('conf');
+			try {
+				db = new Client(conf);
+				conn = db.connect();
+				result = conn.explain("SELECT * from TAG order by time limit 1");
+				console.println(result);
+			} catch(err) {
+				console.println("Error: ", err.message);
+			} finally {
+				conn && conn.close();
+				db && db.close();
+			}
+		`,
+		Output: []string{
+			" PROJECT",
+			"  LIMIT SORT",
+			"   TAG READ (RAW)",
+			"    KEYVALUE FULL SCAN (_TAG_DATA_0)",
+			"    VOLATILE FULL SCAN (_TAG_META)",
+		},
+	}.RunTest(t)
 }
 
 func TestNewDatabaseCoverage(t *testing.T) {

--- a/jsh/test_engine/test_runner.go
+++ b/jsh/test_engine/test_runner.go
@@ -42,6 +42,11 @@ type TestCase struct {
 	ExecBuilder engine.ExecBuilderFunc
 }
 
+func (tc TestCase) RunTest(t *testing.T) {
+	t.Helper()
+	RunTest(t, tc)
+}
+
 func RunTest(t *testing.T, tc TestCase) {
 	t.Helper()
 	t.Run(tc.Name, func(t *testing.T) {

--- a/mods/codec/opts/generate.gen.go
+++ b/mods/codec/opts/generate.gen.go
@@ -318,13 +318,13 @@ func DataZoom(typ string, minPercentage float32, maxPercentage float32) Option {
 //	mods/codec/internal/csv/csv_decode.go:68:1
 //	mods/codec/internal/csv/csv_encode.go:89:1
 type CanSetDelimiter interface {
-	SetDelimiter(newDelimiter string)
+	SetDelimiter(delimiter string)
 }
 
-func Delimiter(newDelimiter string) Option {
+func Delimiter(delimiter string) Option {
 	return func(_one any) {
 		if _o, ok := _one.(CanSetDelimiter); ok {
-			_o.SetDelimiter(newDelimiter)
+			_o.SetDelimiter(delimiter)
 		}
 	}
 }

--- a/mods/lsp/tql/docs_gen.go
+++ b/mods/lsp/tql/docs_gen.go
@@ -2075,6 +2075,19 @@ var generatedTqlDocs = map[string]tqlDocInfo{
 		Description: "TODO",
 		Markdown: "# moment\n\n## Kind\n\nhelper\n\n## Category\n\nconversion\n\n## Signatures\n\n```text\nmoment(...)\n```\n\n## Slots\n\n| Slot | Required | Repeat | Accepts | Suggestions |\n| --- | --- | --- | --- | --- |\n| args | no | yes | expression | TODO |\n\n## Description\n\nTODO\n\n## Examples\n\n### Basic\n\n```js\nmoment()\n```\n\n## Related\n\nTODO",
 	},
+	"named": {
+		Label: "named",
+		Kind: "helper",
+		Category: "named parameters",
+		Signatures: []tqlDocSignature{
+			{Label: "named(...)"},
+		},
+		Slots: []tqlDocSlot{
+			{Name: "args", Required: false, Repeat: true, Accepts: "expression"},
+		},
+		Description: "TODO",
+		Markdown: "# named\n\n## Kind\n\nhelper\n\n## Category\n\nnamed parameters\n\n## Signatures\n\n```text\nnamed(...)\n```\n\n## Slots\n\n| Slot | Required | Repeat | Accepts | Suggestions |\n| --- | --- | --- | --- | --- |\n| args | no | yes | expression | TODO |\n\n## Description\n\nTODO\n\n## Examples\n\n### Basic\n\n```js\nnamed()\n```\n\n## Related\n\nTODO",
+	},
 	"noWait": {
 		Label: "noWait",
 		Kind: "helper",

--- a/mods/lsp/tql/docsrc/helpers/named.md
+++ b/mods/lsp/tql/docsrc/helpers/named.md
@@ -1,0 +1,37 @@
+# named
+
+## Kind
+
+helper
+
+## Category
+
+named parameters
+
+## Signatures
+
+```text
+named(...)
+```
+
+## Slots
+
+| Slot | Required | Repeat | Accepts | Suggestions |
+| --- | --- | --- | --- | --- |
+| args | no | yes | expression | TODO |
+
+## Description
+
+TODO
+
+## Examples
+
+### Basic
+
+```js
+named()
+```
+
+## Related
+
+TODO

--- a/mods/server/http_query_test.go
+++ b/mods/server/http_query_test.go
@@ -110,6 +110,24 @@ func TestHttpQuery(t *testing.T) {
 			},
 		},
 		{
+			name:    "select_v$example_named_bind_params",
+			sqlText: `select (MIN(MIN_TIME)),(MAX(MAX_TIME)) from v$EXAMPLE_stat where name = :name`,
+			params: url.Values{
+				"p": []string{`{"name":"temp"}`},
+			},
+			contentType: "application/json",
+			expectObj: map[string]any{
+				"success": true, "reason": "success",
+				"data": map[string]any{
+					"columns": []any{"(MIN(MIN_TIME))", "(MAX(MAX_TIME))"},
+					"types":   []any{"datetime", "datetime"},
+					"rows": []any{
+						[]any{float64(testTimeTick.UnixNano()), float64(testTimeTick.UnixNano())},
+					},
+				},
+			},
+		},
+		{
 			name:    "select_v$example_transpose",
 			sqlText: `select (min(min_time)),(max(max_time)) from v$EXAMPLE_stat where name = 'temp'`,
 			params: url.Values{
@@ -240,7 +258,7 @@ func TestHttpQuery(t *testing.T) {
 			for k, v := range tc.params {
 				switch k {
 				case "p":
-					var bindParams []any
+					var bindParams any
 					err := json.Unmarshal([]byte(v[0]), &bindParams)
 					require.NoError(t, err)
 					params[k] = bindParams
@@ -277,7 +295,7 @@ func TestHttpQuery(t *testing.T) {
 			for k, v := range tc.params {
 				switch k {
 				case "p":
-					var bindParams []any
+					var bindParams any
 					err := json.Unmarshal([]byte(v[0]), &bindParams)
 					require.NoError(t, err)
 					params[k] = bindParams
@@ -290,7 +308,7 @@ func TestHttpQuery(t *testing.T) {
 			payload := url.Values{}
 			for k, v := range params {
 				switch val := v.(type) {
-				case []any:
+				case []any, map[string]any:
 					jsonVal, _ := json.Marshal(val)
 					payload.Set(k, string(jsonVal))
 				case bool:

--- a/mods/server/http_query_test.go
+++ b/mods/server/http_query_test.go
@@ -364,7 +364,7 @@ func TestHttpQueryMutation(t *testing.T) {
 		execMutation(t,
 			"mutation_create_table",
 			fmt.Sprintf(`CREATE TAG TABLE IF NOT EXISTS %s (name varchar(40) primary key, time datetime basetime, value double summarized)`, mutationTable),
-			"Created successfully.")
+			"table created.")
 	})
 
 	t.Run("mutation_insert_data_1", func(t *testing.T) {
@@ -399,7 +399,7 @@ func TestHttpQueryMutation(t *testing.T) {
 		execMutation(t,
 			"mutation_drop_table",
 			fmt.Sprintf(`DROP TABLE %s`, mutationTable),
-			"Dropped successfully.")
+			"table dropped.")
 	})
 }
 

--- a/mods/server/svrmsg.go
+++ b/mods/server/svrmsg.go
@@ -3,10 +3,12 @@ package server
 import (
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -19,8 +21,10 @@ import (
 )
 
 type QueryRequest struct {
-	SqlText            string `json:"q"`
-	Params             []any  `json:"p,omitempty"`
+	SqlText string `json:"q"`
+	// Params holds bind parameters. It accepts a JSON array (positional binds for `?`)
+	// or a JSON object (named binds for `:name`, converted to sql.Named).
+	Params             any    `json:"p,omitempty"`
 	ReplyTo            string `json:"reply,omitempty"`              // for mqtt query only
 	RowsFlatten        bool   `json:"rowsFlatten,omitempty"`        // json output only for http, mqtt
 	RowsArray          bool   `json:"rowsArray,omitempty"`          // json output only for http, mqtt
@@ -208,8 +212,9 @@ func (req *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHo
 	var meta client.Meta
 	ctx = context.WithValue(ctx, client.MetaKey, &meta)
 
+	params, _ := req.Params.([]any)
 	if !stmtType.IsFetch() {
-		result, err := conn.ExecContext(ctx, req.SqlText, req.Params...)
+		result, err := conn.ExecContext(ctx, req.SqlText, params...)
 		if err != nil {
 			if hook.SetStatusCode != nil {
 				hook.SetStatusCode(http.StatusInternalServerError)
@@ -230,7 +235,7 @@ func (req *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHo
 		return nil
 	}
 
-	rows, err := conn.QueryContext(ctx, req.SqlText, req.Params...)
+	rows, err := conn.QueryContext(ctx, req.SqlText, params...)
 	if err != nil {
 		if hook.SetStatusCode != nil {
 			hook.SetStatusCode(http.StatusInternalServerError)
@@ -299,26 +304,58 @@ func parseQueryParams(raw string) ([]any, error) {
 	}
 	dec := json.NewDecoder(strings.NewReader(raw))
 	dec.UseNumber()
-	var params []any
+	var params any
 	if err := dec.Decode(&params); err != nil {
 		return nil, fmt.Errorf("invalid p, %w", err)
 	}
-	return normalizeQueryParams(params)
-}
-
-func normalizeQueryParams(params []any) ([]any, error) {
-	if len(params) == 0 {
-		return params, nil
-	}
-	ret := make([]any, len(params))
-	for i, param := range params {
-		value, err := normalizeQueryParamValue(param)
-		if err != nil {
-			return nil, err
-		}
-		ret[i] = value
+	ret, err := normalizeQueryParams(params)
+	if err != nil {
+		return nil, fmt.Errorf("invalid p, %w", err)
 	}
 	return ret, nil
+}
+
+// normalizeQueryParams accepts either a JSON array (positional binds for `?`)
+// or a JSON object (named binds for `:name`) and returns args ready to pass
+// to database/sql, converting object entries to sql.Named in sorted key order.
+func normalizeQueryParams(raw any) ([]any, error) {
+	switch params := raw.(type) {
+	case nil:
+		return nil, nil
+	case []any:
+		if len(params) == 0 {
+			return nil, nil
+		}
+		ret := make([]any, len(params))
+		for i, param := range params {
+			value, err := normalizeQueryParamValue(param)
+			if err != nil {
+				return nil, err
+			}
+			ret[i] = value
+		}
+		return ret, nil
+	case map[string]any:
+		if len(params) == 0 {
+			return nil, nil
+		}
+		names := make([]string, 0, len(params))
+		for name := range params {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		ret := make([]any, 0, len(names))
+		for _, name := range names {
+			value, err := normalizeQueryParamValue(params[name])
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, sql.Named(name, value))
+		}
+		return ret, nil
+	default:
+		return nil, fmt.Errorf("p must be an array or object, got %T", raw)
+	}
 }
 
 func normalizeQueryParamValue(value any) (any, error) {

--- a/mods/server/svrmsg.go
+++ b/mods/server/svrmsg.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	client "github.com/machbase/neo-client/v2"
 	"github.com/machbase/neo-server/v8/mods/codec"
 	"github.com/machbase/neo-server/v8/mods/codec/opts"
 	"github.com/machbase/neo-server/v8/mods/util"
@@ -204,6 +205,9 @@ func (req *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHo
 		hook.SetContentEncoding(req.Compress)
 	}
 
+	var meta client.Meta
+	ctx = context.WithValue(ctx, client.MetaKey, &meta)
+
 	if !stmtType.IsFetch() {
 		result, err := conn.ExecContext(ctx, req.SqlText, req.Params...)
 		if err != nil {
@@ -216,8 +220,12 @@ func (req *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHo
 			hook.SetStatusCode(http.StatusOK)
 		}
 		if hook.SetUserMessage != nil {
-			rows, _ := result.RowsAffected()
-			hook.SetUserMessage(spi.MakeUserMessage(stmtType, rows))
+			if userMsg := meta.Message(); userMsg == "" {
+				rows, _ := result.RowsAffected()
+				hook.SetUserMessage(spi.MakeUserMessage(stmtType, rows))
+			} else {
+				hook.SetUserMessage(userMsg)
+			}
 		}
 		return nil
 	}
@@ -276,7 +284,11 @@ func (req *QueryRequest) Execute(ctx context.Context, w io.Writer, hook *QueryHo
 		hook.SetStatusCode(http.StatusOK)
 	}
 	if hook.SetUserMessage != nil {
-		hook.SetUserMessage(spi.MakeUserMessage(stmtType, nrows))
+		if userMsg := meta.Message(); userMsg == "" {
+			hook.SetUserMessage(spi.MakeUserMessage(stmtType, nrows))
+		} else {
+			hook.SetUserMessage(userMsg)
+		}
 	}
 	return nil
 }

--- a/mods/server/svrmsg_test.go
+++ b/mods/server/svrmsg_test.go
@@ -26,6 +26,22 @@ func TestDecodeQueryRequestJSONRejectsCompositeParam(t *testing.T) {
 	require.Contains(t, err.Error(), "scalar")
 }
 
+func TestDecodeQueryRequestJSONNormalizesNamedParams(t *testing.T) {
+	req := &QueryRequest{}
+	err := req.DecodeJSON(strings.NewReader(`{"q":"select * from t where a = :name","p":{"name":"neo"}}`))
+	require.NoError(t, err)
+	require.Equal(t, "select * from t where a = :name", req.SqlText)
+	require.Equal(t, []any{sql.Named("name", "neo")}, req.Params)
+}
+
+func TestDecodeQueryRequestJSONRejectsCompositeNamedParam(t *testing.T) {
+	req := &QueryRequest{}
+	err := req.DecodeJSON(strings.NewReader(`{"q":"select * from t","p":{"name":["neo"]}}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid p")
+	require.Contains(t, err.Error(), "scalar")
+}
+
 func TestParseQueryParams(t *testing.T) {
 	params, err := parseQueryParams("   ")
 	require.NoError(t, err)
@@ -35,9 +51,35 @@ func TestParseQueryParams(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []any{int64(1), 2.5, false, "x"}, params)
 
-	_, err = parseQueryParams(`{"not":"an array"}`)
+	params, err = parseQueryParams(`{"name":"neo","from":1,"to":2.5}`)
+	require.NoError(t, err)
+	require.Equal(t, []any{sql.Named("from", int64(1)), sql.Named("name", "neo"), sql.Named("to", 2.5)}, params)
+
+	_, err = parseQueryParams(`{"nested":["x"]}`)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid p")
+
+	_, err = parseQueryParams(`123`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid p")
+}
+
+func TestNormalizeQueryParams(t *testing.T) {
+	params, err := normalizeQueryParams(nil)
+	require.NoError(t, err)
+	require.Nil(t, params)
+
+	params, err = normalizeQueryParams([]any{})
+	require.NoError(t, err)
+	require.Nil(t, params)
+
+	params, err = normalizeQueryParams(map[string]any{})
+	require.NoError(t, err)
+	require.Nil(t, params)
+
+	_, err = normalizeQueryParams("not an array or object")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "p must be an array or object")
 }
 
 func TestNormalizeQueryParamValue(t *testing.T) {

--- a/mods/tql/fm_dbsrc.go
+++ b/mods/tql/fm_dbsrc.go
@@ -327,6 +327,11 @@ func (x *Node) fmUse(dbname string) *useDatabase {
 	return &useDatabase{use: dbname}
 }
 
+// named("name", "value")
+func (x *Node) fmNamed(name string, value any) sql.NamedArg {
+	return sql.NamedArg{Name: name, Value: value}
+}
+
 // SQL('select ....', arg1, arg2)
 // SQL(bridge('sqlite'), 'SELECT * ...', arg1, arg2)
 func (x *Node) fmSql(args ...any) (any, error) {

--- a/mods/tql/fm_dbsrc.go
+++ b/mods/tql/fm_dbsrc.go
@@ -437,13 +437,18 @@ loop:
 func sqlExec(node *Node, stmtType spi.SQLStatementType, conn *sql.Conn, sqlText string, sqlParams ...any) string {
 	runtime := node.ensureRuntime()
 	var userMsg string
-	result, err := conn.ExecContext(runtime.Context(), sqlText, sqlParams...)
+	var meta client.Meta
+	ctx := context.WithValue(runtime.Context(), client.MetaKey, &meta)
+	result, err := conn.ExecContext(ctx, sqlText, sqlParams...)
 	if err != nil {
 		userMsg = err.Error()
 		node.emit(ErrorRecord(err))
 	} else {
-		nrows, _ := result.RowsAffected()
-		userMsg = spi.MakeUserMessage(stmtType, nrows)
+		userMsg = meta.Message()
+		if userMsg == "" { // when *sql.Conn is a bridged connection
+			nrows, _ := result.RowsAffected()
+			userMsg = spi.MakeUserMessage(stmtType, nrows)
+		}
 		runtime.SetResultColumns(client.Columns{
 			client.MakeColumnRownum(),
 			client.MakeColumnString("MESSAGE"),
@@ -456,7 +461,9 @@ func sqlExec(node *Node, stmtType spi.SQLStatementType, conn *sql.Conn, sqlText 
 func sqlQuery(node *Node, stmtType spi.SQLStatementType, conn *sql.Conn, sqlText string, sqlParams ...any) string {
 	runtime := node.ensureRuntime()
 	var userMsg string
-	rows, err := conn.QueryContext(runtime.Context(), sqlText, sqlParams...)
+	var meta client.Meta
+	ctx := context.WithValue(runtime.Context(), client.MetaKey, &meta)
+	rows, err := conn.QueryContext(ctx, sqlText, sqlParams...)
 	if err != nil {
 		userMsg = err.Error()
 		node.emit(ErrorRecord(err))
@@ -477,7 +484,10 @@ func sqlQuery(node *Node, stmtType spi.SQLStatementType, conn *sql.Conn, sqlText
 			for rows.Next() {
 				nrow++
 				if runtime.ShouldStop() {
-					userMsg = spi.MakeUserMessage(stmtType, nrow) + ", cancelled"
+					if userMsg = meta.Message(); userMsg == "" {
+						userMsg = spi.MakeUserMessage(stmtType, nrow)
+					}
+					userMsg = userMsg + ", cancelled"
 					break
 				}
 				values := spi.MakeBuffer(columnTypes)
@@ -491,7 +501,10 @@ func sqlQuery(node *Node, stmtType spi.SQLStatementType, conn *sql.Conn, sqlText
 				}
 				node.emit(NewRecord(nrow, values))
 			}
-			userMsg = spi.MakeUserMessage(stmtType, nrow)
+			userMsg = meta.Message()
+			if userMsg == "" {
+				userMsg = spi.MakeUserMessage(stmtType, nrow)
+			}
 		}
 	}
 	return userMsg

--- a/mods/tql/fx_definitions.go
+++ b/mods/tql/fx_definitions.go
@@ -218,6 +218,8 @@ var FxDefinitions = []Definition{
 	{"bridge", defTask.fmBridge},
 	{"// use", nil},
 	{"use", defTask.fmUse},
+	{"// named parameters", nil},
+	{"named", defTask.fmNamed},
 	// fourier transform
 	{"// fourier transform", nil},
 	{"minHz", defTask.fmMinHz},

--- a/mods/tql/fx_node.gen.go
+++ b/mods/tql/fx_node.gen.go
@@ -156,6 +156,8 @@ func NewNode(task *Task) *Node {
 		"bridge": x.gen_bridge,
 		// use
 		"use": x.gen_use,
+		// named parameters
+		"named": x.gen_named,
 		// fourier transform
 		"minHz": x.gen_minHz,
 		"maxHz": x.gen_maxHz,
@@ -2203,6 +2205,25 @@ func (x *Node) gen_use(args ...any) (any, error) {
 		return nil, err
 	}
 	ret := x.fmUse(p0)
+	return ret, nil
+}
+
+// gen_named
+//
+// syntax: named(string, )
+func (x *Node) gen_named(args ...any) (any, error) {
+	if len(args) != 2 {
+		return nil, ErrInvalidNumOfArgs("named", 2, len(args))
+	}
+	p0, err := convString(args, 0, "named", "string")
+	if err != nil {
+		return nil, err
+	}
+	p1, err := convAny(args, 1, "named", "interface {}")
+	if err != nil {
+		return nil, err
+	}
+	ret := x.fmNamed(p0, p1)
 	return ret, nil
 }
 

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -621,7 +621,7 @@ func TestSql_show_users(t *testing.T) {
 		`,
 		ExpectCSV: []string{
 			"MESSAGE",
-			"Created successfully.",
+			"user created.",
 			"", "",
 		},
 	}.run(t)
@@ -646,7 +646,7 @@ func TestSql_show_users(t *testing.T) {
 		`,
 		ExpectText: []string{
 			"MESSAGE",
-			"Dropped successfully.",
+			"user dropped.",
 			"", "",
 		},
 	}.run(t)
@@ -661,7 +661,7 @@ func TestSql_show_databases(t *testing.T) {
 		`,
 		ExpectCSV: []string{
 			"MESSAGE",
-			"Created successfully.",
+			"database created.",
 			"", "",
 		},
 	}.run(t)
@@ -689,7 +689,7 @@ func TestSql_show_databases(t *testing.T) {
 		`,
 		ExpectCSV: []string{
 			"MESSAGE",
-			"Dropped successfully.",
+			"database dropped.",
 			"", "",
 		},
 	}.run(t)
@@ -1128,7 +1128,7 @@ func TestSql_show_others(t *testing.T) {
 		ExpectText: []string{
 			`|MESSAGE|`,
 			`|:-----|`,
-			`|executed.|`,
+			`|table flushed.|`,
 			``,
 		},
 	}.run(t)
@@ -1238,11 +1238,11 @@ func TestSql_show_others(t *testing.T) {
 			BOX()
 			`,
 		ExpectText: []string{
-			"+-----------+",
-			"| MESSAGE   |",
-			"+-----------+",
-			"| executed. |",
-			"+-----------+",
+			"+----------------+",
+			"| MESSAGE        |",
+			"+----------------+",
+			"| table flushed. |",
+			"+----------------+",
 			"",
 		},
 	}.run(t)
@@ -1342,11 +1342,11 @@ func TestSql_show_others(t *testing.T) {
 			BOX()
 			`,
 		ExpectText: []string{
-			"+-----------+",
-			"| MESSAGE   |",
-			"+-----------+",
-			"| executed. |",
-			"+-----------+",
+			"+----------------+",
+			"| MESSAGE        |",
+			"+----------------+",
+			"| table flushed. |",
+			"+----------------+",
 			"",
 		},
 	}.run(t)
@@ -1386,11 +1386,11 @@ func TestSql_show_others(t *testing.T) {
 			BOX()
 			`,
 		ExpectText: []string{
-			"+-----------+",
-			"| MESSAGE   |",
-			"+-----------+",
-			"| executed. |",
-			"+-----------+",
+			"+----------------+",
+			"| MESSAGE        |",
+			"+----------------+",
+			"| table flushed. |",
+			"+----------------+",
 			"",
 		},
 	}.run(t)

--- a/mods/tql/task_test.go
+++ b/mods/tql/task_test.go
@@ -1172,6 +1172,34 @@ func TestSql_show_others(t *testing.T) {
 		},
 	}.run(t)
 	TqlTestCase{
+		Name: "SQL_select-from-table-bind-params",
+		Script: `
+			SQL("select TIME, VALUE from tag_simple where name = ?", 'tag1')
+			CSV( precision(3), header(true) )
+			`,
+		ExpectCSV: []string{
+			"TIME,VALUE",
+			"1692686707380411000,0.100",
+			"1692686708380411000,0.200",
+			"\n",
+		},
+	}.run(t)
+	TqlTestCase{
+		Name: "SQL_select-from-table-named-bind-params",
+		Script: `
+			SQL("select TIME, VALUE from tag_simple where name = :name limit :one, :one",
+				named("name", "tag1"),
+				named("one", 1))
+			CSV( precision(3), header(true) )
+			`,
+		ExpectCSV: []string{
+			"TIME,VALUE",
+			"1692686708380411000,0.200",
+			"\n",
+		},
+	}.run(t)
+
+	TqlTestCase{
 		Name: "SQL_select-from-table-rownum",
 		Script: `
 			SQL("select TIME, VALUE from tag_simple where name = 'tag1'")

--- a/mods/tql/test/sql_ddl_executed.txt
+++ b/mods/tql/test/sql_ddl_executed.txt
@@ -9,7 +9,7 @@
 <tbody>
 <tr>
 <td align="left">1</td>
-<td align="left">Created successfully.</td>
+<td align="left">table created.</td>
 </tr>
 </tbody>
 </table>

--- a/mods/util/mdconv/sqlext/sql_request.go
+++ b/mods/util/mdconv/sqlext/sql_request.go
@@ -759,15 +759,6 @@ func makeEllipsisRow(columnCount int) []any {
 	return row
 }
 
-func describeToShowTableQuery(sqlText string) string {
-	trimmed := strings.TrimSpace(sqlText)
-	trimmed = strings.TrimPrefix(strings.ToUpper(trimmed), "DESCRIBE")
-	trimmed = strings.TrimSpace(trimmed)
-	trimmed = strings.TrimPrefix(trimmed, "DESC")
-	trimmed = strings.TrimSpace(trimmed)
-	return "SHOW TABLE " + trimmed
-}
-
 func userMessageForStatement(stmtType spi.SQLStatementType, rowCount int64) string {
 	switch stmtType {
 	case spi.SQLStatementTypeShow, spi.SQLStatementTypeExplain:

--- a/mods/util/split.go
+++ b/mods/util/split.go
@@ -15,15 +15,17 @@ import (
 )
 
 type SqlStatementEnv struct {
-	Error  string `json:"error,omitempty"`
-	Bridge string `json:"bridge,omitempty"`
-	Use    string `json:"use,omitempty"`
+	Error  string            `json:"error,omitempty"`
+	Bridge string            `json:"bridge,omitempty"`
+	Use    string            `json:"use,omitempty"`
+	Named  map[string]string `json:"named,omitempty"`
 }
 
 func (sse *SqlStatementEnv) Reset() {
 	sse.Error = ""
 	sse.Bridge = ""
 	sse.Use = ""
+	sse.Named = nil
 }
 
 type SqlStatement struct {
@@ -260,6 +262,7 @@ func ParseStatementEnv(prev *SqlStatementEnv, text string) (*SqlStatementEnv, er
 	// -- env: bridge=sqlite
 	// -- env: reset
 	// -- env: use=mydb
+	// -- env: named.name=Alice named.from="2024-01-01" named.to="2024-01-08"
 	text = strings.TrimSpace(strings.TrimPrefix(text, "env:"))
 	pairs := ParseNameValuePairs(text)
 	if len(pairs) == 0 {
@@ -267,14 +270,32 @@ func ParseStatementEnv(prev *SqlStatementEnv, text string) (*SqlStatementEnv, er
 	}
 	env := &SqlStatementEnv{}
 	*env = *prev
+	namedCloned := false
 	for _, pair := range pairs {
-		switch pair.Name {
-		case "bridge":
+		switch {
+		case pair.Name == "bridge":
 			env.Bridge = pair.Value
-		case "use":
+		case pair.Name == "use":
 			env.Use = pair.Value
-		case "reset":
+		case pair.Name == "reset":
 			env.Reset()
+			namedCloned = true
+		case strings.HasPrefix(pair.Name, "named."):
+			bindName := strings.TrimPrefix(pair.Name, "named.")
+			if bindName == "" {
+				env.Error = fmt.Sprintf("unknown env: %s", pair.Name)
+				continue
+			}
+			if !namedCloned {
+				// copy-on-write: keep prev.Named untouched until the first mutation
+				named := make(map[string]string, len(prev.Named)+1)
+				for k, v := range prev.Named {
+					named[k] = v
+				}
+				env.Named = named
+				namedCloned = true
+			}
+			env.Named[bindName] = pair.Value
 		default:
 			env.Error = fmt.Sprintf("unknown env: %s", pair.Name)
 		}

--- a/mods/util/split_test.go
+++ b/mods/util/split_test.go
@@ -183,6 +183,116 @@ func TestSplitSqlStatementsDoubleDashFlags(t *testing.T) {
 	}
 }
 
+func TestSplitSqlStatementsEnv(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []*util.SqlStatement
+	}{
+		{
+			name:  "bridge",
+			input: "-- env: bridge=sqlite\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: bridge=sqlite", Env: &util.SqlStatementEnv{Bridge: "sqlite"}},
+				{BeginLine: 2, EndLine: 2, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{Bridge: "sqlite"}},
+			},
+		},
+		{
+			name:  "bridge and use accumulate",
+			input: "-- env: bridge=sqlite\n-- env: use=mydb\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: bridge=sqlite", Env: &util.SqlStatementEnv{Bridge: "sqlite"}},
+				{BeginLine: 2, EndLine: 2, IsComment: true, Text: "-- env: use=mydb", Env: &util.SqlStatementEnv{Bridge: "sqlite", Use: "mydb"}},
+				{BeginLine: 3, EndLine: 3, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{Bridge: "sqlite", Use: "mydb"}},
+			},
+		},
+		{
+			name:  "reset clears env",
+			input: "-- env: bridge=sqlite use=mydb\n-- env: reset\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: bridge=sqlite use=mydb", Env: &util.SqlStatementEnv{Bridge: "sqlite", Use: "mydb"}},
+				{BeginLine: 2, EndLine: 2, IsComment: true, Text: "-- env: reset", Env: &util.SqlStatementEnv{}},
+				{BeginLine: 3, EndLine: 3, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{}},
+			},
+		},
+		{
+			name:  "unknown env key",
+			input: "-- env: foo=bar\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: foo=bar", Env: &util.SqlStatementEnv{Error: "unknown env: foo"}},
+				{BeginLine: 2, EndLine: 2, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{Error: "unknown env: foo"}},
+			},
+		},
+		{
+			name:  "non env comment is ignored",
+			input: "-- just a comment\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- just a comment", Env: &util.SqlStatementEnv{}},
+				{BeginLine: 2, EndLine: 2, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{}},
+			},
+		},
+		{
+			name:  "named single pair",
+			input: `-- env: named.name=Alice` + "\n" + `select * from example where name = :name;`,
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: named.name=Alice", Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Alice"}}},
+				{BeginLine: 2, EndLine: 2, IsComment: false, Text: "select * from example where name = :name;", StmtType: "select", Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Alice"}}},
+			},
+		},
+		{
+			name:  "named multiple pairs with quoted values",
+			input: `-- env: named.name=Alice named.from="2024-01-01" named.to="2024-01-08"` + "\n" + `select * from example where name = :name and time between :from and :to;`,
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: `-- env: named.name=Alice named.from="2024-01-01" named.to="2024-01-08"`, Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Alice", "from": "2024-01-01", "to": "2024-01-08"}}},
+				{BeginLine: 2, EndLine: 2, IsComment: false, Text: "select * from example where name = :name and time between :from and :to;", StmtType: "select", Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Alice", "from": "2024-01-01", "to": "2024-01-08"}}},
+			},
+		},
+		{
+			name:  "named accumulates across lines and merges with bridge/use",
+			input: "-- env: bridge=sqlite named.name=Alice\n-- env: use=mydb named.from=2024-01-01\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: bridge=sqlite named.name=Alice", Env: &util.SqlStatementEnv{Bridge: "sqlite", Named: map[string]string{"name": "Alice"}}},
+				{BeginLine: 2, EndLine: 2, IsComment: true, Text: "-- env: use=mydb named.from=2024-01-01", Env: &util.SqlStatementEnv{Bridge: "sqlite", Use: "mydb", Named: map[string]string{"name": "Alice", "from": "2024-01-01"}}},
+				{BeginLine: 3, EndLine: 3, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{Bridge: "sqlite", Use: "mydb", Named: map[string]string{"name": "Alice", "from": "2024-01-01"}}},
+			},
+		},
+		{
+			name:  "named key overwrites earlier value",
+			input: "-- env: named.name=Alice\n-- env: named.name=Bob\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: named.name=Alice", Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Alice"}}},
+				{BeginLine: 2, EndLine: 2, IsComment: true, Text: "-- env: named.name=Bob", Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Bob"}}},
+				{BeginLine: 3, EndLine: 3, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Bob"}}},
+			},
+		},
+		{
+			name:  "reset clears named",
+			input: "-- env: named.name=Alice\n-- env: reset\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: named.name=Alice", Env: &util.SqlStatementEnv{Named: map[string]string{"name": "Alice"}}},
+				{BeginLine: 2, EndLine: 2, IsComment: true, Text: "-- env: reset", Env: &util.SqlStatementEnv{}},
+				{BeginLine: 3, EndLine: 3, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{}},
+			},
+		},
+		{
+			name:  "named without bind name is an error",
+			input: "-- env: named.=Alice\nSELECT 1;",
+			expect: []*util.SqlStatement{
+				{BeginLine: 1, EndLine: 1, IsComment: true, Text: "-- env: named.=Alice", Env: &util.SqlStatementEnv{Error: "unknown env: named."}},
+				{BeginLine: 2, EndLine: 2, IsComment: false, Text: "SELECT 1;", StmtType: "select", Env: &util.SqlStatementEnv{Error: "unknown env: named."}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			statements, err := util.SplitSqlStatements(strings.NewReader(tc.input))
+			require.NoError(t, err)
+			require.EqualValues(t, tc.expect, statements)
+		})
+	}
+}
+
 func TestSplitSqlStatements(t *testing.T) {
 	tests := []struct {
 		inputFile  string

--- a/spi/database.go
+++ b/spi/database.go
@@ -676,7 +676,7 @@ func ListTablesWalk(ctx context.Context, conn *sql.Conn, showAll bool, callback 
 	descriptiveType := false
 	sqlText := SqlTidy(
 		`SELECT
-			j.DB_NAME as DATABASE_NAME,
+			j.DATABASE_NAME as DATABASE_NAME,
 			u.NAME as USER_NAME,
 			j.NAME as TABLE_NAME,
 			j.ID as TABLE_ID,`,
@@ -709,74 +709,17 @@ func ListTablesWalk(ctx context.Context, conn *sql.Conn, showAll bool, callback 
 					USER_ID as USER_ID,
 					TYPE as TYPE,
 					FLAG as FLAG,
-					DATABASE_NAME as DB_NAME
+					DATABASE_NAME
 				from
 					M$SYS_TABLES
+				where
+					DATABASE_NAME = current_database()
 			) as j
 		WHERE
 			u.USER_ID = j.USER_ID`,
 		ifThenElse(showAll, "", `AND j.NAME NOT LIKE '\_%'`),
 		`ORDER by j.NAME`)
 
-	supportDatabaseMetadata := false
-	conn.Raw(func(driverConn any) error {
-		if c, ok := driverConn.(*client.Conn); ok {
-			supportDatabaseMetadata = c.SupportDatabaseMetadata()
-		}
-		return nil
-	})
-	if !supportDatabaseMetadata {
-		sqlText = SqlTidy(
-			`SELECT
-			j.DB_NAME as DATABASE_NAME,
-			u.NAME as USER_NAME,
-			j.NAME as TABLE_NAME,
-			j.ID as TABLE_ID,`,
-			ifThenElse(descriptiveType, `
-			case j.TYPE
-				when 0 then 'Log'
-				when 1 then 'Fixed'
-				when 3 then 'Volatile'
-				when 4 then 'Lookup'
-				when 5 then 'KeyValue'
-				when 6 then 'Tag'
-				else ''
-			end as TABLE_TYPE,
-			case j.FLAG
-				when 1 then 'Data'
-				when 2 then 'Rollup'
-				when 4 then 'Meta'
-				when 8 then 'Stat'
-				else ''
-			end as TABLE_FLAG`,
-				`
-			j.TYPE as TABLE_TYPE,
-			j.FLAG as TABLE_FLAG`),
-			`FROM
-			M$SYS_USERS u,
-			(
-				select
-					a.ID as ID,
-					a.NAME as NAME,
-					a.USER_ID as USER_ID,
-					a.TYPE as TYPE,
-					a.FLAG as FLAG,
-					case a.DATABASE_ID
-						when -1 then 'MACHBASEDB'
-						else d.MOUNTDB
-					end as DB_NAME
-				from
-					M$SYS_TABLES a
-				left join
-					V$STORAGE_MOUNT_DATABASES d
-				on
-					a.DATABASE_ID = d.BACKUP_TBSID
-			) as j
-		WHERE
-			u.USER_ID = j.USER_ID`,
-			ifThenElse(showAll, "", "AND SUBSTR(j.NAME, 1, 1) <> '_'"),
-			`ORDER by j.NAME`)
-	}
 	rows, err := conn.QueryContext(ctx, sqlText)
 	if err != nil {
 		callback(nil, err)


### PR DESCRIPTION
This pull request introduces support for named SQL parameters in both the JavaScript and HTTP query interfaces, improves test structure and coverage, and updates documentation to reflect these enhancements. The main changes include API and implementation updates to handle named parameters, test refactoring for better maintainability, and documentation additions for the new features.

**Support for Named SQL Parameters:**

* Updated the query interface to accept named parameters as JavaScript objects and convert them to `sql.NamedArg` for execution, enabling queries like `SELECT ... WHERE name = :name` with `{name: "value"}` style parameters. (`jsh/lib/machcli/machcli.js` [[1]](diffhunk://#diff-44f04c897aa6ea5d774a35672b6f0ab02e844780ae61b0e293a35d75f78880b4L57-R67) `jsh/lib/machcli/machcli.go` [[2]](diffhunk://#diff-db9f6595b2a3732fa8458ce50b83ee8bdccab8aa3310c1e50e3a00b6e0547adcR39-R41)
* Modified the HTTP query API to accept named parameters as JSON objects, converting them to named binds internally and updating the request/response handling accordingly. (`mods/server/svrmsg.go` [[1]](diffhunk://#diff-f78a555c6c1b930e267f2706d9dc6cb480eab5da709363a8a525a49ea111a87eL22-R27) [[2]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L243-R261) [[3]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L280-R298) [[4]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L293-R311)
* Added test cases to verify named parameter support in both JavaScript and HTTP interfaces. (`jsh/lib/machcli/machcli_test.go` [[1]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5R204-R235) `mods/server/http_query_test.go` [[2]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64R112-R129)

**Test Suite Refactoring and Enhancement:**

* Refactored test cases to use the new `TestCase.RunTest` helper for improved readability and maintainability, replacing manual test loops with method calls. (`jsh/lib/db/dbms_test.go` [[1]](diffhunk://#diff-abcbafcf8b2a287adf4b50e7d17873f5e4f02441071a8fd9f3b7d22827ade0c4L100-R100) [[2]](diffhunk://#diff-abcbafcf8b2a287adf4b50e7d17873f5e4f02441071a8fd9f3b7d22827ade0c4L131-R131) [[3]](diffhunk://#diff-abcbafcf8b2a287adf4b50e7d17873f5e4f02441071a8fd9f3b7d22827ade0c4L181-R181) [[4]](diffhunk://#diff-abcbafcf8b2a287adf4b50e7d17873f5e4f02441071a8fd9f3b7d22827ade0c4L211-R210) [[5]](diffhunk://#diff-abcbafcf8b2a287adf4b50e7d17873f5e4f02441071a8fd9f3b7d22827ade0c4L247-R242) [[6]](diffhunk://#diff-abcbafcf8b2a287adf4b50e7d17873f5e4f02441071a8fd9f3b7d22827ade0c4L290-R284) `jsh/lib/machcli/machcli_test.go` [[7]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5R34-R46) [[8]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L74-R86) [[9]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L95-R108) [[10]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L122-R136) [[11]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L143-R158) [[12]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L164-R180) [[13]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L227-R273) [[14]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L252-R296) `jsh/test_engine/test_runner.go` [[15]](diffhunk://#diff-1dafb1894f865ae3fac9ded59460a6da71012346f9f59aae8cf7ccabc4b1f64aR45-R49)

**Documentation Updates:**

* Added documentation for the new `named` helper to TQL docs, including a new markdown file and generated entries. (`mods/lsp/tql/docs_gen.go` [[1]](diffhunk://#diff-5b2ae85a70d4fa571153a97b1a56a917c65f90e17ecf4260ba26230bcc92e96aR2078-R2090) `mods/lsp/tql/docsrc/helpers/named.md` [[2]](diffhunk://#diff-6a24469fd1e2be4642f09e769bbbc6afc5f43d520accb1ce2f0b7fbd926840e9R1-R37)

**Dependency and Minor Fixes:**

* Updated `github.com/machbase/neo-client/v2` dependency to a newer version. (`go.mod` [go.modL31-R31](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L31-R31))
* Minor API and message consistency fixes, such as standardizing table creation and drop messages. (`mods/server/http_query_test.go` [[1]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L367-R385) [[2]](diffhunk://#diff-38f8cbd34a36039595e5c7a74ff154d7bfb4eee97eb5dba3a579f41110fbbe64L402-R420)
* Small API cleanups (e.g., renaming parameters for clarity in code generation). (`mods/codec/opts/generate.gen.go` [mods/codec/opts/generate.gen.goL321-R327](diffhunk://#diff-dad7c182f550b052599d9c4a76d6fe2b91fc207ae14cea2eda787766f2467e66L321-R327))

These changes collectively improve the flexibility and usability of the query interfaces, especially for applications requiring named parameter support, while cleaning up and extending test and documentation coverage.