### PR TITLE
Add database support for backup requests and validation

### DIFF
--- a/mods/backup/backupd.go
+++ b/mods/backup/backupd.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	client "github.com/machbase/neo-client/v2"
 	"github.com/machbase/neo-server/v8/mods/logging"
 	"github.com/machbase/neo-server/v8/spi"
 )
@@ -109,6 +110,7 @@ type backupState struct {
 
 type BackupArchive struct {
 	Type      string `json:"type" binding:"required"`
+	Database  string `json:"database"`
 	TableName string `json:"tableName"`
 	Duration  struct {
 		Type  string `json:"type" binding:"required"`
@@ -161,7 +163,16 @@ func (s *Backupd) handleArchive(ctx *gin.Context) {
 	switch strings.ToLower(copyArchive.Type) {
 	case "database":
 		backupTarget = "DATABASE"
+		if copyArchive.Database != "" {
+			backupTarget = fmt.Sprintf("DATABASE %s", client.QuoteIdentifier(copyArchive.Database))
+		}
 	case "table":
+		if copyArchive.Database != "" {
+			rsp["reason"] = "database is only supported for database backup"
+			rsp["elapse"] = time.Since(tick).String()
+			ctx.JSON(http.StatusBadRequest, rsp)
+			return
+		}
 		if copyArchive.TableName == "" {
 			rsp["reason"] = "table name is empty"
 			rsp["elapse"] = time.Since(tick).String()

--- a/mods/backup/backupd_test.go
+++ b/mods/backup/backupd_test.go
@@ -329,6 +329,82 @@ func TestBackupdHandleArchiveConnectPaths(t *testing.T) {
 	})
 }
 
+func TestBackupdHandleArchiveDatabaseTarget(t *testing.T) {
+	origConnector := connectDefault
+	t.Cleanup(func() { connectDefault = origConnector })
+
+	t.Run("uses the requested database for every duration type", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			payload string
+		}{
+			{name: "full", payload: `{"type":"database","database":"FACTORY_A","duration":{"type":"full"},"path":"backup/full"}`},
+			{name: "incremental", payload: `{"type":"database","database":"FACTORY_A","duration":{"type":"incremental","after":"backup/full"},"path":"backup/incremental"}`},
+			{name: "time", payload: `{"type":"database","database":"FACTORY_A","duration":{"type":"time","from":"1700000000","to":"1700000600"},"path":"backup/time"}`},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				capturedSQL := ""
+				started := make(chan struct{})
+				release := make(chan struct{})
+				connectDefault = func(context.Context) (*sql.Conn, error) {
+					return newMockSQLConn(t, sqlMockBehavior{
+						onExec: func(sqlText string) {
+							capturedSQL = sqlText
+							close(started)
+							<-release
+						},
+					}), nil
+				}
+
+				s := NewBackupd(WithBackupdBaseDir(newBackupWorkDir(t)))
+				w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", tc.payload)
+				require.Equal(t, http.StatusOK, w.Code)
+				<-started
+				require.Contains(t, capturedSQL, `BACKUP DATABASE "FACTORY_A"`)
+				require.Equal(t, "FACTORY_A", s.backup.Info.Database)
+				close(release)
+				waitBackupSettled(t, s, 5*time.Second)
+			})
+		}
+	})
+
+	t.Run("keeps the unnamed database backup compatible", func(t *testing.T) {
+		capturedSQL := ""
+		started := make(chan struct{})
+		release := make(chan struct{})
+		connectDefault = func(context.Context) (*sql.Conn, error) {
+			return newMockSQLConn(t, sqlMockBehavior{
+				onExec: func(sqlText string) {
+					capturedSQL = sqlText
+					close(started)
+					<-release
+				},
+			}), nil
+		}
+
+		s := NewBackupd(WithBackupdBaseDir(newBackupWorkDir(t)))
+		w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", `{"type":"database","duration":{"type":"full"},"path":"backup/full"}`)
+		require.Equal(t, http.StatusOK, w.Code)
+		<-started
+		require.Contains(t, capturedSQL, "BACKUP DATABASE INTO DISK")
+		require.NotContains(t, capturedSQL, `BACKUP DATABASE "`)
+		close(release)
+		waitBackupSettled(t, s, 5*time.Second)
+	})
+
+	t.Run("rejects a database target for table backup", func(t *testing.T) {
+		s := NewBackupd(WithBackupdBaseDir(newBackupWorkDir(t)))
+		payload := `{"type":"table","database":"FACTORY_A","tableName":"demo_table","duration":{"type":"full"},"path":"backup/table"}`
+		w := performBackupRequest(t, s.handleArchive, http.MethodPost, "/api/backup/archive", payload)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := decodeJSONBody(t, w)
+		require.Equal(t, "database is only supported for database backup", body["reason"])
+	})
+}
+
 func TestBackupdHandleArchivesAndMountConnectPaths(t *testing.T) {
 	origConnector := connectDefault
 	t.Cleanup(func() { connectDefault = origConnector })

--- a/mods/backup/backupd_test.go
+++ b/mods/backup/backupd_test.go
@@ -52,7 +52,7 @@ func isBackupHelperProcess() bool {
 }
 
 func setupDefaultSPI() error {
-	testServer := &machsvr.TestServer{}
+	testServer = &machsvr.TestServer{}
 	testHomeDir = mustAbsPath(filepath.Join("tmp", "machbase_default"))
 	if err := os.RemoveAll(testHomeDir); err != nil {
 		return err
@@ -786,7 +786,7 @@ func TestBackupRestoreHelper(t *testing.T) {
 		os.Exit(2)
 	}
 
-	if err := machsvr.Initialize(homeDir, 0, machsvr.OPT_SIGHANDLER_OFF); err != nil {
+	if err := machsvr.Initialize(homeDir, freeTCPPort(t), machsvr.OPT_SIGHANDLER_OFF); err != nil {
 		fmt.Fprintln(os.Stderr, "initialize:", err)
 		os.Exit(3)
 	}
@@ -827,7 +827,7 @@ func TestBackupVerifyHelper(t *testing.T) {
 		os.Exit(2)
 	}
 
-	if err := machsvr.Initialize(homeDir, 0, machsvr.OPT_SIGHANDLER_OFF); err != nil {
+	if err := machsvr.Initialize(homeDir, freeTCPPort(t), machsvr.OPT_SIGHANDLER_OFF); err != nil {
 		fmt.Fprintln(os.Stderr, "verify initialize:", err)
 		os.Exit(3)
 	}


### PR DESCRIPTION
This pull request enhances the backup API to support specifying a target database for database backups, enforces correct usage of the `database` field, and introduces comprehensive tests to verify these behaviors. The changes ensure that backups can be performed for a specific database, maintain backward compatibility, and provide clear error handling when the `database` field is misused.

**API Enhancements:**

- Added an optional `Database` field to the `BackupArchive` struct, allowing clients to specify which database to back up when the backup type is `"database"`. (`mods/backup/backupd.go`)

- Updated the backup logic in `handleArchive` to:
  - Include the database name in the backup target when provided, using proper identifier quoting.
  - Reject requests that specify a `database` for table backups, returning a clear error message. (`mods/backup/backupd.go`)

**Dependency and Import Updates:**

- Added an import for the `neo-client` package to use its identifier quoting utility. (`mods/backup/backupd.go`)

**Testing Improvements:**

- Added a new test, `TestBackupdHandleArchiveDatabaseTarget`, which:
  - Verifies that the specified database is used in the backup SQL for all duration types.
  - Confirms backward compatibility for unnamed database backups.
  - Ensures that specifying a database for a table backup is properly rejected with an appropriate error message. (`mods/backup/backupd_test.go`)