### PR TITLE
Update neo-client to v2.0.0 and enhance transaction tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.7.8
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/lib/pq v1.12.3
-	github.com/machbase/neo-client/v2 v2.0.0-20260904073337-f6e7400b8d10
+	github.com/machbase/neo-client/v2 v2.0.0-20260905011852-8881e46c63c5
 	github.com/magefile/mage v1.16.0
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-sqlite3 v1.14.24

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 h1:PwQumkgq4/acIiZhtifTV5OUqqiP82UAl0h87xj/l9k=
 github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
-github.com/machbase/neo-client/v2 v2.0.0-20260904073337-f6e7400b8d10 h1:uko67NDJY777hopr2mWtBBGo4eE4Ch/HpGClkKe0LpM=
-github.com/machbase/neo-client/v2 v2.0.0-20260904073337-f6e7400b8d10/go.mod h1:5DmIxqFEwDV3LATPXQKxEwVcepjLxnUDPbDHPfkkVZM=
+github.com/machbase/neo-client/v2 v2.0.0-20260905011852-8881e46c63c5 h1:wIL8gwI2uH83FscRKmYRxwcio/dOf9UhWb0iZZFhP+s=
+github.com/machbase/neo-client/v2 v2.0.0-20260905011852-8881e46c63c5/go.mod h1:5DmIxqFEwDV3LATPXQKxEwVcepjLxnUDPbDHPfkkVZM=
 github.com/magefile/mage v1.16.0 h1:2naaPmNwrMicCdLBCRDw288hcyClO9lmnm6FMpXyJ5I=
 github.com/magefile/mage v1.16.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/jsh/service/controller_test.go
