### PR TITLE
add support for database alias in NewDatabase function

### DIFF
--- a/jsh/lib/machcli/machcli.go
+++ b/jsh/lib/machcli/machcli.go
@@ -67,6 +67,7 @@ type Config struct {
 	AlternativeHost string `json:"alternativeHost,omitempty"`
 	AlternativePort int    `json:"alternativePort,omitempty"`
 	Database        string `json:"database,omitempty"`
+	DB              string `json:"db,omitempty"` // alias of Database
 }
 
 type Database struct {
@@ -89,6 +90,9 @@ func newDatabase(ctx context.Context, data string) (*Database, error) {
 	} // default values
 	if err := json.Unmarshal([]byte(data), &obj); err != nil {
 		return nil, err
+	}
+	if obj.Database == "" {
+		obj.Database = obj.DB
 	}
 	opts := []string{
 		"host=" + obj.Host,

--- a/jsh/lib/machcli/machcli_test.go
+++ b/jsh/lib/machcli/machcli_test.go
@@ -338,25 +338,36 @@ func TestNewDatabaseCoverage(t *testing.T) {
 }
 
 func TestNewDatabaseAppliesDatabaseDSNOption(t *testing.T) {
-	cfg := fmt.Sprintf(`{"host":"127.0.0.1","port":%d,"user":"sys","password":"manager","database":"MACHBASEDB"}`,
-		machcliTestServer.MachPort(),
-	)
-	db, err := machcli.NewDatabase(cfg)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "database key", key: "database"},
+		{name: "db alias", key: "db"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := fmt.Sprintf(`{"host":"127.0.0.1","port":%d,"user":"sys","password":"manager","%s":"MACHBASEDB"}`,
+				machcliTestServer.MachPort(), tc.key,
+			)
+			db, err := machcli.NewDatabase(cfg)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, db.Close())
+			})
 
-	conn, err := db.Connect()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, conn.Close())
-	})
+			conn, err := db.Connect()
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, conn.Close())
+			})
 
-	var currentDatabase string
-	row := conn.QueryRowContext(context.Background(), "select current_database()")
-	require.NoError(t, row.Scan(&currentDatabase))
-	require.Equal(t, "MACHBASEDB", currentDatabase)
+			var currentDatabase string
+			row := conn.QueryRowContext(context.Background(), "select current_database()")
+			require.NoError(t, row.Scan(&currentDatabase))
+			require.Equal(t, "MACHBASEDB", currentDatabase)
+		})
+	}
 }
 
 func TestClientLoadsSharedConfigAndMergesCallerConfig(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for an alternative configuration key, `db`, as an alias for `database` in the `Config` struct and ensures that both are handled correctly throughout the codebase. It also updates tests to verify this new behavior.

**Support for alternative config key:**

* Added a `DB` field to the `Config` struct as an alias for `Database`, allowing users to specify either `database` or `db` in their configuration (`jsh/lib/machcli/machcli.go`).
* Updated the `newDatabase` function to set `Database` from `DB` if `Database` is not provided, ensuring backward compatibility and flexibility in config parsing (`jsh/lib/machcli/machcli.go`).

**Test coverage improvements:**

* Enhanced the `TestNewDatabaseAppliesDatabaseDSNOption` test to check both `database` and `db` keys, verifying that the alias works as intended (`jsh/lib/machcli/machcli_test.go`). [[1]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5L341-R351) [[2]](diffhunk://#diff-ab2f3bd464eebec42f33d3ace30304a7b3eda10197a3c83f14f0ad4fe23d27e5R369-R370)