+++ b/jsh/service/controller_test.go
@@ -1223,7 +1223,7 @@ func TestControllerLaunchedServiceAutoMountsSharedFS(t *testing.T) {
 	}
 	defer ctl.Stop(nil)
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(20 * time.Second)
 	for {
 		svc := ctl.StatusOf("shared-check")
 		if svc != nil && svc.Status == ServiceStatusStopped {
@@ -1331,7 +1331,7 @@ func TestControllerLaunchedServiceSharedFSConflictCode(t *testing.T) {
 	}
 	defer ctl.Stop(nil)
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(20 * time.Second)
 	for {
 		svc := ctl.StatusOf("shared-conflict")
 		if svc != nil && svc.Status == ServiceStatusStopped {
@@ -1416,7 +1416,7 @@ func TestControllerLaunchedServiceSharedFSAppendNoConflict(t *testing.T) {
 	}
 	defer ctl.Stop(nil)
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(20 * time.Second)
 	for {
 		svc := ctl.StatusOf("shared-append")
 		if svc != nil && svc.Status == ServiceStatusStopped {
@@ -1496,7 +1496,7 @@ func TestControllerLaunchedServiceCleansAbandonedSharedFDs(t *testing.T) {
 	}
 	defer ctl.Stop(nil)
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(20 * time.Second)
 	for {
 		svc := ctl.StatusOf("shared-cleanup")
 		if svc != nil && svc.Status == ServiceStatusStopped {

--- a/spi/sql_test.go
+++ b/spi/sql_test.go
@@ -209,10 +209,10 @@ func TestMachbaseSQLCompatibilityGaps(t *testing.T) {
 	tableName := fixture.tableName
 
 	t.Run("transactions are supported", func(t *testing.T) {
-		// TODO: implement transaction support in neo-client/driver (Begin/BeginTx, Commit, Rollback).
 		tx, err := db.BeginTx(t.Context(), nil)
 		require.NoError(t, err)
 		require.NotNil(t, tx)
+		require.NoError(t, tx.Rollback())
 	})
 
 	t.Run("named parameters are supported", func(t *testing.T) {
@@ -236,6 +236,149 @@ func TestMachbaseSQLCompatibilityGaps(t *testing.T) {
 		_, err = res.LastInsertId()
 		require.Error(t, err)
 		require.Contains(t, strings.ToLower(err.Error()), "not implemented")
+	})
+}
+
+func countRows(t *testing.T, db *sql.DB, tableName string) int {
+	t.Helper()
+	var n int
+	require.NoError(t,
+		db.QueryRowContext(t.Context(),
+			fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&n))
+	return n
+}
+
+func TestClientTxHelper(t *testing.T) {
+	fixture := newSQLCompatFixture(t)
+	db := fixture.db
+	tableName := fixture.tableName
+	// fixture seeds 3 rows: (1,'neo'), (2,'machbase'), (99,NULL)
+
+	t.Run("commit on nil error", func(t *testing.T) {
+		before := countRows(t, db, tableName)
+		err := client.Tx(t.Context(), db, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(t.Context(),
+				fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+				int64(100), "tx-commit")
+			return err
+		})
+		require.NoError(t, err)
+		require.Equal(t, before+1, countRows(t, db, tableName))
+	})
+
+	t.Run("rollback on error and errors.Is is preserved", func(t *testing.T) {
+		sentinel := errors.New("intentional rollback")
+		before := countRows(t, db, tableName)
+		err := client.Tx(t.Context(), db, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(t.Context(),
+				fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+				int64(101), "tx-rollback")
+			require.NoError(t, err)
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+		require.Equal(t, before, countRows(t, db, tableName))
+	})
+
+	t.Run("rollback on error inside tx", func(t *testing.T) {
+		before := countRows(t, db, tableName)
+		err := client.Tx(t.Context(), db, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(t.Context(),
+				fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+				int64(102), "tx-fail")
+			require.NoError(t, err)
+			// NAME column is VARCHAR(100); a type mismatch on ID forces an
+			// engine-side error that must trigger rollback of the insert above.
+			_, err = tx.ExecContext(t.Context(),
+				fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+				"not-a-number", "bad")
+			return err
+		})
+		require.Error(t, err)
+		require.Equal(t, before, countRows(t, db, tableName))
+	})
+
+	t.Run("delete rollback restores rows", func(t *testing.T) {
+		before := countRows(t, db, tableName)
+		err := client.Tx(t.Context(), db, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(t.Context(),
+				fmt.Sprintf("DELETE FROM %s WHERE ID = ?", tableName), int64(1))
+			require.NoError(t, err)
+			return errors.New("abort delete")
+		})
+		require.Error(t, err)
+		require.Equal(t, before, countRows(t, db, tableName))
+	})
+
+	t.Run("panic rolls back and re-panics", func(t *testing.T) {
+		before := countRows(t, db, tableName)
+		require.PanicsWithValue(t, "boom", func() {
+			_ = client.Tx(t.Context(), db, func(tx *sql.Tx) error {
+				_, err := tx.ExecContext(t.Context(),
+					fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+					int64(103), "tx-panic")
+				require.NoError(t, err)
+				panic("boom")
+			})
+		})
+		require.Equal(t, before, countRows(t, db, tableName))
+	})
+
+	t.Run("tx conn commits on the same connection", func(t *testing.T) {
+		conn, err := db.Conn(t.Context())
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		before := countRows(t, db, tableName)
+		err = client.TxConn(t.Context(), conn, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(t.Context(),
+				fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+				int64(104), "txconn-commit")
+			return err
+		})
+		require.NoError(t, err)
+		require.Equal(t, before+1, countRows(t, db, tableName))
+	})
+
+	t.Run("tx conn rolls back on error", func(t *testing.T) {
+		conn, err := db.Conn(t.Context())
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		sentinel := errors.New("txconn rollback")
+		before := countRows(t, db, tableName)
+		err = client.TxConn(t.Context(), conn, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(t.Context(),
+				fmt.Sprintf("INSERT INTO %s VALUES(?, ?)", tableName),
+				int64(105), "txconn-rollback")
+			require.NoError(t, err)
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel)
+		require.Equal(t, before, countRows(t, db, tableName))
+	})
+
+	t.Run("tag table does not support transactions", func(t *testing.T) {
+		tagTable := fmt.Sprintf("SQL_COMPAT_TAG_%d", time.Now().UnixNano())
+		_, err := db.ExecContext(t.Context(), fmt.Sprintf(
+			`CREATE TAG TABLE %s (NAME VARCHAR(100) PRIMARY KEY, TIME DATETIME BASETIME, VALUE DOUBLE)`, tagTable))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_, _ = db.ExecContext(t.Context(), fmt.Sprintf(`DROP TABLE %s`, tagTable))
+		})
+
+		err = client.Tx(t.Context(), db, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(t.Context(),
+				fmt.Sprintf("INSERT INTO %s VALUES(?, ?, ?)", tagTable),
+				"tag", time.Now(), 1.0)
+			return err
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "MACHCLI-ERR-2362")
 	})
 }
 


### PR DESCRIPTION
This pull request primarily improves SQL transaction support in the test suite and updates a dependency version. The key changes include enabling and testing transactional operations in the Machbase Neo client, as well as increasing test timeouts to improve reliability.

**SQL Transaction Support Improvements:**

* Enabled and tested transaction support in the Machbase Neo SQL driver by removing the TODO comment and verifying that transactions can be started and rolled back in `TestMachbaseSQLCompatibilityGaps` (`spi/sql_test.go`).
* Added a comprehensive `TestClientTxHelper` suite to verify transactional behavior, including commit, rollback on error, rollback on panic, and transaction handling on specific connection objects. Also tested error propagation and tag table transaction restrictions (`spi/sql_test.go`).

**Test Reliability Improvements:**

* Increased the service controller test timeouts from 5 seconds to 20 seconds in several tests to reduce flakiness (`jsh/service/controller_test.go`). [[1]](diffhunk://#diff-1b07e974d327312e3ac00eb5b65af956d5f94b0962f44d682ca4a89beb7f6f0eL1226-R1226) [[2]](diffhunk://#diff-1b07e974d327312e3ac00eb5b65af956d5f94b0962f44d682ca4a89beb7f6f0eL1334-R1334) [[3]](diffhunk://#diff-1b07e974d327312e3ac00eb5b65af956d5f94b0962f44d682ca4a89beb7f6f0eL1419-R1419) [[4]](diffhunk://#diff-1b07e974d327312e3ac00eb5b65af956d5f94b0962f44d682ca4a89beb7f6f0eL1499-R1499)

**Dependency Updates:**

* Updated `github.com/machbase/neo-client/v2` to a newer version in `go.mod`.